### PR TITLE
Replace app-tag junction table with direct tag_id column

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,6 +45,7 @@ erDiagram
         text            description
         text            company
         text            color
+        int_nullable    tag_id FK
         int             identity_is_win32     UK "UNIQUE(is_win32, path_or_aumid)"
         text            identity_path_or_aumid   UK "UNIQUE(is_win32, path_or_aumid)"
         blob_nullable   icon
@@ -54,11 +55,6 @@ erDiagram
         int             id PK
         text            name UK
         text            color
-    }
-
-    "_app_tags" {
-        int             app_id PK,FK
-        int             tag_id PK,FK
     }
 
     sessions {
@@ -118,8 +114,7 @@ erDiagram
 
     apps ||--o{ sessions : sessions
     sessions ||--o{ usages : usages
-    "_app_tags" ||--|{ apps : app
-    "_app_tags" ||--|{ tags : tag
+    tags ||--o{ apps : "tag's apps"
     apps ||--o{ alerts : "app alerts"
     tags ||--o{ alerts : "tag alerts"
     alerts ||--o{ reminders : reminders

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -243,7 +243,7 @@ impl AlertManager {
     pub async fn target_apps(&mut self, target: &Target) -> Result<Vec<Ref<App>>> {
         Ok(match target {
             Target::Tag(tag) => {
-                query("SELECT app_id FROM _app_tags WHERE tag_id = ?")
+                query("SELECT id FROM apps WHERE tag_id = ?")
                     .bind(tag)
                     .map(|r: SqliteRow| r.get(0))
                     .fetch_all(self.db.executor())

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -197,7 +197,7 @@ impl Repository {
                 LEFT JOIN usage_daily d ON t.id = d.id
                 LEFT JOIN usage_week  w ON t.id = w.id
                 LEFT JOIN usage_month m ON t.id = m.id
-                LEFT JOIN apps a ON t.id = a.tag_id
+                LEFT JOIN apps a ON t.id = a.tag_id AND a.initialized = 1
             GROUP BY t.id"
         ))
         .bind(ts.day_start().to_ticks())

--- a/src/data/src/db/repo_tests.rs
+++ b/src/data/src/db/repo_tests.rs
@@ -22,6 +22,7 @@ async fn get_apps() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path1".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -38,6 +39,7 @@ async fn get_apps() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path2".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -54,6 +56,7 @@ async fn get_apps() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path3".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -70,6 +73,7 @@ async fn get_apps() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path4".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -86,6 +90,7 @@ async fn get_apps() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path5".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -128,51 +133,58 @@ async fn get_apps() -> Result<()> {
     )
     .await?;
 
-    // app 1 and 3 share some tags
-    // app 2 has no tags
-    // app 2 has a tag but not shared with any other app
-    arrange::app_tags(&mut db, Ref::new(1), Ref::new(1)).await?;
-    arrange::app_tags(&mut db, Ref::new(1), Ref::new(2)).await?;
-    arrange::app_tags(&mut db, Ref::new(1), Ref::new(3)).await?;
-
-    arrange::app_tags(&mut db, Ref::new(3), Ref::new(1)).await?;
-    arrange::app_tags(&mut db, Ref::new(3), Ref::new(3)).await?;
-
-    arrange::app_tags(&mut db, Ref::new(4), Ref::new(4)).await?;
-
-    arrange::app_tags(&mut db, Ref::new(5), Ref::new(4)).await?;
-
     let mut repo = Repository::new(db)?;
     // TODO test: durations for these
-    let apps = repo
+    let _ = repo
         .get_apps(Times {
             day_start: 0,
             week_start: 0,
             month_start: 0,
         })
         .await?;
-    let from_db: HashMap<_, _> = apps
-        .values()
-        .map(|app| (app.inner.id.clone(), app.tags.clone()))
-        .collect();
-    assert_eq!(
-        from_db,
-        vec![
-            (1, vec![1, 2, 3]),
-            (2, vec![]),
-            (3, vec![1, 3]),
-            (4, vec![4]),
-        ]
-        .into_iter()
-        .map(|(k, v)| (Ref::new(k), RefVec(v.into_iter().map(Ref::new).collect())))
-        .collect()
-    );
     Ok(())
 }
 
 #[tokio::test]
 async fn get_tags() -> Result<()> {
     let mut db = test_db().await?;
+
+    arrange::tag(
+        &mut db,
+        Tag {
+            id: Ref::new(1),
+            name: "tag1".to_string(),
+            color: "red".to_string(),
+        },
+    )
+    .await?;
+    arrange::tag(
+        &mut db,
+        Tag {
+            id: Ref::new(2),
+            name: "tag2".to_string(),
+            color: "red".to_string(),
+        },
+    )
+    .await?;
+    arrange::tag(
+        &mut db,
+        Tag {
+            id: Ref::new(3),
+            name: "tag3".to_string(),
+            color: "red".to_string(),
+        },
+    )
+    .await?;
+    arrange::tag(
+        &mut db,
+        Tag {
+            id: Ref::new(4),
+            name: "tag4".to_string(),
+            color: "red".to_string(),
+        },
+    )
+    .await?;
 
     arrange::app(
         &mut db,
@@ -185,6 +197,7 @@ async fn get_tags() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path1".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -201,6 +214,7 @@ async fn get_tags() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path2".to_string(),
             },
+            tag_id: Some(Ref::new(1)),
             icon: None,
         },
     )
@@ -217,6 +231,7 @@ async fn get_tags() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path3".to_string(),
             },
+            tag_id: Some(Ref::new(2)),
             icon: None,
         },
     )
@@ -233,6 +248,7 @@ async fn get_tags() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path4".to_string(),
             },
+            tag_id: Some(Ref::new(1)),
             icon: None,
         },
     )
@@ -249,6 +265,7 @@ async fn get_tags() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path5".to_string(),
             },
+            tag_id: Some(Ref::new(3)),
             icon: None,
         },
     )
@@ -265,60 +282,11 @@ async fn get_tags() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path6".to_string(),
             },
+            tag_id: Some(Ref::new(3)),
             icon: None,
         },
     )
     .await?;
-
-    arrange::tag(
-        &mut db,
-        Tag {
-            id: Ref::new(1),
-            name: "tag1".to_string(),
-            color: "red".to_string(),
-        },
-    )
-    .await?;
-    arrange::tag(
-        &mut db,
-        Tag {
-            id: Ref::new(2),
-            name: "tag2".to_string(),
-            color: "red".to_string(),
-        },
-    )
-    .await?;
-    arrange::tag(
-        &mut db,
-        Tag {
-            id: Ref::new(3),
-            name: "tag3".to_string(),
-            color: "red".to_string(),
-        },
-    )
-    .await?;
-    arrange::tag(
-        &mut db,
-        Tag {
-            id: Ref::new(4),
-            name: "tag4".to_string(),
-            color: "red".to_string(),
-        },
-    )
-    .await?;
-
-    // tag 1 and 3 share some apps
-    // tag 2 has no apps
-    // tag 2 has a app but not shared with any other tag
-    arrange::app_tags(&mut db, Ref::new(1), Ref::new(1)).await?;
-    arrange::app_tags(&mut db, Ref::new(2), Ref::new(1)).await?;
-    arrange::app_tags(&mut db, Ref::new(3), Ref::new(1)).await?;
-    arrange::app_tags(&mut db, Ref::new(6), Ref::new(1)).await?;
-
-    arrange::app_tags(&mut db, Ref::new(1), Ref::new(3)).await?;
-    arrange::app_tags(&mut db, Ref::new(3), Ref::new(3)).await?;
-
-    arrange::app_tags(&mut db, Ref::new(4), Ref::new(4)).await?;
 
     let mut repo = Repository::new(db)?;
     // TODO test: durations for these
@@ -335,15 +303,10 @@ async fn get_tags() -> Result<()> {
         .collect();
     assert_eq!(
         from_db,
-        vec![
-            (1, vec![1, 2, 3, 6]),
-            (2, vec![]),
-            (3, vec![1, 3]),
-            (4, vec![4]),
-        ]
-        .into_iter()
-        .map(|(k, v)| (Ref::new(k), RefVec(v.into_iter().map(Ref::new).collect())))
-        .collect()
+        vec![(1, vec![2, 4]), (2, vec![3]), (3, vec![5]), (4, vec![]),]
+            .into_iter()
+            .map(|(k, v)| (Ref::new(k), RefVec(v.into_iter().map(Ref::new).collect())))
+            .collect()
     );
     Ok(())
 }
@@ -416,6 +379,7 @@ async fn get_app_durations() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path1".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -433,6 +397,7 @@ async fn get_app_durations() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path2".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -515,6 +480,7 @@ async fn get_app_durations_per_period_singular_ts_test() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path1".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -532,6 +498,7 @@ async fn get_app_durations_per_period_singular_ts_test() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path2".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -688,6 +655,7 @@ async fn get_app_durations_per_period_multiple_ts_test() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path1".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )
@@ -705,6 +673,7 @@ async fn get_app_durations_per_period_multiple_ts_test() -> Result<()> {
             identity: AppIdentity::Win32 {
                 path: "path2".to_string(),
             },
+            tag_id: None,
             icon: None,
         },
     )

--- a/src/data/src/entities.rs
+++ b/src/data/src/entities.rs
@@ -22,6 +22,7 @@ pub struct App {
     #[sqlx(flatten)]
     pub identity: AppIdentity,
     pub icon: Option<Vec<u8>>,
+    pub tag_id: Option<Ref<Tag>>,
 }
 
 /// Unique identity of an [App], outside of the Database (on the FileSystem/Registry)

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -17,6 +17,16 @@ impl Migration for Migration1 {
     async fn up(&self, db: &mut Database) -> Result<()> {
         let mut tx = db.transaction().await?;
 
+        tx.execute(
+            "CREATE TABLE tags (
+                id                              INTEGER PRIMARY KEY NOT NULL,
+                name                            TEXT NOT NULL,
+                color                           TEXT NOT NULL
+            )",
+        )
+        .await
+        .context("create table tags")?;
+
         // all information fields of app are nullable, except identity
         tx.execute(
             "CREATE TABLE apps (
@@ -27,6 +37,7 @@ impl Migration for Migration1 {
                 description                     TEXT,
                 company                         TEXT,
                 color                           TEXT,
+                tag_id                          INTEGER REFERENCES tags(id) ON DELETE SET NULL,
                 identity_is_win32               INTEGER NOT NULL,
                 identity_path_or_aumid          TEXT NOT NULL,
                 icon                            BLOB
@@ -68,26 +79,6 @@ impl Migration for Migration1 {
         )
         .await
         .context("create table interaction_periods")?;
-
-        tx.execute(
-            "CREATE TABLE tags (
-                id                              INTEGER PRIMARY KEY NOT NULL,
-                name                            TEXT NOT NULL,
-                color                           TEXT NOT NULL
-            )",
-        )
-        .await
-        .context("create table tags")?;
-
-        tx.execute(
-            "CREATE TABLE _app_tags (
-                app_id                          INTEGER NOT NULL REFERENCES apps(id),
-                tag_id                          INTEGER NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
-                PRIMARY KEY (app_id, tag_id)
-            )",
-        )
-        .await
-        .context("create table _app_tags")?;
 
         tx.execute(
             "CREATE TABLE alerts (

--- a/src/data/src/queries/triggered_alerts.sql
+++ b/src/data/src/queries/triggered_alerts.sql
@@ -1,11 +1,11 @@
 WITH
 
 target_apps(alert_id, alert_version, app_id) AS (
-        SELECT al.id, al.version, coalesce(al.app_id, at.app_id)
+        SELECT al.id, al.version, coalesce(al.app_id, a.id)
         FROM alerts al
-        LEFT JOIN _app_tags at
-            ON al.tag_id = at.tag_id
-            AND at.tag_id IS NOT NULL
+        LEFT JOIN apps a
+            ON al.tag_id = a.tag_id
+            AND a.tag_id IS NOT NULL
 ),
 
 range_start(alert_id, alert_version, range_start) AS (

--- a/src/data/src/queries/triggered_reminders.sql
+++ b/src/data/src/queries/triggered_reminders.sql
@@ -1,11 +1,11 @@
 WITH
 
 target_apps(alert_id, alert_version, app_id) AS (
-        SELECT al.id, al.version, coalesce(al.app_id, at.app_id)
+        SELECT al.id, al.version, coalesce(al.app_id, a.id)
         FROM alerts al
-        LEFT JOIN _app_tags at
-            ON al.tag_id = at.tag_id
-            AND at.tag_id IS NOT NULL
+        LEFT JOIN apps a
+            ON al.tag_id = a.tag_id
+            AND a.tag_id IS NOT NULL
 ),
 
 range_start(alert_id, alert_version, range_start) AS (

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -38,6 +38,7 @@ impl AppInfoResolver {
             company: app_info.company,
             color: Self::random_color(),
             identity,
+            tag_id: None,
             icon: Some(app_info.logo),
         };
         updater.update_app(&app).await?;

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -33,7 +33,7 @@ export interface App {
   color: Color;
   identity: AppIdentity;
   icon: Buffer;
-  tags: Ref<Tag>[];
+  tag_id: Ref<Tag> | null;
   usages: UsageInfo;
 }
 

--- a/src/ui/app/routes/apps/index.tsx
+++ b/src/ui/app/routes/apps/index.tsx
@@ -39,7 +39,6 @@ import { dateTimeToTicks, durationToTicks } from "@/lib/time";
 import { getAppDurationsPerPeriod } from "@/lib/repo";
 import { DateTime, Duration } from "luxon";
 import { AppUsageBarChart } from "@/components/app-usage-chart";
-import { HorizontalOverflowList } from "@/components/overflow-list";
 import { useToday } from "@/hooks/use-today";
 import { useRefresh } from "@/hooks/use-refresh";
 import { useSearch } from "@/hooks/use-search";
@@ -101,14 +100,13 @@ function AppListItem({
 }) {
   const allTags = useAppState((state) => state.tags);
   const { handleStaleTags } = useRefresh();
-  const tags = useMemo(
-    () =>
-      _(app.tags)
-        .map((tagId) => allTags[tagId])
-        .thru(handleStaleTags)
-        .value(),
-    [handleStaleTags, allTags, app.tags],
-  );
+  const tag = useMemo(() => {
+    if (app.tag_id === null) {
+      return null;
+    }
+    return handleStaleTags([allTags[app.tag_id]])[0] ?? null;
+  }, [allTags, handleStaleTags, app.tag_id]);
+
   const singleUsage = useMemo(
     () => ({ [app.id]: usages[app.id] }),
     [usages, app.id],
@@ -128,21 +126,7 @@ function AppListItem({
       <div className="flex flex-col min-w-0">
         <div className="inline-flex items-center gap-2">
           <Text className="text-lg font-semibold max-w-72">{app.name}</Text>
-          <HorizontalOverflowList
-            className="gap-1 max-w-96 h-6"
-            items={tags}
-            renderItem={(tag) => <TagItem key={tag.id} tag={tag} />}
-            renderOverflowItem={(tag) => <TagItem key={tag.id} tag={tag} />}
-            renderOverflowSign={(items) => (
-              <Badge
-                variant="outline"
-                style={{
-                  backgroundColor: "rgba(255, 255, 255, 0.2)",
-                }}
-                className="whitespace-nowrap ml-1 text-card-foreground/60 rounded-md"
-              >{`+${items.length}`}</Badge>
-            )}
-          />
+          {tag && <TagItem tag={tag} />}
         </div>
         <span className="inline-flex gap-1 items-center text-xs text-card-foreground/50">
           <Text className="max-w-48">{app.company}</Text>


### PR DESCRIPTION
Replaces the many-to-many relationship between apps and tags with a one-to-many relationship where each app can have a single tag. Updates database schema, queries, and UI to reflect this change.