### PR TITLE
Alert/Reminder Engine Improvements

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,7 +136,6 @@ The SQLite database stores all tracked data and configuration. Key entities are:
 erDiagram
     apps {
         int             id PK
-        tinyint         initialized "true if details are set"
         tinyint         found   "temp col, true if found by upsert"
         text            name
         text            description
@@ -146,12 +145,17 @@ erDiagram
         int             identity_is_win32     UK "UNIQUE(is_win32, path_or_aumid)"
         text            identity_path_or_aumid   UK "UNIQUE(is_win32, path_or_aumid)"
         blob_nullable   icon
+        int             created_at
+        int_nullable    initialized_at "set if details are set"
+        int             updated_at
     }
 
     tags {
         int             id PK
         text            name UK
         text            color
+        int             created_at
+        int             updated_at
     }
 
     sessions {
@@ -191,6 +195,8 @@ erDiagram
         text_nullable   trigger_action_message_content     "Content of Message(Content)"
         int             trigger_action_tag      "Kill / Dim / Message"
         tinyint         active
+        int             created_at
+        int             updated_at
     }
 
     alert_events {
@@ -206,6 +212,8 @@ erDiagram
         real            threshold
         text            message
         tinyint         active
+        int             created_at
+        int             updated_at
     }
 
     reminder_events {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,7 @@ erDiagram
         int             id PK
         int             alert_id FK
         int             timestamp
+        int             reason
     }
 
     reminders {
@@ -211,6 +212,7 @@ erDiagram
         int             id PK
         int             reminder_id FK
         int             timestamp
+        int             reason
     }
 
     apps ||--o{ sessions : sessions

--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -138,6 +138,10 @@ pub struct Alert {
     #[sqlx(flatten)]
     /// Action to take on trigger
     pub trigger_action: TriggerAction,
+    /// Created at
+    pub created_at: Timestamp,
+    /// Updated at
+    pub updated_at: Timestamp,
     /// List of linked [Reminder]s
     pub reminders: Vec<Reminder>,
     /// List of hit [super::AlertEvent]s
@@ -156,6 +160,10 @@ pub struct Reminder {
     pub threshold: f64,
     /// Message to send when the threshold is reached
     pub message: String,
+    /// Created at
+    pub created_at: Timestamp,
+    /// Updated at
+    pub updated_at: Timestamp,
     /// List of hit [super::ReminderEvent]s
     #[sqlx(flatten)]
     pub events: ValuePerPeriod<i64>,
@@ -168,6 +176,8 @@ impl PartialEq<Reminder> for Reminder {
             && (self.threshold - other.threshold).abs() <= f64::EPSILON
             && self.message == other.message
             && self.events == other.events
+            && self.created_at == other.created_at
+            && self.updated_at == other.updated_at
     }
 }
 

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -282,6 +282,8 @@ pub struct TriggeredReminder {
     pub reminder: Reminder,
     /// Name of the offending target (App/Tag)
     pub name: String,
+    /// Usage limit
+    pub usage_limit: crate::table::Duration,
 }
 
 /// Reference to hold statements regarding [Alert] and [Reminder] queries

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -343,9 +343,10 @@ impl AlertManager {
 
     /// Insert a [AlertEvent]
     pub async fn insert_alert_event(&mut self, event: &AlertEvent) -> Result<()> {
-        query("INSERT INTO alert_events VALUES (NULL, ?, ?)")
+        query("INSERT INTO alert_events VALUES (NULL, ?, ?, ?)")
             .bind(&event.alert_id)
             .bind(event.timestamp)
+            .bind(&event.reason)
             .execute(self.db.executor())
             .await?;
         Ok(())
@@ -353,9 +354,10 @@ impl AlertManager {
 
     /// Insert a [ReminderEvent]
     pub async fn insert_reminder_event(&mut self, event: &ReminderEvent) -> Result<()> {
-        query("INSERT INTO reminder_events VALUES (NULL, ?, ?)")
+        query("INSERT INTO reminder_events VALUES (NULL, ?, ?, ?)")
             .bind(&event.reminder_id)
             .bind(event.timestamp)
+            .bind(&event.reason)
             .execute(self.db.executor())
             .await?;
         Ok(())

--- a/src/data/src/db/repo_crud.rs
+++ b/src/data/src/db/repo_crud.rs
@@ -55,7 +55,7 @@ impl Repository {
                 LEFT JOIN usage_today d ON a.id = d.id
                 LEFT JOIN usage_week  w ON a.id = w.id
                 LEFT JOIN usage_month m ON a.id = m.id
-            WHERE a.initialized = 1
+            WHERE a.initialized_at IS NOT NULL
             GROUP BY a.id"
         ))
         .bind(ts.day_start(true).to_ticks())
@@ -93,7 +93,7 @@ impl Repository {
                 LEFT JOIN usage_today d ON t.id = d.id
                 LEFT JOIN usage_week  w ON t.id = w.id
                 LEFT JOIN usage_month m ON t.id = m.id
-                LEFT JOIN apps a ON t.id = a.tag_id AND a.initialized = 1
+                LEFT JOIN apps a ON t.id = a.tag_id AND a.initialized_at IS NOT NULL
             GROUP BY t.id"
         ))
         .bind(ts.day_start(true).to_ticks())

--- a/src/data/src/db/repo_crud.rs
+++ b/src/data/src/db/repo_crud.rs
@@ -269,7 +269,11 @@ impl Repository {
     }
 
     /// Create a new [Tag] from a [infused::CreateTag]
-    pub async fn create_tag(&mut self, tag: &infused::CreateTag) -> Result<infused::Tag> {
+    pub async fn create_tag(
+        &mut self,
+        tag: &infused::CreateTag,
+        ts: impl TimeSystem,
+    ) -> Result<infused::Tag> {
         let mut tx = self.db.transaction().await?;
         let res = query("INSERT INTO tags VALUES (NULL, ?, ?)")
             .bind(&tag.name)
@@ -291,6 +295,8 @@ impl Repository {
                 id,
                 name: tag.name.clone(),
                 color: tag.color.clone(),
+                created_at: ts.now().to_ticks(),
+                updated_at: ts.now().to_ticks(),
             },
             apps: infused::RefVec(tag.apps.clone()),
             usages: infused::ValuePerPeriod::default(),

--- a/src/data/src/db/repo_crud.rs
+++ b/src/data/src/db/repo_crud.rs
@@ -24,11 +24,11 @@ const TAG_DUR: &str = "SELECT a.tag_id AS id,
             GROUP BY a.tag_id";
 
 const ALERT_EVENT_COUNT: &str = "SELECT e.alert_id, COUNT(e.id) FROM alert_events e
-            WHERE timestamp BETWEEN ? AND ?
+            WHERE reason = 0 AND timestamp BETWEEN ? AND ?
             GROUP BY e.alert_id";
 
 const REMINDER_EVENT_COUNT: &str = "SELECT e.reminder_id, COUNT(e.id) FROM reminder_events e
-            WHERE timestamp BETWEEN ? AND ?
+            WHERE reason = 0 AND timestamp BETWEEN ? AND ?
             GROUP BY e.reminder_id";
 
 impl Repository {

--- a/src/data/src/db/repo_crud.rs
+++ b/src/data/src/db/repo_crud.rs
@@ -187,6 +187,8 @@ impl Repository {
                         usage_limit: alert.inner.usage_limit,
                         time_frame: alert.inner.time_frame,
                         trigger_action: alert.inner.trigger_action,
+                        created_at: alert.inner.created_at,
+                        updated_at: alert.inner.updated_at,
 
                         events: alert.events,
                         reminders: Vec::new(),
@@ -206,7 +208,11 @@ impl Repository {
         Ok(alerts)
     }
     /// Update the [App] with additional information
-    pub async fn update_app(&mut self, app: &infused::UpdatedApp) -> Result<()> {
+    pub async fn update_app(
+        &mut self,
+        app: &infused::UpdatedApp,
+        ts: impl TimeSystem,
+    ) -> Result<()> {
         query(
             "UPDATE apps SET
                     name = ?,
@@ -214,7 +220,7 @@ impl Repository {
                     company = ?,
                     color = ?,
                     tag_id = ?,
-                    initialized = 1
+                    updated_at = ?
                 WHERE id = ?",
         )
         .bind(&app.name)
@@ -222,6 +228,7 @@ impl Repository {
         .bind(&app.company)
         .bind(&app.color)
         .bind(&app.tag_id)
+        .bind(ts.now().to_ticks())
         .bind(&app.id)
         .execute(self.db.executor())
         .await?;
@@ -229,7 +236,11 @@ impl Repository {
     }
 
     /// Update the [Tag] with additional information
-    pub async fn update_tag(&mut self, tag: &infused::UpdatedTag) -> Result<()> {
+    pub async fn update_tag(
+        &mut self,
+        tag: &infused::UpdatedTag,
+        ts: impl TimeSystem,
+    ) -> Result<()> {
         query(
             "UPDATE tags SET
                     name = ?,
@@ -238,6 +249,7 @@ impl Repository {
         )
         .bind(&tag.name)
         .bind(&tag.color)
+        .bind(ts.now().to_ticks())
         .bind(&tag.id)
         .execute(self.db.executor())
         .await?;
@@ -250,6 +262,7 @@ impl Repository {
         tag_id: Ref<Tag>,
         removed_apps: Vec<Ref<App>>,
         added_apps: Vec<Ref<App>>,
+        ts: impl TimeSystem,
     ) -> Result<()> {
         let mut tx = self.db.transaction().await?;
         let updates = removed_apps.into_iter().map(|app| (app, None)).chain(
@@ -258,8 +271,9 @@ impl Repository {
                 .map(|app| (app, Some(tag_id.clone()))),
         );
         for (app, tag) in updates {
-            query("UPDATE apps SET tag_id = ? WHERE id = ?")
+            query("UPDATE apps SET tag_id = ?, updated_at = ? WHERE id = ?")
                 .bind(tag)
+                .bind(ts.now().to_ticks())
                 .bind(app)
                 .execute(&mut *tx)
                 .await?;
@@ -275,15 +289,18 @@ impl Repository {
         ts: impl TimeSystem,
     ) -> Result<infused::Tag> {
         let mut tx = self.db.transaction().await?;
-        let res = query("INSERT INTO tags VALUES (NULL, ?, ?)")
+        let res = query("INSERT INTO tags VALUES (NULL, ?, ?, ?, ?)")
             .bind(&tag.name)
             .bind(&tag.color)
+            .bind(ts.now().to_ticks())
+            .bind(ts.now().to_ticks())
             .execute(&mut *tx)
             .await?;
         let id = Ref::new(res.last_insert_rowid());
         for app in &tag.apps {
-            query("UPDATE apps SET tag_id = ? WHERE id = ?")
+            query("UPDATE apps SET tag_id = ?, updated_at = ? WHERE id = ?")
                 .bind(&id)
+                .bind(ts.now().to_ticks())
                 .bind(app)
                 .execute(&mut *tx)
                 .await?;
@@ -330,7 +347,11 @@ impl Repository {
     }
 
     /// Creates a [Alert]
-    pub async fn create_alert(&mut self, alert: infused::CreateAlert) -> Result<infused::Alert> {
+    pub async fn create_alert(
+        &mut self,
+        alert: infused::CreateAlert,
+        ts: impl TimeSystem,
+    ) -> Result<infused::Alert> {
         let mut tx = self.db.transaction().await?;
 
         let (app_id, tag_id) = Self::destructure_target(&alert.target);
@@ -339,7 +360,7 @@ impl Repository {
 
         // Insert the alert
         let alert_id: Ref<Alert> =
-            query("INSERT INTO alerts VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id")
+            query("INSERT INTO alerts VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id")
                 .bind(app_id)
                 .bind(tag_id)
                 .bind(alert.usage_limit)
@@ -348,6 +369,8 @@ impl Repository {
                 .bind(message_content)
                 .bind(tag)
                 .bind(true)
+                .bind(ts.now().to_ticks())
+                .bind(ts.now().to_ticks())
                 .fetch_one(&mut *tx)
                 .await?
                 .get(0);
@@ -356,11 +379,13 @@ impl Repository {
 
         // Insert the reminders
         for reminder in alert.reminders {
-            let id = query("INSERT INTO reminders VALUES (NULL, ?, ?, ?, ?) RETURNING id")
+            let id = query("INSERT INTO reminders VALUES (NULL, ?, ?, ?, ?, ?, ?) RETURNING id")
                 .bind(&alert_id)
                 .bind(reminder.threshold)
                 .bind(&reminder.message)
                 .bind(true)
+                .bind(ts.now().to_ticks())
+                .bind(ts.now().to_ticks())
                 .fetch_one(&mut *tx)
                 .await?
                 .get(0);
@@ -369,6 +394,8 @@ impl Repository {
                 alert_id: alert_id.clone(),
                 threshold: reminder.threshold,
                 message: reminder.message,
+                created_at: ts.now().to_ticks(),
+                updated_at: ts.now().to_ticks(),
                 events: infused::ValuePerPeriod::default(),
             };
             reminders.push(reminder);
@@ -382,6 +409,8 @@ impl Repository {
             usage_limit: alert.usage_limit,
             time_frame: alert.time_frame,
             trigger_action: alert.trigger_action,
+            created_at: ts.now().to_ticks(),
+            updated_at: ts.now().to_ticks(),
             reminders,
             events: infused::ValuePerPeriod::default(),
         };
@@ -394,6 +423,7 @@ impl Repository {
         &mut self,
         prev: infused::Alert,
         mut next: infused::UpdatedAlert,
+        ts: impl TimeSystem,
     ) -> Result<infused::Alert> {
         let mut tx = self.db.transaction().await?;
         let has_any_alert_events = Self::has_any_alert_events(&mut *tx, &prev.id).await?;
@@ -405,7 +435,8 @@ impl Repository {
 
         let prev_reminders: HashMap<_, _> = prev
             .reminders
-            .into_iter()
+            .iter()
+            .cloned()
             .map(|r| (r.id.clone(), r))
             .collect();
 
@@ -415,28 +446,36 @@ impl Repository {
             usage_limit: next.usage_limit,
             time_frame: next.time_frame.clone(),
             trigger_action: next.trigger_action.clone(),
+            created_at: prev.created_at,
+            updated_at: ts.now().to_ticks(),
             reminders: Vec::new(),
             events: infused::ValuePerPeriod::default(),
         };
 
         if should_upgrade_alert {
-            next.id = Self::upgrade_alert_only(&mut tx, &next).await?;
+            next.id = Self::upgrade_alert_only(&mut tx, &prev, &next, &ts).await?;
 
             for mut reminder in next.reminders {
                 if !reminder.active {
                     continue;
                 }
-                Self::insert_reminder_only(&mut *tx, &next.id, &mut reminder).await?;
+                let prev_reminder = prev_reminders.get(&reminder.id);
+                Self::insert_reminder_only(&mut *tx, prev_reminder, &next.id, &mut reminder, &ts)
+                    .await?;
                 next_alert.reminders.push(infused::Reminder {
                     id: reminder.id,
                     alert_id: next.id.clone(),
                     threshold: reminder.threshold,
                     message: reminder.message,
+                    created_at: prev_reminder
+                        .map(|r| r.created_at)
+                        .unwrap_or(ts.now().to_ticks()),
+                    updated_at: ts.now().to_ticks(),
                     events: infused::ValuePerPeriod::default(), // since this is a new reminder.
                 });
             }
         } else {
-            Self::update_alert_only(&mut *tx, &next).await?;
+            Self::update_alert_only(&mut *tx, &next, &ts).await?;
             next_alert.events = prev.events;
 
             for mut reminder in next.reminders {
@@ -448,23 +487,35 @@ impl Repository {
                     alert_id: next.id.clone(),
                     threshold: reminder.threshold,
                     message: reminder.message.clone(),
+                    created_at: ts.now().to_ticks(),
+                    updated_at: ts.now().to_ticks(),
                     events: infused::ValuePerPeriod::default(),
                 };
                 if let Some(prev_reminder) = prev_reminder {
                     let should_upgrade_reminder =
                         has_any_reminder_events && (reminder.threshold != prev_reminder.threshold);
 
+                    next_reminder.created_at = prev_reminder.created_at;
                     if should_upgrade_reminder {
                         // Even if this reminder is no longer active, if it's threshold changes & has a
                         // event we should insert (upgrade) the reminder.
-                        Self::upgrade_reminder_only(&mut tx, &next.id, &mut reminder).await?;
+                        Self::upgrade_reminder_only(
+                            &mut tx,
+                            prev_reminder,
+                            &next.id,
+                            &mut reminder,
+                            &ts,
+                        )
+                        .await?;
                         next_reminder.id = reminder.id;
                     } else {
-                        Self::update_reminder_only(&mut *tx, &mut reminder).await?;
+                        Self::update_reminder_only(&mut *tx, prev_reminder, &mut reminder, &ts)
+                            .await?;
                         next_reminder.events = prev_reminder.events.clone();
                     }
                 } else {
-                    Self::insert_reminder_only(&mut *tx, &next.id, &mut reminder).await?;
+                    Self::insert_reminder_only(&mut *tx, None, &next.id, &mut reminder, &ts)
+                        .await?;
                     next_reminder.id = reminder.id;
                 }
                 next_alert.reminders.push(next_reminder);
@@ -503,6 +554,7 @@ impl Repository {
     async fn update_alert_only<'a, E: SqliteExecutor<'a>>(
         executor: E,
         alert: &infused::UpdatedAlert,
+        ts: &impl TimeSystem,
     ) -> Result<()> {
         let (app_id, tag_id) = Self::destructure_target(&alert.target);
         let (dim_duration, message_content, tag) =
@@ -515,7 +567,8 @@ impl Repository {
                 time_frame = ?,
                 dim_duration = ?,
                 message_content = ?,
-                trigger_action_tag = ?
+                trigger_action_tag = ?,
+                updated_at = ?
             WHERE id = ?",
         )
         .bind(app_id)
@@ -525,6 +578,7 @@ impl Repository {
         .bind(dim_duration)
         .bind(message_content)
         .bind(tag)
+        .bind(ts.now().to_ticks())
         .bind(&alert.id)
         .execute(executor)
         .await?;
@@ -533,9 +587,12 @@ impl Repository {
 
     async fn upgrade_alert_only(
         executor: &mut sqlx::SqliteConnection,
+        prev: &infused::Alert,
         alert: &infused::UpdatedAlert,
+        ts: &impl TimeSystem,
     ) -> Result<Ref<Alert>> {
-        query("UPDATE alerts SET active = 0 WHERE id = ?")
+        query("UPDATE alerts SET active = 0, updated_at = ? WHERE id = ?")
+            .bind(ts.now().to_ticks())
             .bind(&alert.id)
             .execute(&mut *executor)
             .await?;
@@ -543,32 +600,43 @@ impl Repository {
         let (app_id, tag_id) = Self::destructure_target(&alert.target);
         let (dim_duration, message_content, tag) =
             Self::destructure_trigger_action(&alert.trigger_action);
-        let new_id = query("INSERT INTO alerts VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id")
-            .bind(app_id)
-            .bind(tag_id)
-            .bind(alert.usage_limit)
-            .bind(&alert.time_frame)
-            .bind(dim_duration)
-            .bind(message_content)
-            .bind(tag)
-            .bind(true)
-            .fetch_one(&mut *executor)
-            .await?
-            .get(0);
+        let new_id =
+            query("INSERT INTO alerts VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id")
+                .bind(app_id)
+                .bind(tag_id)
+                .bind(alert.usage_limit)
+                .bind(&alert.time_frame)
+                .bind(dim_duration)
+                .bind(message_content)
+                .bind(tag)
+                .bind(true)
+                .bind(prev.created_at)
+                .bind(ts.now().to_ticks())
+                .fetch_one(&mut *executor)
+                .await?
+                .get(0);
 
         Ok(new_id)
     }
 
     async fn insert_reminder_only<'a, E: SqliteExecutor<'a>>(
         executor: E,
+        prev_reminder: Option<&infused::Reminder>,
         alert_id: &Ref<Alert>,
         reminder: &mut infused::UpdatedReminder,
+        ts: &impl TimeSystem,
     ) -> Result<()> {
-        reminder.id = query("INSERT INTO reminders VALUES(NULL, ?, ?, ?, ?) RETURNING id")
+        reminder.id = query("INSERT INTO reminders VALUES(NULL, ?, ?, ?, ?, ?, ?) RETURNING id")
             .bind(alert_id)
             .bind(reminder.threshold)
             .bind(&reminder.message)
             .bind(true)
+            .bind(
+                prev_reminder
+                    .map(|r| r.created_at)
+                    .unwrap_or(ts.now().to_ticks()),
+            )
+            .bind(ts.now().to_ticks())
             .fetch_one(executor)
             .await?
             .get(0);
@@ -577,13 +645,16 @@ impl Repository {
 
     async fn update_reminder_only<'a, E: SqliteExecutor<'a>>(
         executor: E,
+        _prev_reminder: &infused::Reminder,
         reminder: &mut infused::UpdatedReminder,
+        ts: &impl TimeSystem,
     ) -> Result<()> {
         reminder.id =
-            query("UPDATE reminders SET threshold = ?, message = ?, active = ? WHERE id = ?")
+            query("UPDATE reminders SET threshold = ?, message = ?, active = ?, updated_at = ? WHERE id = ?")
                 .bind(reminder.threshold)
                 .bind(&reminder.message)
                 .bind(reminder.active)
+                .bind(ts.now().to_ticks())
                 .bind(&reminder.id)
                 .fetch_one(executor)
                 .await?
@@ -593,19 +664,24 @@ impl Repository {
 
     async fn upgrade_reminder_only(
         executor: &mut sqlx::SqliteConnection,
+        prev_reminder: &infused::Reminder,
         alert_id: &Ref<Alert>,
         reminder: &mut infused::UpdatedReminder,
+        ts: &impl TimeSystem,
     ) -> Result<()> {
-        query("UPDATE reminders SET active = 0 WHERE id = ?")
+        query("UPDATE reminders SET active = 0, updated_at = ? WHERE id = ?")
+            .bind(ts.now().to_ticks())
             .bind(&reminder.id)
             .execute(&mut *executor)
             .await?;
 
-        reminder.id = query("INSERT INTO reminders VALUES(NULL, ?, ?, ?, ?) RETURNING id")
+        reminder.id = query("INSERT INTO reminders VALUES(NULL, ?, ?, ?, ?, ?, ?) RETURNING id")
             .bind(alert_id)
             .bind(reminder.threshold)
             .bind(&reminder.message)
             .bind(true)
+            .bind(prev_reminder.created_at)
+            .bind(ts.now().to_ticks())
             .fetch_one(&mut *executor)
             .await?
             .get(0);

--- a/src/data/src/db/repo_crud.rs
+++ b/src/data/src/db/repo_crud.rs
@@ -4,7 +4,7 @@ use sqlx::SqliteExecutor;
 
 use super::repo::Repository;
 use super::*;
-use crate::entities::TriggerAction;
+use crate::entities::{Reason, TriggerAction};
 
 /// SQL expression for getting the duration of all apps in day, week, month range.
 pub const APP_DUR: &str = "SELECT a.id AS id,
@@ -619,6 +619,22 @@ impl Repository {
             .await?;
         Ok(())
     }
+
+    /// Create Alert event ignore
+    pub async fn create_alert_event_ignore(
+        &mut self,
+        alert_id: Ref<Alert>,
+        timestamp: Timestamp,
+    ) -> Result<()> {
+        query("INSERT INTO alert_events VALUES (NULL, ?, ?, ?)")
+            .bind(alert_id)
+            .bind(timestamp)
+            .bind(Reason::Ignored)
+            .execute(self.db.executor())
+            .await?;
+        Ok(())
+    }
+
     /// Gets all [InteractionPeriod]s in a time range
     pub async fn get_interaction_periods(
         &mut self,

--- a/src/data/src/db/repo_tests.rs
+++ b/src/data/src/db/repo_tests.rs
@@ -11,7 +11,7 @@ use crate::db::infused::{
     CreateAlert, CreateReminder, RefVec, ValuePerPeriod, WithDuration, WithGroupedDuration,
 };
 use crate::db::tests::arrange::*;
-use crate::entities::{TimeFrame, TriggerAction};
+use crate::entities::{Reason, TimeFrame, TriggerAction};
 use crate::table::Period;
 
 const ONE_HOUR: i64 = 60 * 60 * 1000 * 10000;
@@ -476,6 +476,7 @@ async fn get_alerts() -> Result<()> {
                 id: Ref::new(0),
                 alert_id: alert_id.clone(),
                 timestamp,
+                reason: Reason::Hit,
             },
         )
         .await?;

--- a/src/data/src/db/repo_tests.rs
+++ b/src/data/src/db/repo_tests.rs
@@ -33,6 +33,8 @@ fn create_to_alert(c: CreateAlert, id: i64) -> Alert {
         time_frame: c.time_frame,
         trigger_action: c.trigger_action,
         active: true,
+        created_at: 0,
+        updated_at: 0,
     }
 }
 
@@ -44,6 +46,8 @@ fn infused_to_alert(c: infused::Alert) -> Alert {
         time_frame: c.time_frame,
         trigger_action: c.trigger_action,
         active: true,
+        created_at: 0,
+        updated_at: 0,
     }
 }
 
@@ -64,6 +68,8 @@ async fn get_apps() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -81,6 +87,8 @@ async fn get_apps() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -98,6 +106,8 @@ async fn get_apps() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -115,6 +125,8 @@ async fn get_apps() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -132,6 +144,8 @@ async fn get_apps() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -142,6 +156,8 @@ async fn get_apps() -> Result<()> {
             id: Ref::new(1),
             name: "tag1".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -151,6 +167,8 @@ async fn get_apps() -> Result<()> {
             id: Ref::new(2),
             name: "tag2".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -160,6 +178,8 @@ async fn get_apps() -> Result<()> {
             id: Ref::new(3),
             name: "tag3".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -169,6 +189,8 @@ async fn get_apps() -> Result<()> {
             id: Ref::new(4),
             name: "tag4".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -196,6 +218,8 @@ async fn get_tags() -> Result<()> {
             id: Ref::new(1),
             name: "tag1".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -205,6 +229,8 @@ async fn get_tags() -> Result<()> {
             id: Ref::new(2),
             name: "tag2".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -214,6 +240,8 @@ async fn get_tags() -> Result<()> {
             id: Ref::new(3),
             name: "tag3".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -223,6 +251,8 @@ async fn get_tags() -> Result<()> {
             id: Ref::new(4),
             name: "tag4".to_string(),
             color: "red".to_string(),
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -240,6 +270,8 @@ async fn get_tags() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -257,6 +289,8 @@ async fn get_tags() -> Result<()> {
             },
             tag_id: Some(Ref::new(1)),
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -274,6 +308,8 @@ async fn get_tags() -> Result<()> {
             },
             tag_id: Some(Ref::new(2)),
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -291,6 +327,8 @@ async fn get_tags() -> Result<()> {
             },
             tag_id: Some(Ref::new(1)),
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -308,6 +346,8 @@ async fn get_tags() -> Result<()> {
             },
             tag_id: Some(Ref::new(3)),
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -325,6 +365,8 @@ async fn get_tags() -> Result<()> {
             },
             tag_id: Some(Ref::new(3)),
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?;
@@ -370,6 +412,8 @@ async fn get_alerts() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?
@@ -382,6 +426,8 @@ async fn get_alerts() -> Result<()> {
         time_frame: TimeFrame::Daily,
         trigger_action: TriggerAction::Kill,
         active: false,
+        created_at: 0,
+        updated_at: 0,
     };
     let alert12 = Alert {
         id: Ref::new(2),
@@ -390,6 +436,8 @@ async fn get_alerts() -> Result<()> {
         time_frame: TimeFrame::Daily,
         trigger_action: TriggerAction::Kill,
         active: true,
+        created_at: 0,
+        updated_at: 0,
     };
     let alert21 = Alert {
         id: Ref::new(3),
@@ -397,6 +445,8 @@ async fn get_alerts() -> Result<()> {
         target: Target::App { id: app1.clone() },
         time_frame: TimeFrame::Weekly,
         trigger_action: TriggerAction::Dim { duration: 1 },
+        created_at: 0,
+        updated_at: 0,
         active: true,
     };
     let alert31 = Alert {
@@ -408,6 +458,8 @@ async fn get_alerts() -> Result<()> {
             content: "urmam".into(),
         },
         active: false,
+        created_at: 0,
+        updated_at: 0,
     };
     let alert32 = Alert {
         id: Ref::new(5),
@@ -418,6 +470,8 @@ async fn get_alerts() -> Result<()> {
             content: "urmam".into(),
         },
         active: false,
+        created_at: 0,
+        updated_at: 0,
     };
     let alert33 = Alert {
         id: Ref::new(6),
@@ -428,6 +482,8 @@ async fn get_alerts() -> Result<()> {
             content: "urmam".into(),
         },
         active: true,
+        created_at: 0,
+        updated_at: 0,
     };
 
     let _alert11 = arrange::alert(&mut db, alert11.clone()).await?;
@@ -602,6 +658,8 @@ async fn get_app_durations() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?
@@ -620,6 +678,8 @@ async fn get_app_durations() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?
@@ -703,6 +763,8 @@ async fn get_app_durations_per_period_singular_ts_test() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?
@@ -721,6 +783,8 @@ async fn get_app_durations_per_period_singular_ts_test() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?
@@ -921,6 +985,8 @@ async fn create_alert() -> Result<()> {
                 threshold: r.threshold,
                 message: r.message,
                 events: Default::default(),
+                created_at: 0,
+                updated_at: 0,
             })
             .collect()
     }
@@ -944,6 +1010,8 @@ async fn create_alert() -> Result<()> {
             },
             tag_id: None,
             icon: None,
+            created_at: 0,
+            updated_at: 0,
         },
     )
     .await?
@@ -959,7 +1027,8 @@ async fn create_alert() -> Result<()> {
         trigger_action: TriggerAction::Kill,
         reminders: Vec::new(),
     };
-    let created1 = repo.create_alert(alert1.clone()).await?;
+    let ts = Times::default();
+    let created1 = repo.create_alert(alert1.clone(), ts.clone()).await?;
     assert_eq!(
         infused_to_alert(created1.clone()),
         create_to_alert(alert1, 1)
@@ -977,7 +1046,7 @@ async fn create_alert() -> Result<()> {
             message: "Half way there".into(),
         }],
     };
-    let created2 = repo.create_alert(alert2.clone()).await?;
+    let created2 = repo.create_alert(alert2.clone(), ts.clone()).await?;
     let created2id = Ref::new(2);
     assert_eq!(
         infused_to_alert(created2.clone()),
@@ -1015,7 +1084,7 @@ async fn create_alert() -> Result<()> {
         ],
     };
 
-    let created3 = repo.create_alert(alert3.clone()).await?;
+    let created3 = repo.create_alert(alert3.clone(), ts.clone()).await?;
     let created3id = Ref::new(3);
     assert_eq!(
         infused_to_alert(created3.clone()),

--- a/src/data/src/entities.rs
+++ b/src/data/src/entities.rs
@@ -10,9 +10,6 @@ pub use crate::table::{Color, Duration, Id, Period, Ref, Timestamp};
 pub struct App {
     /// Identified
     pub id: Ref<Self>,
-    // /// true if the app details have finalized.
-    // /// else, all fields except id, identity and initialized are empty
-    // pub initialized: bool,
     // /// only used for [UsageWriter::find_or_insert_app]
     // pub found: bool,
     /// Name
@@ -30,6 +27,13 @@ pub struct App {
     pub icon: Option<Vec<u8>>,
     /// Link to [Tag]
     pub tag_id: Option<Ref<Tag>>,
+    /// Created at
+    pub created_at: Timestamp,
+    // /// set if the app details have finalized.
+    // /// else, all fields except id, identity, created_at, updated_at and initialized_at are empty
+    // pub initialized_at: Timestamp,
+    /// Updated at
+    pub updated_at: Timestamp,
 }
 
 /// Unique identity of an [App], outside of the Database (on the FileSystem/Registry)
@@ -76,6 +80,10 @@ pub struct Tag {
     pub name: String,
     /// Color
     pub color: Color,
+    /// Created at
+    pub created_at: Timestamp,
+    /// Updated at
+    pub updated_at: Timestamp,
 }
 
 /// Non-continuous session of [App] usage
@@ -240,6 +248,10 @@ pub struct Alert {
     pub trigger_action: TriggerAction,
     /// Whether this alert is not deleted
     pub active: bool,
+    /// Created at
+    pub created_at: Timestamp,
+    /// Updated at
+    pub updated_at: Timestamp,
 }
 
 /// Notifications to send upon a certain threshold of an [Alert]'s usage_limit
@@ -255,6 +267,10 @@ pub struct Reminder {
     pub message: String,
     /// Whether this reminder is not deleted
     pub active: bool,
+    /// Created at
+    pub created_at: Timestamp,
+    /// Updated at
+    pub updated_at: Timestamp,
 }
 
 impl PartialEq<Reminder> for Reminder {

--- a/src/data/src/entities.rs
+++ b/src/data/src/entities.rs
@@ -269,6 +269,17 @@ impl PartialEq<Reminder> for Reminder {
 
 impl Eq for Reminder {}
 
+/// Reason for the [AlertEvent]/[ReminderEvent]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Type, Serialize, Deserialize)]
+#[repr(i64)]
+pub enum Reason {
+    #[default]
+    /// The [Alert]/[Reminder] was triggered
+    Hit,
+    /// The [Alert]/[Reminder] was ignored
+    Ignored,
+}
+
 /// An instance of [Alert] triggering.
 #[derive(Default, Debug, Clone, PartialEq, Eq, FromRow, Serialize)]
 pub struct AlertEvent {
@@ -278,6 +289,8 @@ pub struct AlertEvent {
     pub alert_id: Ref<Alert>,
     /// Timestamp of the [Alert] trigger
     pub timestamp: Timestamp,
+    /// Reason for the [AlertEvent]
+    pub reason: Reason,
 }
 
 /// An instance of [Reminder] triggering.
@@ -289,6 +302,8 @@ pub struct ReminderEvent {
     pub reminder_id: Ref<Reminder>,
     /// Timestamp of the [Reminder] trigger
     pub timestamp: Timestamp,
+    /// Reason for the [ReminderEvent]
+    pub reason: Reason,
 }
 
 macro_rules! table {

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -122,7 +122,8 @@ impl Migration for Migration1 {
             "CREATE TABLE alert_events (
                 id                              INTEGER PRIMARY KEY NOT NULL,
                 alert_id                        INTEGER NOT NULL REFERENCES alerts(id) ON DELETE CASCADE,
-                timestamp                       INTEGER NOT NULL
+                timestamp                       INTEGER NOT NULL,
+                reason                          INTEGER NOT NULL
             )",
         )
         .await
@@ -132,7 +133,8 @@ impl Migration for Migration1 {
             "CREATE TABLE reminder_events (
                 id                              INTEGER PRIMARY KEY NOT NULL,
                 reminder_id                     INTEGER NOT NULL REFERENCES reminders(id) ON DELETE CASCADE,
-                timestamp                       INTEGER NOT NULL
+                timestamp                       INTEGER NOT NULL,
+                reason                          INTEGER NOT NULL
             )",
         )
         .await

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -21,7 +21,9 @@ impl Migration for Migration1 {
             "CREATE TABLE tags (
                 id                              INTEGER PRIMARY KEY NOT NULL,
                 name                            TEXT NOT NULL,
-                color                           TEXT NOT NULL
+                color                           TEXT NOT NULL,
+                created_at                      INTEGER NOT NULL,
+                updated_at                      INTEGER NOT NULL
             )",
         )
         .await
@@ -31,7 +33,6 @@ impl Migration for Migration1 {
         tx.execute(
             "CREATE TABLE apps (
                 id                              INTEGER PRIMARY KEY NOT NULL,
-                initialized                     TINYINT NOT NULL DEFAULT FALSE,
                 found                           TINYINT NOT NULL DEFAULT FALSE,
                 name                            TEXT,
                 description                     TEXT,
@@ -40,7 +41,10 @@ impl Migration for Migration1 {
                 tag_id                          INTEGER REFERENCES tags(id) ON DELETE SET NULL,
                 identity_is_win32               INTEGER NOT NULL,
                 identity_path_or_aumid          TEXT NOT NULL,
-                icon                            BLOB
+                icon                            BLOB,
+                created_at                      INTEGER NOT NULL,
+                initialized_at                  INTEGER NOT NULL,
+                updated_at                      INTEGER NOT NULL
             )",
         )
         .await
@@ -100,7 +104,9 @@ impl Migration for Migration1 {
                 trigger_action_dim_duration     INTEGER,
                 trigger_action_message_content  TEXT,
                 trigger_action_tag              INTEGER NOT NULL,
-                active                          TINYINT NOT NULL DEFAULT TRUE
+                active                          TINYINT NOT NULL DEFAULT TRUE,
+                created_at                      INTEGER NOT NULL,
+                updated_at                      INTEGER NOT NULL
             )",
         )
         .await
@@ -112,7 +118,9 @@ impl Migration for Migration1 {
                 alert_id                        INTEGER NOT NULL REFERENCES alerts(id) ON DELETE CASCADE,
                 threshold                       REAL NOT NULL,
                 message                         TEXT NOT NULL,
-                active                          TINYINT NOT NULL DEFAULT TRUE
+                active                          TINYINT NOT NULL DEFAULT TRUE,
+                created_at                      INTEGER NOT NULL,
+                updated_at                      INTEGER NOT NULL
             )",
         )
         .await

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -43,7 +43,7 @@ impl Migration for Migration1 {
                 identity_path_or_aumid          TEXT NOT NULL,
                 icon                            BLOB,
                 created_at                      INTEGER NOT NULL,
-                initialized_at                  INTEGER NOT NULL,
+                initialized_at                  INTEGER,
                 updated_at                      INTEGER NOT NULL
             )",
         )

--- a/src/data/src/queries/triggered_reminders.sql
+++ b/src/data/src/queries/triggered_reminders.sql
@@ -35,7 +35,7 @@ SELECT r.*, (CASE WHEN al.app_id IS NOT NULL THEN (
     SELECT a.name FROM apps a WHERE a.id = al.app_id
 ) ELSE (
     SELECT t.name FROM tags t WHERE t.id = al.tag_id
-) END) name
+) END) name, al.usage_limit AS usage_limit
     FROM alerts al
     INNER JOIN dur d
         ON al.id = d.alert_id

--- a/src/data/src/queries/triggered_reminders.sql
+++ b/src/data/src/queries/triggered_reminders.sql
@@ -44,7 +44,9 @@ SELECT r.*, (CASE WHEN al.app_id IS NOT NULL THEN (
         AND d.dur >= al.usage_limit * r.threshold
     WHERE d.range_start >
         (SELECT COALESCE(MAX(re.timestamp), 0) FROM reminder_events re
-            WHERE r.id = re.reminder_id
-            )
+            WHERE r.id = re.reminder_id) AND
+        d.range_start >
+        (SELECT COALESCE(MAX(ae.timestamp), 0) FROM alert_events ae
+            WHERE al.id = ae.alert_id)
     GROUP BY r.id
     HAVING al.active <> 0 AND r.active <> 0

--- a/src/engine/src/cache.rs
+++ b/src/engine/src/cache.rs
@@ -161,7 +161,7 @@ impl Cache {
 async fn inner_mut_compiles() {
     use scoped_futures::ScopedFutureExt;
 
-    let window: Window = Window::foreground().unwrap();
+    let window: Window = Window::foreground().unwrap_or_else(Window::desktop);
     let process: ProcessId = 1;
     let mut cache = Cache::new();
 

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -64,7 +64,7 @@ impl Engine {
 
         ret.current_usage = Usage {
             id: Default::default(),
-            session_id: ret.get_session_details(foreground, start.clone()).await?,
+            session_id: ret.get_session_details(foreground, start).await?,
             start: start.to_ticks(),
             end: start.to_ticks(),
         };
@@ -105,7 +105,7 @@ impl Engine {
                 let foreground = foreground_window_session()?;
                 self.current_usage = Usage {
                     id: Default::default(),
-                    session_id: self.get_session_details(foreground, now.clone()).await?,
+                    session_id: self.get_session_details(foreground, *now).await?,
                     start: now.to_ticks(),
                     end: now.to_ticks(),
                 };
@@ -136,7 +136,7 @@ impl Engine {
                     .insert_or_update_usage(&mut self.current_usage)
                     .await?;
 
-                let session_result = self.get_session_details(session, at.clone()).await;
+                let session_result = self.get_session_details(session, at).await;
 
                 // If we have an error getting the session, we don't change the current usage.
                 // An alternative would be to insert some sort of 'invalid usage' marker.

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -258,6 +258,6 @@ async fn update_app_infos(db_pool: DatabasePool, handle: Handle) -> Result<()> {
 
 /// Get the foreground [Window], and makes it into a [WindowSession] blocking until one is present.
 fn foreground_window_session() -> Result<WindowSession> {
-    let window = Window::foreground().unwrap_or_else(|| Window::desktop());
+    let window = Window::foreground().unwrap_or_else(Window::desktop);
     WindowSession::new(window)
 }

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -168,8 +168,8 @@ async fn sentry_loop(
 /// Runs the [Engine] and [Sentry] loops in an asynchronous executor.
 fn processor(
     config: &Config,
-    fg: WindowSession,
-    now: Timestamp,
+    mut fg: WindowSession,
+    mut now: Timestamp,
     event_rx: Receiver<Event>,
     alert_rx: Receiver<Timestamp>,
 ) -> Result<()> {
@@ -211,6 +211,8 @@ fn processor(
         for attempt in 0.. {
             if attempt > 0 {
                 info!("restarting engine loop");
+                fg = foreground_window_session()?;
+                now = Timestamp::now();
             }
             engine_loop(
                 db_pool.clone(),

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -258,9 +258,6 @@ async fn update_app_infos(db_pool: DatabasePool, handle: Handle) -> Result<()> {
 
 /// Get the foreground [Window], and makes it into a [WindowSession] blocking until one is present.
 fn foreground_window_session() -> Result<WindowSession> {
-    loop {
-        if let Some(window) = Window::foreground() {
-            return WindowSession::new(window);
-        }
-    }
+    let window = Window::foreground().unwrap_or_else(|| Window::desktop());
+    WindowSession::new(window)
 }

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -25,7 +25,6 @@ impl AppInfoResolver {
         identity: AppIdentity,
     ) -> Result<()> {
         info!("updating app info {:?} ({:?})", app, identity);
-
         let app_info = Self::resolve(&identity).await?;
 
         let db = db_pool.get_db().await?;
@@ -40,8 +39,10 @@ impl AppInfoResolver {
             identity,
             tag_id: None,
             icon: app_info.logo,
+            ..Default::default()
         };
-        updater.update_app(&app).await?;
+        let now = platform::objects::Timestamp::now();
+        updater.update_app(&app, now).await?;
         Ok(())
     }
 

--- a/src/engine/src/sentry.rs
+++ b/src/engine/src/sentry.rs
@@ -157,7 +157,7 @@ impl Sentry {
 
     /// Message the user with the given [TriggeredAlert]'s name and message.
     pub fn handle_message_action(&self, name: &str, msg: &str) -> Result<()> {
-        ToastManager::show_basic(name, msg)?;
+        ToastManager::show_alert(&format!("Alert: {}", name), msg)?;
         Ok(())
     }
 
@@ -169,13 +169,13 @@ impl Sentry {
 
     /// Message the user with the given [TriggeredReminder]'s name and message and progress.
     pub fn handle_reminder_message(&self, name: &str, msg: &str, value: f64) -> Result<()> {
-        ToastManager::show_with_progress(
-            name,
+        ToastManager::show_reminder(
+            &format!("Reminder: {}", name),
             msg,
             Progress {
-                title: String::new(),
+                title: None,
                 value,
-                value_string_override: "".to_string(),
+                value_string_override: None,
                 //status: "1h/1h 40m".to_string(),
                 status: "".to_string(),
             },

--- a/src/engine/src/sentry.rs
+++ b/src/engine/src/sentry.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use data::db::{AlertManager, Database, TriggeredAlert};
-use data::entities::{AlertEvent, ReminderEvent, Target, Timestamp, TriggerAction};
+use data::entities::{AlertEvent, Reason, ReminderEvent, Target, Timestamp, TriggerAction};
 use platform::objects::{
     Process, ProcessId, Progress, Timestamp as PlatformTimestamp, ToastManager, Window,
 };
@@ -52,6 +52,7 @@ impl Sentry {
                     id: Default::default(),
                     reminder_id: triggered_reminder.reminder.id.clone(),
                     timestamp: now.to_ticks(),
+                    reason: Reason::Hit,
                 })
                 .await?;
         }
@@ -141,6 +142,7 @@ impl Sentry {
                     id: Default::default(),
                     alert_id: alert.id.clone(),
                     timestamp: now.to_ticks(),
+                    reason: Reason::Hit,
                 })
                 .await?;
         }

--- a/src/platform/src/events/foreground.rs
+++ b/src/platform/src/events/foreground.rs
@@ -40,15 +40,13 @@ impl ForegroundEventWatcher {
 
     /// Poll for a new [`ForegroundChangedEvent`].
     pub fn poll(&mut self, at: Timestamp) -> Result<Option<ForegroundChangedEvent>> {
-        if let Some(fg) = Window::foreground() {
-            let session = WindowSession::new(fg).context("foreground window session")?;
-            if session == self.session {
-                return Ok(None);
-            }
-
+        let window = Window::foreground().unwrap_or_else(|| Window::desktop());
+        let session = WindowSession::new(window).context("foreground window session")?;
+        if session == self.session {
+            Ok(None)
+        } else {
             self.session = session.clone();
-            return Ok(Some(ForegroundChangedEvent { at, session }));
+            Ok(Some(ForegroundChangedEvent { at, session }))
         }
-        Ok(None)
     }
 }

--- a/src/platform/src/events/foreground.rs
+++ b/src/platform/src/events/foreground.rs
@@ -40,7 +40,7 @@ impl ForegroundEventWatcher {
 
     /// Poll for a new [`ForegroundChangedEvent`].
     pub fn poll(&mut self, at: Timestamp) -> Result<Option<ForegroundChangedEvent>> {
-        let window = Window::foreground().unwrap_or_else(|| Window::desktop());
+        let window = Window::foreground().unwrap_or_else(Window::desktop);
         let session = WindowSession::new(window).context("foreground window session")?;
         if session == self.session {
             Ok(None)

--- a/src/platform/src/objects/timestamp.rs
+++ b/src/platform/src/objects/timestamp.rs
@@ -239,6 +239,11 @@ impl Duration {
         Duration(millis * 10_000)
     }
 
+    /// Create a [`Duration`] from ticks
+    pub const fn from_ticks(ticks: i64) -> Duration {
+        Duration(ticks)
+    }
+
     /// Get the number of milliseconds in the [`Duration`]
     pub fn millis(&self) -> u32 {
         (self.0 / 10_000) as u32

--- a/src/platform/src/objects/toast.rs
+++ b/src/platform/src/objects/toast.rs
@@ -9,11 +9,11 @@ use windows::UI::Notifications::{ToastNotification, ToastNotificationManager};
 /// for Toast notifications.
 pub struct Progress {
     /// Title
-    pub title: String,
+    pub title: Option<String>,
     /// Progress value
     pub value: f64,
     /// Progress value text
-    pub value_string_override: String,
+    pub value_string_override: Option<String>,
     /// Status
     pub status: String,
 }
@@ -37,20 +37,23 @@ impl ToastManager {
     appLogoOverlay.SetAttribute(&"placement".into(), &"appLogoOverride".into())?;
     toastVisualElements.GetAt(0)?.AppendChild(&appLogoOverlay)?;*/
 
-    /// Show a basic toast notification with title and text.
-    pub fn show_basic(title: &str, message: &str) -> Result<()> {
+    /// Show a basic toast notification with title and text with an alarm scenario.
+    pub fn show_alert(title: &str, message: &str) -> Result<()> {
         let mgr = ToastNotificationManager::CreateToastNotifierWithId(&AUMID.into())?;
 
         let content = XmlDocument::new()?;
         content.LoadXml(
             &r#"
-            <toast activationType="protocol">
+            <toast activationType="protocol" scenario="alarm">
                 <visual>
                     <binding template="ToastGeneric">
                         <text id='1'></text>
                         <text id='2'></text>
                     </binding>
                 </visual>
+                <actions>
+                    <action content='Dismiss' arguments='action=dismiss'/>
+                </actions>
             </toast>"#
                 .into(),
         )?;
@@ -68,7 +71,7 @@ impl ToastManager {
     }
 
     /// Show a basic toast notification with title, text and a progress bar.
-    pub fn show_with_progress(title: &str, message: &str, progress: Progress) -> Result<()> {
+    pub fn show_reminder(title: &str, message: &str, progress: Progress) -> Result<()> {
         let mgr = ToastNotificationManager::CreateToastNotifierWithId(&AUMID.into())?;
 
         let content = XmlDocument::new()?;
@@ -95,13 +98,15 @@ impl ToastManager {
         let progress_xml = content
             .SelectSingleNode(&"//progress[@id='3']".into())?
             .cast::<XmlElement>()?;
-        progress_xml.SetAttribute(&"title".into(), &progress.title.into())?;
+        if let Some(title) = progress.title {
+            progress_xml.SetAttribute(&"title".into(), &title.into())?;
+        }
         progress_xml.SetAttribute(&"value".into(), &progress.value.to_string().into())?;
         progress_xml.SetAttribute(&"status".into(), &progress.status.into())?;
-        progress_xml.SetAttribute(
-            &"valueStringOverride".into(),
-            &progress.value_string_override.into(),
-        )?;
+        if let Some(value_string_override) = progress.value_string_override {
+            progress_xml
+                .SetAttribute(&"valueStringOverride".into(), &value_string_override.into())?;
+        }
 
         let toast = ToastNotification::CreateToastNotification(&content)?;
         mgr.Show(&toast)?;

--- a/src/platform/src/objects/toast.rs
+++ b/src/platform/src/objects/toast.rs
@@ -18,7 +18,7 @@ pub struct Progress {
     pub status: String,
 }
 
-const AUMID: &str = "Cobalt";
+const AUMID: &str = "me.enigmatrix.cobalt";
 
 /// Toast notification manager using the WinRT APIs.
 pub struct ToastManager;

--- a/src/platform/src/objects/window.rs
+++ b/src/platform/src/objects/window.rs
@@ -7,8 +7,9 @@ use windows::Win32::System::Com::CoTaskMemFree;
 use windows::Win32::System::Com::StructuredStorage::PropVariantToStringAlloc;
 use windows::Win32::UI::Shell::PropertiesSystem::{IPropertyStore, SHGetPropertyStoreForWindow};
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
-    SetLayeredWindowAttributes, SetWindowLongW, GWL_EXSTYLE, LWA_ALPHA, WS_EX_LAYERED,
+    GetDesktopWindow, GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW,
+    GetWindowThreadProcessId, SetLayeredWindowAttributes, SetWindowLongW, GWL_EXSTYLE, LWA_ALPHA,
+    WS_EX_LAYERED,
 };
 
 use crate::buf::{buf, Buffer, WideBuffer};
@@ -56,6 +57,12 @@ impl Window {
         } else {
             Some(Self::new(fg))
         }
+    }
+
+    /// Get the Desktop [Window]
+    pub fn desktop() -> Self {
+        let hwnd = unsafe { GetDesktopWindow() };
+        Self::new(hwnd)
     }
 
     /// Get the [ProcessId] of the [Window]

--- a/src/ui/app/lib/repo.ts
+++ b/src/ui/app/lib/repo.ts
@@ -18,7 +18,7 @@ import type {
 } from "@/lib/entities";
 import { invoke } from "@tauri-apps/api/core";
 import type { EntityMap, EntityStore } from "@/lib/state";
-import type { DateTime } from "luxon";
+import { DateTime } from "luxon";
 import { dateTimeToTicks } from "@/lib/time";
 
 export interface CreateTag {
@@ -203,6 +203,13 @@ export async function updateAlert(
 
 export async function removeAlert(alertId: Ref<Alert>): Promise<void> {
   return await invoke("remove_alert", { alertId });
+}
+
+export async function createAlertEventIgnore(
+  alertId: Ref<Alert>,
+): Promise<void> {
+  const timestamp = dateTimeToTicks(DateTime.now());
+  return await invoke("create_alert_event_ignore", { alertId, timestamp });
 }
 
 export async function getAppSessionUsages({

--- a/src/ui/src-tauri/src/lib.rs
+++ b/src/ui/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
             repo::create_alert,
             repo::update_alert,
             repo::remove_alert,
+            repo::create_alert_event_ignore,
             repo::get_app_session_usages,
             repo::get_interaction_periods,
             repo::get_system_events,

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -257,6 +257,20 @@ pub async fn remove_alert(state: State<'_, AppState>, alert_id: Ref<Alert>) -> A
 
 #[tauri::command]
 #[tracing::instrument(err, skip(state))]
+pub async fn create_alert_event_ignore(
+    state: State<'_, AppState>,
+    alert_id: Ref<Alert>,
+    timestamp: Timestamp,
+) -> AppResult<()> {
+    let mut repo = {
+        let mut state = state.write().await;
+        state.assume_init_mut().get_repo().await?
+    };
+    Ok(repo.create_alert_event_ignore(alert_id, timestamp).await?)
+}
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
 pub async fn get_app_session_usages(
     state: State<'_, AppState>,
     start: Timestamp,

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -159,22 +159,24 @@ pub async fn update_usages_end(state: State<'_, AppState>) -> AppResult<()> {
 #[tauri::command]
 #[tracing::instrument(err, skip(state))]
 pub async fn update_app(state: State<'_, AppState>, app: infused::UpdatedApp) -> AppResult<()> {
+    let now = platform::objects::Timestamp::now();
     let mut repo = {
         let mut state = state.write().await;
         state.assume_init_mut().get_repo().await?
     };
-    repo.update_app(&app).await?;
+    repo.update_app(&app, now).await?;
     Ok(())
 }
 
 #[tauri::command]
 #[tracing::instrument(err, skip(state))]
 pub async fn update_tag(state: State<'_, AppState>, tag: infused::UpdatedTag) -> AppResult<()> {
+    let now = platform::objects::Timestamp::now();
     let mut repo = {
         let mut state = state.write().await;
         state.assume_init_mut().get_repo().await?
     };
-    repo.update_tag(&tag).await?;
+    repo.update_tag(&tag, now).await?;
     Ok(())
 }
 
@@ -186,11 +188,12 @@ pub async fn update_tag_apps(
     removed_apps: Vec<Ref<App>>,
     added_apps: Vec<Ref<App>>,
 ) -> AppResult<()> {
+    let now = platform::objects::Timestamp::now();
     let mut repo = {
         let mut state = state.write().await;
         state.assume_init_mut().get_repo().await?
     };
-    repo.update_tag_apps(tag_id, removed_apps, added_apps)
+    repo.update_tag_apps(tag_id, removed_apps, added_apps, now)
         .await?;
     Ok(())
 }
@@ -201,11 +204,12 @@ pub async fn create_tag(
     state: State<'_, AppState>,
     tag: infused::CreateTag,
 ) -> AppResult<infused::Tag> {
+    let now = platform::objects::Timestamp::now();
     let mut repo = {
         let mut state = state.write().await;
         state.assume_init_mut().get_repo().await?
     };
-    Ok(repo.create_tag(&tag).await?)
+    Ok(repo.create_tag(&tag, now).await?)
 }
 
 #[tauri::command]
@@ -224,11 +228,12 @@ pub async fn create_alert(
     state: State<'_, AppState>,
     alert: infused::CreateAlert,
 ) -> AppResult<infused::Alert> {
+    let now = platform::objects::Timestamp::now();
     let mut repo = {
         let mut state = state.write().await;
         state.assume_init_mut().get_repo().await?
     };
-    Ok(repo.create_alert(alert).await?)
+    Ok(repo.create_alert(alert, now).await?)
 }
 
 #[tauri::command]
@@ -238,11 +243,12 @@ pub async fn update_alert(
     prev: infused::Alert,
     next: infused::UpdatedAlert,
 ) -> AppResult<infused::Alert> {
+    let now = platform::objects::Timestamp::now();
     let mut repo = {
         let mut state = state.write().await;
         state.assume_init_mut().get_repo().await?
     };
-    Ok(repo.update_alert(prev, next).await?)
+    Ok(repo.update_alert(prev, next, now).await?)
 }
 
 #[tauri::command]

--- a/src/util/src/time.rs
+++ b/src/util/src/time.rs
@@ -17,3 +17,38 @@ pub trait TimeSystem {
     /// Get the start of the month
     fn month_start(&self, local_tz: bool) -> Self::Ticks;
 }
+
+const UNITS: [(&str, u128); 6] = [
+    ("d", 86400000000),
+    ("h", 3600000000),
+    ("m", 60000000),
+    ("s", 1000000),
+    ("ms", 1000),
+    ("μs", 1),
+];
+
+/// Format a duration as a human readable string.
+pub fn human_duration(d: std::time::Duration) -> String {
+    let mut map: Vec<(u128, &str)> = Vec::new();
+    let mut μs = d.as_micros();
+    for (unit, n_μs) in UNITS {
+        map.push((μs / n_μs, unit));
+        μs %= n_μs;
+    }
+
+    match map
+        .into_iter()
+        .filter_map(|(n, u)| {
+            if n > 0 {
+                Some(format!("{}{}", n, u))
+            } else {
+                None
+            }
+        })
+        .take(2)
+        .reduce(|acc, item| format!("{} {}", acc, item))
+    {
+        Some(val) => val,
+        None => "-".to_string(),
+    }
+}


### PR DESCRIPTION
### TL;DR

Added timestamps to database entities and improved event tracking with reason field.

### What changed?

- Added `created_at`, `updated_at`, and `initialized_at` timestamps to database entities (apps, tags, alerts, reminders)
- Replaced the boolean `initialized` flag with an `initialized_at` timestamp in the apps table
- Added a `reason` field to alert and reminder events to distinguish between different event types (Hit/Ignored)
- Updated database schema in ARCHITECTURE.md to reflect these changes
- Enhanced toast notifications with better formatting and progress indicators
- Added fallback to desktop window when foreground window can't be determined
- Improved time formatting with human-readable durations
- Added functionality to ignore alerts via a new API endpoint

### Why make this change?

These changes improve data tracking by adding timestamps to all entities, making it easier to analyze usage patterns over time. The addition of reason codes for events provides more context about why alerts and reminders were triggered or ignored. The UI improvements for notifications make them more informative and user-friendly. The desktop window fallback ensures the application continues to function even when it can't determine the foreground window.