### PR TITLE
Engine Stability Fixes

### DIFF
--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -252,9 +252,11 @@ impl Engine {
                     let id = id.clone();
 
                     spawner.spawn(async move {
-                        AppInfoResolver::update_app(db_pool, id, identity)
+                        AppInfoResolver::update_app(db_pool, id.clone(), identity.clone())
                             .await
-                            .context("update app with info")
+                            .with_context(|| {
+                                format!("update app({:?}, {:?}) with info", id, identity)
+                            })
                             .error();
                     });
                 }

--- a/src/engine/src/main.rs
+++ b/src/engine/src/main.rs
@@ -100,7 +100,7 @@ fn event_loop(
             } else {
                 event_tx.send(Event::Tick(now))?;
             }
-            if let Some(event) = it_watcher.poll(now)? {
+            if let Some(event) = it_watcher.lock().unwrap().poll(now)? {
                 event_tx.send(Event::InteractionChanged(event))?;
             }
             Ok(())

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -39,7 +39,7 @@ impl AppInfoResolver {
             color: Self::random_color(),
             identity,
             tag_id: None,
-            icon: Some(app_info.logo),
+            icon: app_info.logo,
         };
         updater.update_app(&app).await?;
         Ok(())

--- a/src/platform/src/objects/message_window.rs
+++ b/src/platform/src/objects/message_window.rs
@@ -111,6 +111,10 @@ impl Drop for MessageWindow {
             UnregisterClassW(PCWSTR::from_raw(self.class_name.as_ptr()), None)
                 .context("Failed to unregister MessageWindow class")
                 .error();
+
+            let callbacks =
+                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut Rc<RefCell<Vec<Callback>>>;
+            drop(Box::from_raw(callbacks));
         }
     }
 }


### PR DESCRIPTION
This PR:
- Adds functionality to retry failed app info updates on startup
- Makes app logo handling more robust by making it optional and separating extraction logic
- Properly cleans up window callback memory on drop
- Refactors interaction tracking to use atomic state for thread safety
- Improves system event handling by tracking interaction periods
- Fixes duplicate power setting notifications during initial window registration