### PR TITLE
Add Tooltip in Gantt Charts

### DIFF
--- a/src/ui/app/components/viz/gantt.tsx
+++ b/src/ui/app/components/viz/gantt.tsx
@@ -10,6 +10,8 @@ import {
   ChevronDown,
   LaptopIcon,
   Loader2Icon,
+  KeyboardIcon,
+  MouseIcon,
 } from "lucide-react";
 import { DateTime } from "luxon";
 import type {
@@ -176,11 +178,13 @@ function InteractionPeriodBars({
   rangeStart,
   rangeEnd,
   timeUnit,
+  setHoverInteractionPeriod,
 }: {
   interactionPeriods: InteractionPeriod[];
   rangeStart: DateTime;
   rangeEnd: DateTime;
   timeUnit: TimeUnit;
+  setHoverInteractionPeriod: (ip: InteractionPeriod | null) => void;
 }) {
   return (
     <>
@@ -193,6 +197,8 @@ function InteractionPeriodBars({
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
           timeUnit={timeUnit}
+          onMouseOver={() => setHoverInteractionPeriod(interactionPeriod)}
+          onMouseLeave={() => setHoverInteractionPeriod(null)}
         />
       ))}
     </>
@@ -291,6 +297,8 @@ export function Gantt({
     defaultExpanded ?? {},
   );
   const [hoverUsage, setHoverUsage] = useState<HoverData | null>(null);
+  const [hoverInteractionPeriod, setHoverInteractionPeriod] =
+    useState<InteractionPeriod | null>(null);
 
   const timeUnit = useMemo(
     () => getTimeUnits(rangeStart, rangeEnd),
@@ -360,6 +368,34 @@ export function Gantt({
           )}
         </div>
       </Tooltip>
+
+      <Tooltip show={hoverInteractionPeriod !== null} targetRef={ref}>
+        <div className="max-w-[800px]">
+          {hoverInteractionPeriod && (
+            <div className={cn("flex flex-col")}>
+              <div className="flex items-center gap-1 text-sm">
+                <Text className="text-base">Interaction</Text>
+                <KeyboardIcon size={16} className="ml-4" />
+                <div>{hoverInteractionPeriod.key_strokes}</div>
+                <MouseIcon size={16} className="ml-2" />
+                <div>{hoverInteractionPeriod.mouse_clicks}</div>
+              </div>
+              <div className="flex items-center text-muted-foreground gap-1 text-xs">
+                <DateTimeText ticks={hoverInteractionPeriod.start} /> -
+                <DateTimeText ticks={hoverInteractionPeriod.end} />
+                (
+                <DurationText
+                  ticks={
+                    hoverInteractionPeriod.end - hoverInteractionPeriod.start
+                  }
+                />
+                )
+              </div>
+            </div>
+          )}
+        </div>
+      </Tooltip>
+
       <div className="bg-transparent overflow-hidden flex text-muted-foreground">
         {/* Fixed left column */}
         <div className="w-[300px] flex-shrink-0">
@@ -477,6 +513,7 @@ export function Gantt({
                 <div className="h-[52px] relative">
                   <div className="absolute inset-x-0 top-4">
                     <InteractionPeriodBars
+                      setHoverInteractionPeriod={setHoverInteractionPeriod}
                       interactionPeriods={interactionPeriods}
                       rangeStart={rangeStart}
                       rangeEnd={rangeEnd}

--- a/src/ui/app/components/viz/gantt.tsx
+++ b/src/ui/app/components/viz/gantt.tsx
@@ -25,7 +25,7 @@ import { ticksToDateTime } from "@/lib/time";
 import type { AppSessionUsages } from "@/lib/repo";
 import { Text } from "@/components/ui/text";
 import { useApps } from "@/hooks/use-refresh";
-import AppIcon from "../app/app-icon";
+import AppIcon from "@/components/app/app-icon";
 import type { ClassValue } from "clsx";
 import { cn } from "@/lib/utils";
 import { HScrollView } from "@/components/hscroll-view";


### PR DESCRIPTION
Adds tooltips to the gantt chart displaying detailed information when hovering over:
- Sessions: showing title, start/end times, and duration
- Usages: showing start/end times and duration
- Interaction periods: showing keyboard/mouse activity counts and timing details

Also fixes the AppIcon import path to use the absolute path format.