### PR TITLE
Add util hooks

### DIFF
--- a/DEV_GUIDE_Viewer.md
+++ b/DEV_GUIDE_Viewer.md
@@ -34,7 +34,16 @@ We use `zustand` to manage state in [src/ui/app/lib/state.ts](src/ui/app/lib/sta
 The store can be refreshed using `refresh()`, but must be initialized via `initState()` first. Note that this function also initializes the corresponding state on the Tauri Rust side.
 
 It's possible for the state to be out-of-date with the database since new `App`s can be created via opening them for the first time, by the Engine. 
-Thus, queries that return this `App` id (e.g. `getAppDurations`) will not find a corresponding `App` in the state. The way we currently handle this is to not show these entities in the UI.
+Thus, queries that return this `App` id (e.g. `getAppDurations`) will not find a corresponding `App` in the state. Use `useRefresh()`'s `handleStaleXxx`
+functions to handle this case. Functions that rely on `useAppState(state => state.Xxx)` just need to use `handleStaleXxx` and use that in their
+`useEffect` dependencies.
+
+`useRefresh()` also provides a `refreshToken` otherwise, usually used when we interface with the Tauri Rust side. e.g.:
+```ts
+useEffect(() => {
+    getAppDurations(/**/).then(setUsages);
+}, [refreshToken, /**/]);
+```
 
 ## Bindings
 

--- a/src/ui/app/components/date-time-range-picker.tsx
+++ b/src/ui/app/components/date-time-range-picker.tsx
@@ -14,6 +14,7 @@ import { DateTime } from "luxon";
 import { Input } from "@/components/ui/input";
 import { Label } from "./ui/label";
 import { toHumanDateTime } from "@/lib/time";
+import { useToday } from "@/hooks/use-today";
 
 type DateTimeRangePickerProps = {
   className?: string;
@@ -136,7 +137,7 @@ export function DateTimeRangePicker({
   showIcon = true,
   ...props
 }: DateTimeRangePickerProps) {
-  const today = DateTime.now().startOf("day");
+  const today = useToday();
 
   const [open, setOpen] = React.useState(false);
 

--- a/src/ui/app/hooks/use-fom.tsx
+++ b/src/ui/app/hooks/use-fom.tsx
@@ -1,0 +1,17 @@
+import { type UseFormProps, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type z } from "zod";
+
+export const useZodForm = <TSchema extends z.ZodType>({
+  schema,
+  ...props
+}: Omit<UseFormProps<TSchema["_input"]>, "resolver"> & {
+  schema: TSchema;
+}) => {
+  const form = useForm<TSchema["_input"]>({
+    ...props,
+    resolver: zodResolver(schema, undefined),
+  });
+
+  return form;
+};

--- a/src/ui/app/hooks/use-refresh.tsx
+++ b/src/ui/app/hooks/use-refresh.tsx
@@ -1,7 +1,21 @@
 import { useAppState, refresh } from "@/lib/state";
+import { useCallback } from "react";
 
 export function useRefresh() {
   const lastRefresh = useAppState((state) => state.lastRefresh);
+  // TODO: queue a debounced refresh?
+  const handleStale = useCallback(
+    function <T>(data: (T | undefined)[]) {
+      return data.filter((x) => x !== undefined);
+    },
+    [lastRefresh]
+  );
 
-  return { refreshToken: lastRefresh, refresh };
+  return {
+    refreshToken: lastRefresh,
+    refresh,
+    handleStaleApps: handleStale,
+    handleStaleTags: handleStale,
+    handleStaleAlerts: handleStale,
+  };
 }

--- a/src/ui/app/hooks/use-refresh.tsx
+++ b/src/ui/app/hooks/use-refresh.tsx
@@ -1,0 +1,7 @@
+import { useAppState, refresh } from "@/lib/state";
+
+export function useRefresh() {
+  const lastRefresh = useAppState((state) => state.lastRefresh);
+
+  return { refreshToken: lastRefresh, refresh };
+}

--- a/src/ui/app/hooks/use-search.tsx
+++ b/src/ui/app/hooks/use-search.tsx
@@ -1,0 +1,22 @@
+import fuzzysort from "fuzzysort";
+import _ from "lodash";
+import { useMemo, useState } from "react";
+import { type Path } from "react-hook-form";
+
+export function useSearch<T>(items: T[], paths: Path<T>[]) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    if (query) {
+      const results = fuzzysort.go(query, items, {
+        keys: paths,
+      });
+      // ignore fuzzy-search sorting.
+      return _.map(results, "obj");
+    } else {
+      return items;
+    }
+  }, [items, JSON.stringify(paths), query]);
+
+  return [query, setQuery, filtered] as const;
+}

--- a/src/ui/app/hooks/use-today.tsx
+++ b/src/ui/app/hooks/use-today.tsx
@@ -1,0 +1,15 @@
+import { useAppState } from "@/lib/state";
+import { useMemo } from "react";
+
+export function useToday() {
+  const lastRefresh = useAppState((state) => state.lastRefresh);
+  const today = useMemo(() => {
+    return lastRefresh.startOf("day");
+  }, [+lastRefresh.startOf("day").toJSDate()]); // memoize today
+  return today;
+}
+
+export function getToday() {
+  const lastRefresh = useAppState.getState().lastRefresh;
+  return lastRefresh.startOf("day");
+}

--- a/src/ui/app/lib/state.ts
+++ b/src/ui/app/lib/state.ts
@@ -21,6 +21,7 @@ export async function refresh() {
   ]);
   state.setApps(apps as Record<Ref<App>, App>);
   state.setTags(tags as Record<Ref<Tag>, Tag>);
+  state.setLastRefresh(now);
 }
 
 // Entity store with T|undefined values. This is because
@@ -29,17 +30,21 @@ export type EntityStore<T> = Record<Ref<T>, T | undefined>;
 export type EntityMap<T, V> = Record<Ref<T>, V | undefined>;
 
 type AppState = {
+  lastRefresh: DateTime;
   apps: EntityStore<App>;
   tags: EntityStore<Tag>;
   setApps: (apps: EntityStore<App>) => void;
   setTags: (tags: EntityStore<Tag>) => void;
+  setLastRefresh: (lastRefresh: DateTime) => void;
 };
 
 export const useAppState = create<AppState>((set) => {
   return {
+    lastRefresh: DateTime.now(),
     apps: [],
     tags: [],
     setApps: (apps) => set({ apps }),
     setTags: (tags) => set({ tags }),
+    setLastRefresh: (lastRefresh) => set({ lastRefresh }),
   };
 });

--- a/src/ui/app/routes/apps/index.tsx
+++ b/src/ui/app/routes/apps/index.tsx
@@ -34,7 +34,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { ArrowDownUp, Filter, SortAsc, SortDesc } from "lucide-react";
 import _ from "lodash";
-import fuzzysort from "fuzzysort";
 import { Text } from "@/components/ui/text";
 import { dateTimeToTicks, durationToTicks, toHumanDuration } from "@/lib/time";
 import { getAppDurationsPerPeriod } from "@/lib/repo";
@@ -43,6 +42,7 @@ import { AppUsageBarChart } from "@/components/app-usage-chart";
 import { HorizontalOverflowList } from "@/components/overflow-list";
 import { useToday } from "@/hooks/use-today";
 import { useRefresh } from "@/hooks/use-refresh";
+import { useSearch } from "@/hooks/use-search";
 
 const period = Duration.fromObject({ hour: 1 });
 
@@ -206,22 +206,13 @@ export default function Apps() {
   );
   const [sortProperty, setSortProperty] =
     useState<SortProperty>("usages.usage_today");
-  const [search, setSearch] = useState<string>("");
 
   const appValues = useMemo(() => Object.values(apps), [apps]);
-
-  const appsFiltered = useMemo(() => {
-    if (search) {
-      const results = fuzzysort.go(search, appValues, {
-        keys: ["name", "company", "description"],
-      });
-      // ignore fuzzy-search sorting.
-      return _.map(results, "obj");
-    } else {
-      return appValues;
-    }
-  }, [appValues, search]);
-
+  const [search, setSearch, appsFiltered] = useSearch(appValues, [
+    "name",
+    "company",
+    "description",
+  ]);
   const appsSorted = useMemo(() => {
     return _(appsFiltered)
       .orderBy([sortProperty], [sortDirection])

--- a/src/ui/app/routes/apps/index.tsx
+++ b/src/ui/app/routes/apps/index.tsx
@@ -99,12 +99,14 @@ function AppListItem({
   period: Duration;
 }) {
   const allTags = useAppState((state) => state.tags);
+  const { handleStaleTags } = useRefresh();
   const tags = useMemo(
     () =>
-      app.tags
+      _(app.tags)
         .map((tagId) => allTags[tagId])
-        .filter((tag) => tag !== undefined), // filter stale tags
-    [allTags, app.tags]
+        .thru(handleStaleTags)
+        .value(),
+    [handleStaleTags, allTags, app.tags]
   );
   const singleUsage = useMemo(
     () => ({ [app.id]: usages[app.id] }),
@@ -196,7 +198,7 @@ type SortProperty =
 
 export default function Apps() {
   const today = useToday();
-  const { refreshToken } = useRefresh();
+  const { refreshToken, handleStaleApps } = useRefresh();
   const apps = useAppState((state) => state.apps);
 
   const [sortDirection, setSortDirection] = useState<SortDirection>(
@@ -223,9 +225,9 @@ export default function Apps() {
   const appsSorted = useMemo(() => {
     return _(appsFiltered)
       .orderBy([sortProperty], [sortDirection])
-      .filter((app) => app !== undefined) // filter stale apps
+      .thru(handleStaleApps)
       .value();
-  }, [appsFiltered, sortDirection, sortProperty]);
+  }, [appsFiltered, sortDirection, sortProperty, handleStaleApps]);
 
   const [start, end] = useMemo(() => [today, today.endOf("day")], [today]);
 

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,8 +1,9 @@
 {
-  "lockfileVersion": 0,
+  "lockfileVersion": 1,
   "workspaces": {
     "": {
       "dependencies": {
+        "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.1",
@@ -30,12 +31,14 @@
         "react": "^19.0.0",
         "react-day-picker": "8.10.1",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.54.2",
         "react-router": "^7.1.1",
         "react-virtualized-auto-sizer": "^1.0.25",
         "react-window": "^1.8.11",
         "recharts": "^2.15.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.24.1",
         "zustand": "^5.0.3",
       },
       "devDependencies": {
@@ -195,6 +198,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.8", "", {}, "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -1068,6 +1073,8 @@
 
     "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
 
+    "react-hook-form": ["react-hook-form@7.54.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg=="],
+
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
@@ -1311,6 +1318,8 @@
     "yaml": ["yaml@2.7.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
 
     "zustand": ["zustand@5.0.3", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg=="],
 

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -38,6 +38,7 @@
         "recharts": "^2.15.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "use-debounce": "^10.0.4",
         "zod": "^3.24.1",
         "zustand": "^5.0.3",
       },
@@ -1270,6 +1271,8 @@
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-debounce": ["use-debounce@10.0.4", "", { "peerDependencies": { "react": "*" } }, "sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint --fix app/**"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.1",
@@ -40,12 +41,14 @@
     "react": "^19.0.0",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.2",
     "react-router": "^7.1.1",
     "react-virtualized-auto-sizer": "^1.0.25",
     "react-window": "^1.8.11",
     "recharts": "^2.15.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.24.1",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -48,6 +48,7 @@
     "recharts": "^2.15.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "use-debounce": "^10.0.4",
     "zod": "^3.24.1",
     "zustand": "^5.0.3"
   },


### PR DESCRIPTION
### TL;DR
Added hooks for handling stale data and introduced form utilities to improve data management across the application.

### What changed?
- Created new hooks for common functionality:
  - `useRefresh`: Handles stale data and provides refresh functionality
  - `useSearch`: Implements fuzzy search with memoization
  - `useToday`: Manages consistent date handling
  - `useZodForm`: Simplifies form validation with Zod
- Updated app-usage-chart to handle stale data properly
- Added lastRefresh tracking to the app state
- Enhanced date-time-range-picker with consistent today reference
- Added new dependencies for form handling and validation

### How to test?
1. Verify app usage charts update correctly when data becomes stale
2. Test search functionality in the apps list
3. Confirm date/time pickers show consistent today values
4. Validate that forms using useZodForm handle validation correctly

### Why make this change?
To improve data consistency and reduce bugs related to stale data handling. The new hooks provide reusable solutions for common patterns, making the codebase more maintainable and reducing duplicate logic across components.