### PR TITLE
Engine Timestamp Fix

### DIFF
--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -262,9 +262,9 @@ impl AlertManager {
         &mut self,
         times: &impl TimeSystem,
     ) -> Result<Vec<TriggeredAlert>> {
-        let day_start = times.day_start().to_ticks();
-        let week_start = times.week_start().to_ticks();
-        let month_start = times.month_start().to_ticks();
+        let day_start = times.day_start(true).to_ticks();
+        let week_start = times.week_start(true).to_ticks();
+        let month_start = times.month_start(true).to_ticks();
         let result = query_as(include_str!("../queries/triggered_alerts.sql"))
             .bind(day_start)
             .bind(week_start)
@@ -279,9 +279,9 @@ impl AlertManager {
         &mut self,
         times: &impl TimeSystem,
     ) -> Result<Vec<TriggeredReminder>> {
-        let day_start = times.day_start().to_ticks();
-        let week_start = times.week_start().to_ticks();
-        let month_start = times.month_start().to_ticks();
+        let day_start = times.day_start(true).to_ticks();
+        let week_start = times.week_start(true).to_ticks();
+        let month_start = times.month_start(true).to_ticks();
         let result = query_as(include_str!("../queries/triggered_reminders.sql"))
             .bind(day_start)
             .bind(week_start)

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -182,11 +182,11 @@ impl Repository {
             WHERE a.initialized = 1
             GROUP BY a.id"
         ))
-        .bind(ts.day_start().to_ticks())
+        .bind(ts.day_start(true).to_ticks())
         .bind(i64::MAX)
-        .bind(ts.week_start().to_ticks())
+        .bind(ts.week_start(true).to_ticks())
         .bind(i64::MAX)
-        .bind(ts.month_start().to_ticks())
+        .bind(ts.month_start(true).to_ticks())
         .bind(i64::MAX)
         .fetch_all(self.db.executor())
         .await?;
@@ -220,11 +220,11 @@ impl Repository {
                 LEFT JOIN apps a ON t.id = a.tag_id AND a.initialized = 1
             GROUP BY t.id"
         ))
-        .bind(ts.day_start().to_ticks())
+        .bind(ts.day_start(true).to_ticks())
         .bind(i64::MAX)
-        .bind(ts.week_start().to_ticks())
+        .bind(ts.week_start(true).to_ticks())
         .bind(i64::MAX)
-        .bind(ts.month_start().to_ticks())
+        .bind(ts.month_start(true).to_ticks())
         .bind(i64::MAX)
         .fetch_all(self.db.executor())
         .await?;

--- a/src/data/src/db/tests.rs
+++ b/src/data/src/db/tests.rs
@@ -540,15 +540,15 @@ impl ToTicks for Tick {
 impl TimeSystem for Times {
     type Ticks = Tick;
 
-    fn day_start(&self) -> Self::Ticks {
+    fn day_start(&self, _: bool) -> Self::Ticks {
         Tick(self.day_start)
     }
 
-    fn week_start(&self) -> Self::Ticks {
+    fn week_start(&self, _: bool) -> Self::Ticks {
         Tick(self.week_start)
     }
 
-    fn month_start(&self) -> Self::Ticks {
+    fn month_start(&self, _: bool) -> Self::Ticks {
         Tick(self.month_start)
     }
 }

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -8,6 +8,7 @@ use scoped_futures::ScopedFutureExt;
 use util::error::{Context, Result};
 use util::future::runtime::Handle;
 use util::future::sync::Mutex;
+use util::time::ToTicks;
 use util::tracing::{info, trace, ResultTraceExt};
 
 use crate::cache::{AppDetails, Cache, SessionDetails};
@@ -54,8 +55,8 @@ impl Engine {
         ret.current_usage = Usage {
             id: Default::default(),
             session_id: ret.get_session_details(foreground).await?,
-            start: start.into(),
-            end: start.into(),
+            start: start.to_ticks(),
+            end: start.to_ticks(),
         };
 
         Ok(ret)
@@ -67,7 +68,7 @@ impl Engine {
             Event::ForegroundChanged(ForegroundChangedEvent { at, session }) => {
                 info!("fg switch: {:?}", session);
 
-                self.current_usage.end = at.into();
+                self.current_usage.end = at.to_ticks();
                 self.inserter
                     .insert_or_update_usage(&mut self.current_usage)
                     .await?;
@@ -80,8 +81,8 @@ impl Engine {
                     self.current_usage = Usage {
                         id: Default::default(),
                         session_id: session.clone(),
-                        start: at.into(),
-                        end: at.into(),
+                        start: at.to_ticks(),
+                        end: at.to_ticks(),
                     };
                 }
 
@@ -90,7 +91,7 @@ impl Engine {
             Event::Tick(now) => {
                 trace!("tick at {:?}", now);
 
-                self.current_usage.end = now.into();
+                self.current_usage.end = now.to_ticks();
                 self.inserter
                     .insert_or_update_usage(&mut self.current_usage)
                     .await?;
@@ -105,8 +106,8 @@ impl Engine {
                 self.inserter
                     .insert_interaction_period(&InteractionPeriod {
                         id: Default::default(),
-                        start: self.active_period_start.into(),
-                        end: at.into(),
+                        start: self.active_period_start.to_ticks(),
+                        end: at.to_ticks(),
                         mouse_clicks: recorded_mouse_clicks,
                         key_strokes: recorded_key_presses,
                     })

--- a/src/engine/src/sentry.rs
+++ b/src/engine/src/sentry.rs
@@ -7,6 +7,7 @@ use platform::objects::{
 };
 use util::error::Result;
 use util::future::sync::Mutex;
+use util::time::ToTicks;
 use util::tracing::{info, ResultTraceExt};
 
 use crate::cache::Cache;
@@ -44,7 +45,7 @@ impl Sentry {
                 .insert_reminder_event(&ReminderEvent {
                     id: Default::default(),
                     reminder: triggered_reminder.reminder.id.0.into(),
-                    timestamp: now.into(),
+                    timestamp: now.to_ticks(),
                 })
                 .await?;
         }
@@ -106,8 +107,8 @@ impl Sentry {
             }
             TriggerAction::Dim(dur) => {
                 let windows = self.windows_for_target(&alert.target).await?;
-                let start = timestamp.unwrap_or(now.into());
-                let end: Timestamp = now.into();
+                let start = timestamp.unwrap_or(now.to_ticks());
+                let end: Timestamp = now.to_ticks();
                 let progress = (end - start) as f64 / (*dur as f64);
                 for window in windows {
                     let dim_level = 1.0f64 - progress.min(1.0f64);
@@ -127,7 +128,7 @@ impl Sentry {
                 .insert_alert_event(&AlertEvent {
                     id: Default::default(),
                     alert: alert.id.0.clone().into(),
-                    timestamp: now.into(),
+                    timestamp: now.to_ticks(),
                 })
                 .await?;
         }

--- a/src/platform/src/objects/timestamp.rs
+++ b/src/platform/src/objects/timestamp.rs
@@ -87,17 +87,12 @@ impl Timestamp {
         let ft_ticks: u64 = unsafe { mem::transmute(ft) };
         ft_ticks + FILE_TIME_OFFSET
     }
-}
 
-impl From<u64> for Timestamp {
-    fn from(t: u64) -> Self {
-        Self { ticks: t }
-    }
-}
-
-impl From<i64> for Timestamp {
-    fn from(t: i64) -> Self {
-        Self { ticks: t as u64 }
+    /// Convert [Timestamp] from ticks
+    pub fn from_ticks(ticks: i64) -> Self {
+        Self {
+            ticks: ticks as u64,
+        }
     }
 }
 

--- a/src/platform/src/objects/timestamp.rs
+++ b/src/platform/src/objects/timestamp.rs
@@ -89,18 +89,6 @@ impl Timestamp {
     }
 }
 
-impl From<Timestamp> for u64 {
-    fn from(t: Timestamp) -> Self {
-        t.ticks
-    }
-}
-
-impl From<Timestamp> for i64 {
-    fn from(t: Timestamp) -> Self {
-        t.ticks as i64
-    }
-}
-
 impl From<u64> for Timestamp {
     fn from(t: u64) -> Self {
         Self { ticks: t }

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -4,6 +4,7 @@ use data::db::repo::{infused, WithDuration, WithGroupedDuration};
 use data::entities::{App, Duration, Ref, Tag, Timestamp};
 use tauri::State;
 use util::error::Context;
+use util::time::ToTicks;
 use util::tracing;
 
 use crate::error::AppResult;
@@ -99,7 +100,7 @@ pub async fn update_usages_end(state: State<'_, AppState>) -> AppResult<()> {
         .assume_init_mut()
         .get_repo()
         .await?
-        .update_usages_set_last(now.into())
+        .update_usages_set_last(now.to_ticks())
         .await?;
     Ok(())
 }

--- a/src/ui/src-tauri/src/state.rs
+++ b/src/ui/src-tauri/src/state.rs
@@ -31,7 +31,7 @@ impl QueryOptions {
     /// Get the current time 'now' from the options
     pub fn get_now(&self) -> platform::objects::Timestamp {
         if let Some(now) = self.now {
-            now.into()
+            platform::objects::Timestamp::from_ticks(now)
         } else {
             platform::objects::Timestamp::now()
         }

--- a/src/util/src/time.rs
+++ b/src/util/src/time.rs
@@ -7,9 +7,9 @@ pub trait ToTicks {
 pub trait TimeSystem {
     type Ticks: ToTicks;
     /// Get the start of the day
-    fn day_start(&self) -> Self::Ticks;
+    fn day_start(&self, local_tz: bool) -> Self::Ticks;
     /// Get the start of the week. The week starts on Sunday.
-    fn week_start(&self) -> Self::Ticks;
+    fn week_start(&self, local_tz: bool) -> Self::Ticks;
     /// Get the start of the month
-    fn month_start(&self) -> Self::Ticks;
+    fn month_start(&self, local_tz: bool) -> Self::Ticks;
 }


### PR DESCRIPTION
fix(platform): local timezone ticks handling

- Added timezone conversion support for day, week, and month start calculations
- Changed week start to Monday instead of Sunday
- Introduced local timezone parameter for time system calculations

feat(platform,engine): use ticks directly

- Replaced timestamp conversion with direct ticks handling
- Updated engine and sentry to use to_ticks() consistently
- Removed From/Into implementations in favor of explicit conversions

feat(platform,ui): add from_ticks

- Added from_ticks constructor for Timestamp
- Updated UI components to use ticks-based timestamp handling
- Standardized timestamp creation across codebase