### PR TITLE
Heatmap Visualization

### DIFF
--- a/src/ui/app/components/heatmap.tsx
+++ b/src/ui/app/components/heatmap.tsx
@@ -78,8 +78,8 @@ const Heatmap: React.FC<HeatmapProps> = ({
   }, [startDate, data]);
 
   const maxWeek = Math.max(...heatmapData.map((d) => d.week));
-  const width = (maxWeek + 1) * CELL_SIZE + PADDING * 2;
-  const height = 7 * CELL_SIZE + PADDING * 2;
+  const width = (maxWeek + 1) * CELL_SIZE + PADDING;
+  const height = 7 * CELL_SIZE + PADDING + 10; // added 10px at the bottom
 
   const renderCells = () => {
     return heatmapData.map((entry, index) => {
@@ -152,16 +152,22 @@ const Heatmap: React.FC<HeatmapProps> = ({
   };
 
   return (
-    <div className="relative">
-      <svg
-        width="100%"
-        height="100%"
-        viewBox={`0 0 ${width} ${height}`}
-        ref={ref}
+    <div className="relative overflow-x-auto">
+      <div
+        className="min-h-[200px] aspect-video"
+        style={{ aspectRatio: width / height }}
       >
-        {renderCells()}
-        {renderAxes()}
-      </svg>
+        <svg
+          width="100%"
+          height="100%"
+          viewBox={`0 0 ${width} ${height}`}
+          preserveAspectRatio="none"
+          ref={ref}
+        >
+          {renderCells()}
+          {renderAxes()}
+        </svg>
+      </div>
       {tooltipData && (
         <div
           className="absolute bg-card p-2 border border-border rounded shadow text-sm pointer-events-none"

--- a/src/ui/app/components/heatmap.tsx
+++ b/src/ui/app/components/heatmap.tsx
@@ -13,7 +13,10 @@ function rotateArray<T>(arr: T[], n: number) {
 export interface HeatmapProps {
   startDate: DateTime;
   data: Map<number, number>; // DateTime -> value
+  className?: ClassValue;
+  innerClassName?: ClassValue;
   axisClassName?: ClassValue;
+  firstDayOfMonthClassName?: ClassValue;
 }
 
 export interface HeatmapData {
@@ -44,7 +47,10 @@ const PADDING = 25;
 const Heatmap: React.FC<HeatmapProps> = ({
   startDate,
   data,
+  className,
+  innerClassName,
   axisClassName,
+  firstDayOfMonthClassName,
 }) => {
   const [tooltipData, setTooltipData] = useState<{
     x: number;
@@ -83,7 +89,8 @@ const Heatmap: React.FC<HeatmapProps> = ({
 
   const renderCells = () => {
     return heatmapData.map((entry, index) => {
-      const intensity = entry.value / 360000000000 + 0.1; // 10 hours
+      const intensity = entry.value / 360000000000 + 0.1; // TODO this is 10 hours but needs to be configurable
+      // TODO this color scaling needs to be configurable
       const fill =
         entry.value === 0 ? "#222222" : `rgba(0, 128, 0, ${intensity})`;
       const cellDate = entry.date;
@@ -97,8 +104,7 @@ const Heatmap: React.FC<HeatmapProps> = ({
           width={CELL_SIZE - 2}
           height={CELL_SIZE - 2}
           fill={fill}
-          stroke={isFirstDayOfMonth ? "#000" : "none"}
-          strokeWidth={isFirstDayOfMonth ? 2 : 0}
+          className={cn(isFirstDayOfMonth && firstDayOfMonthClassName)}
           rx={3}
           onMouseEnter={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();
@@ -152,9 +158,9 @@ const Heatmap: React.FC<HeatmapProps> = ({
   };
 
   return (
-    <div className="relative overflow-x-auto">
+    <div className={cn("relative overflow-x-auto", className)}>
       <div
-        className="min-h-[200px] aspect-video"
+        className={cn(innerClassName)}
         style={{ aspectRatio: width / height }}
       >
         <svg

--- a/src/ui/app/components/heatmap.tsx
+++ b/src/ui/app/components/heatmap.tsx
@@ -5,6 +5,7 @@ import type { ClassValue } from "clsx";
 import { cn } from "@/lib/utils";
 import { DateTimeText } from "./time-text";
 import { DurationText } from "./duration-text";
+import { hexToRgb } from "@/lib/color-utils";
 
 function rotateArray<T>(arr: T[], n: number) {
   return arr.slice(n).concat(arr.slice(0, n));
@@ -13,6 +14,8 @@ function rotateArray<T>(arr: T[], n: number) {
 export interface HeatmapProps {
   startDate: DateTime;
   data: Map<number, number>; // DateTime -> value
+  emptyCellColorRgb?: string;
+  fullCellColorRgb?: string;
   className?: ClassValue;
   innerClassName?: ClassValue;
   axisClassName?: ClassValue;
@@ -42,7 +45,7 @@ const MONTHS = [
   "Dec",
 ];
 const CELL_SIZE = 14;
-const PADDING = 25;
+const PADDING = 30;
 
 const Heatmap: React.FC<HeatmapProps> = ({
   startDate,
@@ -51,6 +54,8 @@ const Heatmap: React.FC<HeatmapProps> = ({
   innerClassName,
   axisClassName,
   firstDayOfMonthClassName,
+  emptyCellColorRgb = "hsl(var(--muted))",
+  fullCellColorRgb = "#00FF00",
 }) => {
   const [tooltipData, setTooltipData] = useState<{
     x: number;
@@ -91,8 +96,11 @@ const Heatmap: React.FC<HeatmapProps> = ({
     return heatmapData.map((entry, index) => {
       const intensity = entry.value / 360000000000 + 0.1; // TODO this is 10 hours but needs to be configurable
       // TODO this color scaling needs to be configurable
+      const { r, g, b } = hexToRgb(fullCellColorRgb)!;
       const fill =
-        entry.value === 0 ? "#222222" : `rgba(0, 128, 0, ${intensity})`;
+        entry.value === 0
+          ? emptyCellColorRgb
+          : `rgba(${r} ${g} ${b}/ ${intensity})`;
       const cellDate = entry.date;
       const isFirstDayOfMonth = cellDate.day === 1;
 
@@ -104,7 +112,10 @@ const Heatmap: React.FC<HeatmapProps> = ({
           width={CELL_SIZE - 2}
           height={CELL_SIZE - 2}
           fill={fill}
-          className={cn(isFirstDayOfMonth && firstDayOfMonthClassName)}
+          className={cn(
+            isFirstDayOfMonth &&
+              cn("stroke-primary stroke-1", firstDayOfMonthClassName),
+          )}
           rx={3}
           onMouseEnter={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();
@@ -126,11 +137,11 @@ const Heatmap: React.FC<HeatmapProps> = ({
     const yAxis = rotateArray(DAYS, 1).map((day, index) => (
       <text
         key={`day-${index}`}
-        x={PADDING - 5}
+        x={PADDING - 10}
         y={index * CELL_SIZE + PADDING + CELL_SIZE / 2}
         textAnchor="end"
         dominantBaseline="middle"
-        className={cn(axisClassName)}
+        className={cn("fill-muted-foreground/75", axisClassName)}
         fontSize={10}
       >
         {day}
@@ -147,7 +158,7 @@ const Heatmap: React.FC<HeatmapProps> = ({
           y={PADDING - 5}
           textAnchor="middle"
           fontSize={10}
-          className={cn(axisClassName)}
+          className={cn("fill-muted-foreground/75", axisClassName)}
         >
           {month}
         </text>

--- a/src/ui/app/components/heatmap.tsx
+++ b/src/ui/app/components/heatmap.tsx
@@ -1,15 +1,9 @@
 import type React from "react";
 import { useMemo, useRef, useState } from "react";
-import {
-  DateTime,
-  Interval,
-  type WeekdayNumbers,
-  type WeekNumbers,
-} from "luxon";
+import { DateTime, Interval } from "luxon";
 import type { ClassValue } from "clsx";
 import { cn } from "@/lib/utils";
 import { DateTimeText } from "./time-text";
-import { toHumanDuration } from "@/lib/time";
 import { DurationText } from "./duration-text";
 
 function rotateArray<T>(arr: T[], n: number) {

--- a/src/ui/app/components/heatmap.tsx
+++ b/src/ui/app/components/heatmap.tsx
@@ -1,0 +1,177 @@
+import type React from "react";
+import { useMemo, useState } from "react";
+import {
+  DateTime,
+  Interval,
+  type WeekdayNumbers,
+  type WeekNumbers,
+} from "luxon";
+import type { ClassValue } from "clsx";
+import { cn } from "@/lib/utils";
+import { DateTimeText } from "./time-text";
+
+export interface HeatmapProps {
+  startDate: DateTime;
+  startOfWeek: number;
+  data: Map<number, number>; // DateTime -> value
+  axisClassName?: ClassValue;
+}
+
+export interface HeatmapData {
+  date: DateTime;
+  day: number;
+  week: number;
+  value: number;
+}
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+const CELL_SIZE = 14;
+const PADDING = 20;
+
+const Heatmap: React.FC<HeatmapProps> = ({
+  startDate,
+  startOfWeek,
+  data,
+  axisClassName,
+}) => {
+  const [tooltipData, setTooltipData] = useState<{
+    x: number;
+    y: number;
+    date: DateTime;
+    value: number;
+  } | null>(null);
+
+  const heatmapData = useMemo(() => {
+    const result: HeatmapData[] = [];
+    const endDate = startDate.plus({ years: 1 });
+    const interval = Interval.fromDateTimes(startDate, endDate);
+
+    for (const day of interval.splitBy({ days: 1 })) {
+      const currentDate = day.start!;
+      // TODO adjust yaxis based on startOfWeek.
+      // TODO check if the rest of the display shown is even correct?
+      const adjustedDay = (currentDate.weekday - startOfWeek + 7) % 7;
+      const week = currentDate.weekNumber - startDate.weekNumber + 1;
+
+      result.push({
+        date: currentDate,
+        day: adjustedDay,
+        week,
+        value: data.get(+currentDate) || 0,
+      });
+    }
+
+    return result;
+  }, [startDate, startOfWeek, data]);
+
+  const maxWeek = Math.max(...heatmapData.map((d) => d.week));
+  const width = (maxWeek + 1) * CELL_SIZE + PADDING * 2;
+  const height = 7 * CELL_SIZE + PADDING * 2;
+
+  const renderCells = () => {
+    return heatmapData.map((entry, index) => {
+      const intensity = entry.value / 360000000000 + 0.1; // 10 hours
+      const fill =
+        entry.value === 0 ? "#222222" : `rgba(0, 128, 0, ${intensity})`;
+      const cellDate = entry.date;
+      const isFirstDayOfMonth = cellDate.day === 1;
+
+      return (
+        <rect
+          key={index}
+          x={entry.week * CELL_SIZE + PADDING}
+          y={entry.day * CELL_SIZE + PADDING}
+          width={CELL_SIZE - 2}
+          height={CELL_SIZE - 2}
+          fill={fill}
+          stroke={isFirstDayOfMonth ? "#000" : "none"}
+          strokeWidth={isFirstDayOfMonth ? 2 : 0}
+          rx={3}
+          onMouseEnter={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setTooltipData({
+              x: rect.left + window.scrollX,
+              y: rect.top + window.scrollY,
+              date: entry.date,
+              value: entry.value,
+            });
+          }}
+          onMouseLeave={() => setTooltipData(null)}
+        />
+      );
+    });
+  };
+
+  const renderAxes = () => {
+    const yAxis = DAYS.map((day, index) => (
+      <text
+        key={`day-${index}`}
+        x={PADDING}
+        y={index * CELL_SIZE + PADDING + CELL_SIZE / 2}
+        textAnchor="end"
+        dominantBaseline="middle"
+        className={cn(axisClassName)}
+        fontSize={10}
+      >
+        {day}
+      </text>
+    ));
+
+    const xAxis = MONTHS.map((month, index) => {
+      const firstDayOfMonth = startDate.set({ month: index + 1, day: 1 });
+      const week = firstDayOfMonth.weekNumber - startDate.weekNumber + 1;
+      return (
+        <text
+          key={`month-${index}`}
+          x={week * CELL_SIZE + PADDING + CELL_SIZE/2}
+          y={PADDING - 5}
+          textAnchor="middle"
+          fontSize={10}
+          className={cn(axisClassName)}
+        >
+          {month}
+        </text>
+      );
+    });
+
+    return [...yAxis, ...xAxis];
+  };
+
+  // TODO fix tooltip
+  return (
+    <div className="relative">
+      <svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`}>
+        {renderCells()}
+        {renderAxes()}
+      </svg>
+      {tooltipData && (
+        <div
+          className="absolute bg-card p-2 border border-border rounded shadow text-sm"
+          style={{
+            left: `${tooltipData.x}px`,
+            top: `${tooltipData.y - 40}px`,
+          }}
+        >
+          <DateTimeText datetime={tooltipData.date} className="font-semibold"/>
+          <p>Value: {tooltipData.value}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Heatmap;

--- a/src/ui/app/components/heatmap.tsx
+++ b/src/ui/app/components/heatmap.tsx
@@ -20,6 +20,8 @@ export interface HeatmapProps {
   innerClassName?: ClassValue;
   axisClassName?: ClassValue;
   firstDayOfMonthClassName?: ClassValue;
+  // returns between 0 and 1
+  scaling: (value: number) => number;
 }
 
 export interface HeatmapData {
@@ -56,6 +58,7 @@ const Heatmap: React.FC<HeatmapProps> = ({
   firstDayOfMonthClassName,
   emptyCellColorRgb = "hsl(var(--muted))",
   fullCellColorRgb = "#00FF00",
+  scaling,
 }) => {
   const [tooltipData, setTooltipData] = useState<{
     x: number;
@@ -94,8 +97,7 @@ const Heatmap: React.FC<HeatmapProps> = ({
 
   const renderCells = () => {
     return heatmapData.map((entry, index) => {
-      const intensity = entry.value / 360000000000 + 0.1; // TODO this is 10 hours but needs to be configurable
-      // TODO this color scaling needs to be configurable
+      const intensity = scaling(entry.value);
       const { r, g, b } = hexToRgb(fullCellColorRgb)!;
       const fill =
         entry.value === 0

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -568,12 +568,11 @@ export default function App({ params }: Route.ComponentProps) {
             prev={monthPrev}
           />
         </div>
-        <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min">
+        <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min p-4">
           <Heatmap
             axisClassName="fill-muted-foreground"
             data={yearData}
             startDate={yearStart}
-            startOfWeek={0}
           />
         </div>
       </div>

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -25,7 +25,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getAppDurationsPerPeriod } from "@/lib/repo";
 import { Duration, type DateTime } from "luxon";
 import { useApp, useRefresh, useTag, useTags } from "@/hooks/use-refresh";
-import { dateTimeToTicks, durationToTicks, ticksToDateTime } from "@/lib/time";
+import { dateTimeToTicks, durationToTicks } from "@/lib/time";
 import { useToday } from "@/hooks/use-today";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
@@ -54,7 +54,6 @@ import {
 import { SearchBar } from "@/components/search-bar";
 import { useSearch } from "@/hooks/use-search";
 import { CreateTagDialog } from "@/components/create-tag-dialog";
-import Heatmap from "@/components/heatmap";
 
 function ChooseTagPopover({
   tagId,
@@ -420,31 +419,6 @@ export default function App({ params }: Route.ComponentProps) {
 
   const { copy, hasCopied } = useClipboard();
 
-  const [yearStart, yearEnd] = useMemo(
-    () => [today.startOf("year"), today.endOf("year")],
-    [],
-  );
-  const [yearData, setYearData] = useState(new Map());
-
-  useEffect(() => {
-    getAppDurationsPerPeriod({
-      start: yearStart,
-      end: yearEnd,
-      period: Duration.fromObject({ day: 1 }),
-    }).then((usages) => {
-      setYearData(
-        new Map(
-          _(usages[app.id])
-            .map(
-              (appDur) =>
-                [+ticksToDateTime(appDur.group), appDur.duration] as const,
-            )
-            .value(),
-        ),
-      );
-    });
-  }, [yearStart, yearEnd, app]);
-
   return (
     <>
       <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
@@ -568,13 +542,7 @@ export default function App({ params }: Route.ComponentProps) {
             prev={monthPrev}
           />
         </div>
-        <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min p-4">
-          <Heatmap
-            axisClassName="fill-muted-foreground"
-            data={yearData}
-            startDate={yearStart}
-          />
-        </div>
+        <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
       </div>
     </>
   );

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -25,7 +25,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getAppDurationsPerPeriod } from "@/lib/repo";
 import { Duration, type DateTime } from "luxon";
 import { useApp, useRefresh, useTag, useTags } from "@/hooks/use-refresh";
-import { dateTimeToTicks, durationToTicks } from "@/lib/time";
+import { dateTimeToTicks, durationToTicks, ticksToDateTime } from "@/lib/time";
 import { useToday } from "@/hooks/use-today";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
@@ -54,6 +54,7 @@ import {
 import { SearchBar } from "@/components/search-bar";
 import { useSearch } from "@/hooks/use-search";
 import { CreateTagDialog } from "@/components/create-tag-dialog";
+import Heatmap from "@/components/heatmap";
 
 function ChooseTagPopover({
   tagId,
@@ -419,6 +420,31 @@ export default function App({ params }: Route.ComponentProps) {
 
   const { copy, hasCopied } = useClipboard();
 
+  const [yearStart, yearEnd] = useMemo(
+    () => [today.startOf("year"), today.endOf("year")],
+    [],
+  );
+  const [yearData, setYearData] = useState(new Map());
+
+  useEffect(() => {
+    getAppDurationsPerPeriod({
+      start: yearStart,
+      end: yearEnd,
+      period: Duration.fromObject({ day: 1 }),
+    }).then((usages) => {
+      setYearData(
+        new Map(
+          _(usages[app.id])
+            .map(
+              (appDur) =>
+                [+ticksToDateTime(appDur.group), appDur.duration] as const,
+            )
+            .value(),
+        ),
+      );
+    });
+  }, [yearStart, yearEnd, app]);
+
   return (
     <>
       <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
@@ -542,7 +568,14 @@ export default function App({ params }: Route.ComponentProps) {
             prev={monthPrev}
           />
         </div>
-        <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
+        <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min">
+          <Heatmap
+            axisClassName="fill-muted-foreground"
+            data={yearData}
+            startDate={yearStart}
+            startOfWeek={0}
+          />
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
Adds a new heatmap component to visualize app usage data over time. The heatmap displays daily activity levels using color intensity, includes month/day labels, and features an interactive tooltip showing precise usage duration for each day. Integrates with the app detail view to show yearly usage patterns.

Key features:
- Color-coded cells representing daily app usage
- Month and day labels along axes
- Interactive tooltips with exact usage duration
- Visual indicators for first day of each month
- Responsive layout with configurable styling