### PR TITLE
Usage Pie Chart

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.19.0",
         "vite": "^5.4.11",
+        "vite-plugin-devtools-json": "^0.1.0",
         "vite-tsconfig-paths": "^5.1.4",
       },
     },
@@ -1331,6 +1332,8 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
     "valibot": ["valibot@0.41.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
@@ -1344,6 +1347,8 @@
     "vite": ["vite@5.4.11", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q=="],
 
     "vite-node": ["vite-node@3.0.0-beta.2", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.0", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0 || ^6.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg=="],
+
+    "vite-plugin-devtools-json": ["vite-plugin-devtools-json@0.1.0", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" } }, "sha512-KvdgPBUAAhwnpOgXmJhs6KI4/IPn6xUppLGm20D0Uvp/doZ9TpTYYfzSHX0TgvdsSlTAwzZfzDse+ujGskp68g=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 

--- a/src/ui/app/components/viz/app-usage-chart-tooltip.tsx
+++ b/src/ui/app/components/viz/app-usage-chart-tooltip.tsx
@@ -19,14 +19,19 @@ function HoverCard({
   app: App;
   usageTicks: number;
   totalUsageTicks?: number;
-  at: DateTime;
+  at: DateTime | undefined;
 }) {
   return (
     <div className="flex items-center gap-2 py-2">
       <AppIcon buffer={app.icon} className="w-6 h-6 shrink-0 ml-2 mr-1" />
       <div className="flex flex-col">
         <Text className="text-base max-w-52">{app.name}</Text>
-        <DateTimeText className="text-xs text-muted-foreground" datetime={at} />
+        {at && (
+          <DateTimeText
+            className="text-xs text-muted-foreground"
+            datetime={at}
+          />
+        )}
       </div>
 
       <div className="flex-1"></div>
@@ -47,7 +52,7 @@ export const AppUsageChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
     payload: EntityMap<App, number>;
-    dt: DateTime;
+    dt?: DateTime;
     hideIndicator?: boolean;
     maximumApps?: number;
     hoveredAppId: Ref<App> | null;

--- a/src/ui/app/components/viz/app-usage-pie.tsx
+++ b/src/ui/app/components/viz/app-usage-pie.tsx
@@ -1,0 +1,317 @@
+import type { App, Tag, Ref, WithDuration } from "@/lib/entities";
+import { untagged, useAppState, type EntityMap } from "@/lib/state";
+import type { ClassValue } from "clsx";
+import { useTheme } from "@/components/theme-provider";
+import { useApps, useRefresh, useTags } from "@/hooks/use-refresh";
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as echarts from "echarts";
+import _ from "lodash";
+import { Tooltip } from "@/components/viz/tooltip";
+import { AppUsageChartTooltipContent } from "./app-usage-chart-tooltip";
+import { DateTime } from "luxon";
+import { cn } from "@/lib/utils";
+import { DEFAULT_ICON_SVG_URL } from "../app/app-icon";
+import { toDataUrl } from "../app/app-icon";
+
+interface GlobalModel {
+  getSeriesByIndex: (index: number) => echarts.SeriesModel;
+}
+
+interface RadiusAxis {
+  dataToRadius: (data: number) => number;
+  polar: PolarAxis;
+}
+
+interface PolarAxis {
+  getAngleAxis: () => AngleAxis;
+}
+
+interface AngleAxis {
+  dataToAngle: (data: number) => number;
+}
+export interface AppUsagePieChartProps {
+  data: EntityMap<App, WithDuration<App>>;
+  // apps to highlight, order them by index in array. will be drawn left to right = top to bottom. unhighlighted apps will be drawn on top of highlighted apps.
+  highlightedAppIds?: Ref<App>[];
+  unhighlightedAppOpacity?: number;
+  hideApps?: Record<Ref<App>, boolean>;
+  animationsEnabled?: boolean;
+
+  className?: ClassValue;
+  onHover?: (data?: WithDuration<App>) => void;
+  onTagHover?: (data?: Tag) => void;
+}
+
+export function AppUsagePieChart({
+  data,
+  highlightedAppIds,
+  unhighlightedAppOpacity = 0.3,
+  hideApps,
+  animationsEnabled = true,
+  className,
+  onHover,
+}: AppUsagePieChartProps) {
+  const { theme } = useTheme();
+
+  const [hoverSeries, setHoverSeries] = useState<EntityMap<App, number>>({});
+  const [hoveredData, setHoveredData] = useState<{
+    date: DateTime;
+    appId?: Ref<App>;
+  } | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstanceRef = useRef<echarts.ECharts | null>(null);
+
+  const appIds = useMemo(
+    () => Object.keys(data).map((id) => +id as Ref<App>),
+    [data],
+  );
+  const apps = useApps(appIds);
+  const tags = useTags();
+
+  const totalUsage = useMemo(() => {
+    return _(apps)
+      .filter((app) => !hideApps?.[app.id])
+      .reduce((sum, app) => sum + (data[app.id]?.duration ?? 0), 0);
+  }, [apps, data, hideApps]);
+
+  const payload = useMemo(() => {
+    return _.mapValues(data, (duration) => duration?.duration ?? 0);
+  }, [data]);
+
+  const tagPayload = useMemo(() => {
+    return _(apps)
+      .map((app) => [app.tagId ?? -1, data[app.id]?.duration ?? 0])
+      .groupBy(0)
+      .mapValues((x) => x.reduce((sum, [, duration]) => sum + duration, 0))
+      .value();
+  }, [apps, data]);
+
+  const appData = useMemo(() => {
+    return _(apps)
+      .filter((app) => !hideApps?.[app.id])
+      .map((app) => ({
+        ...app,
+        duration: data[app.id]?.duration ?? 0,
+      }))
+      .filter((app) => app.duration > 0)
+      .orderBy(["tagId", "duration"], ["asc", "desc"])
+      .value();
+  }, [apps, data, hideApps]);
+
+  const tagData = useMemo(() => {
+    // Get all tagged apps
+    const taggedAppIds = new Set(tags.flatMap((tag) => tag.apps));
+
+    // Calculate untagged duration
+    const untaggedDuration = apps
+      .filter((app) => !taggedAppIds.has(app.id) && !hideApps?.[app.id])
+      .reduce((sum, app) => sum + (data[app.id]?.duration ?? 0), 0);
+
+    // Create tag data including untagged
+    const tagData = [
+      // Tags
+      ...tags.map((tag) => ({
+        ...tag,
+        duration: _(tag.apps)
+          .map((appId) => data[appId]?.duration ?? 0)
+          .sum(),
+      })),
+      // Add untagged category if there are untagged apps
+      ...(untaggedDuration > 0
+        ? [
+            {
+              ...untagged,
+              duration: untaggedDuration,
+            },
+          ]
+        : []),
+    ].filter((tag) => tag.duration > 0);
+
+    return tagData;
+  }, [tags, apps, data, hideApps]);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    const chart = echarts.init(chartRef.current, undefined, {});
+    chartInstanceRef.current = chart;
+
+    const tagSeries = tagData
+      .filter((tag) => tag.duration)
+      .map(
+        (tag) =>
+          ({
+            type: "bar",
+            coordinateSystem: "polar",
+            stack: "tags",
+            data: [
+              {
+                id: tag.id,
+                name: tag.name,
+                value: tag.duration,
+                itemStyle: {
+                  color: tag.color,
+                },
+              },
+            ],
+          }) satisfies echarts.SeriesOption,
+      );
+
+    const appSeries = appData
+      .filter((app) => app.duration)
+      .map(
+        (app) =>
+          ({
+            type: "bar",
+            coordinateSystem: "polar",
+            stack: "apps",
+            labelLayout(params) {
+              const model = (chart["getModel"] as () => GlobalModel)();
+              const series = model.getSeriesByIndex(params.seriesIndex);
+              const radiusAxis = series.getBaseAxis() as unknown as RadiusAxis;
+              const value = series.getRawValue(params.dataIndex!);
+              const radius = radiusAxis.dataToRadius(value as number);
+              const angleAxis = radiusAxis.polar.getAngleAxis();
+              const angle =
+                angleAxis.dataToAngle(0) -
+                angleAxis.dataToAngle(value as number);
+
+              // const radiusDiff = outerRadius - innerRadius;
+              const radiusDiff = 0.35 * radius; // TODO use a better way
+
+              const percent = angle;
+
+              const angleLengthValue = (percent / 360) * 2 * Math.PI * radius;
+              const maxSize =
+                Math.min(radiusDiff, angleLengthValue) * Math.SQRT1_2;
+              const size = Math.max(Math.min(maxSize * 0.9, 32), 0); // 10% padding
+
+              console.log(
+                value,
+                radius,
+                angle,
+                angleLengthValue,
+                size,
+                radiusAxis,
+                angleAxis,
+                series,
+              );
+              return {
+                width: size,
+                height: size,
+              };
+            },
+            data: [
+              {
+                id: app.id,
+                name: app.name,
+                value: app.duration,
+                itemStyle: {
+                  color: app.color,
+                },
+                label: {
+                  show: true,
+                  rotate: 0,
+                  position: "middle",
+                  backgroundColor: {
+                    image: toDataUrl(app.icon) ?? DEFAULT_ICON_SVG_URL,
+                  },
+                  formatter: () => {
+                    return `{empty|}`;
+                  },
+                  rich: {
+                    empty: {},
+                  },
+                },
+              },
+            ],
+          }) satisfies echarts.SeriesOption,
+      );
+
+    const option: echarts.EChartsOption = {
+      animation: animationsEnabled,
+      // animationDuration: 300,
+
+      angleAxis: {
+        max: "dataMax",
+        show: false,
+      },
+      polar: {
+        radius: ["30%", "90%"],
+      },
+      radiusAxis: {
+        type: "category",
+        data: ["tags"],
+        show: false,
+      },
+      tooltip: {
+        trigger: "item",
+      },
+      series: [...tagSeries, ...appSeries],
+    } satisfies echarts.EChartsOption;
+
+    // chart.getZr().on("mousemove", (params) => {
+    //   const pos = [params.offsetX, params.offsetY];
+    //   const isInGrid = chart.containPixel("grid", pos);
+    //   if (isInGrid) {
+    //     const pointerData = chart.convertFromPixel("grid", pos);
+    //     setHoveredData({
+    //       date: ticksToDateTime(xaxisRange[pointerData[0]]),
+    //     });
+    //   } else if (!isInGrid) {
+    //     setHoveredData(null);
+    //     onHover?.(undefined);
+    //   }
+    // });
+
+    // chart.on("mousemove", (params) => {
+    //   const appId = +(params.seriesId ?? 0) as Ref<App>;
+    //   setHoveredData({ date: ticksToDateTime(+params.name), appId });
+    //   if (onHover) {
+    //     onHover({
+    //       id: appId,
+    //       duration: params.value as number,
+    //       group: params.axisValue as number,
+    //     });
+    //   }
+    // });
+
+    const resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(() => chart.resize());
+    });
+
+    chart.on("finished", () => {
+      resizeObserver.observe(chartRef.current!);
+    });
+
+    chart.setOption(option);
+
+    return () => {
+      chart.dispose();
+      resizeObserver.disconnect();
+    };
+  }, [
+    data,
+    appData,
+    tagData,
+    onHover,
+    animationsEnabled,
+    highlightedAppIds,
+    unhighlightedAppOpacity,
+    theme,
+  ]);
+
+  return (
+    <div ref={chartRef} className={cn("w-full h-full", className)}>
+      <Tooltip targetRef={chartRef} show={!!hoveredData}>
+        <AppUsageChartTooltipContent
+          hoveredAppId={hoveredData?.appId ?? null}
+          payload={hoverSeries}
+          dt={hoveredData?.date ?? DateTime.fromSeconds(0)}
+          maximumApps={10}
+          highlightedAppIds={highlightedAppIds}
+        />
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/ui/app/components/viz/tag-usage-chart-tooltip.tsx
+++ b/src/ui/app/components/viz/tag-usage-chart-tooltip.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import _ from "lodash";
 import type { Ref, Tag } from "@/lib/entities";
-import { type EntityMap } from "@/lib/state";
+import { untagged, type EntityMap } from "@/lib/state";
 import { DateTime } from "luxon";
 import { DurationText } from "@/components/time/duration-text";
 import { DateTimeText } from "@/components/time/time-text";
@@ -88,7 +88,14 @@ export const TagUsageChartTooltipContent = React.forwardRef<
       () => (singleTagId ? undefined : _(payload).values().sum()),
       [singleTagId, payload],
     );
-    const involvedTags = useTags(involvedTagIds);
+    const involvedTagsWithoutUntagged = useTags(involvedTagIds);
+    const involvedTags = useMemo(
+      () => [
+        ...involvedTagsWithoutUntagged,
+        ...(payload[untagged.id] ? [untagged] : []),
+      ],
+      [involvedTagsWithoutUntagged, payload],
+    );
     const involvedTagSorted = useMemo(
       () =>
         _(involvedTags)

--- a/src/ui/app/components/viz/tag-usage-chart-tooltip.tsx
+++ b/src/ui/app/components/viz/tag-usage-chart-tooltip.tsx
@@ -20,7 +20,7 @@ function HoverCard({
   tag: Tag;
   usageTicks: number;
   totalUsageTicks?: number;
-  at: DateTime;
+  at: DateTime | undefined;
 }) {
   return (
     <div className="flex items-center gap-2 py-2">
@@ -33,7 +33,12 @@ function HoverCard({
           <Text className="text-base max-w-52">{tag.name}</Text>
           <ScoreCircle score={tag.score} />
         </div>
-        <DateTimeText className="text-xs text-muted-foreground" datetime={at} />
+        {at && (
+          <DateTimeText
+            className="text-xs text-muted-foreground"
+            datetime={at}
+          />
+        )}
       </div>
 
       <div className="flex-1"></div>
@@ -54,7 +59,7 @@ export const TagUsageChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
     payload: EntityMap<Tag, number>;
-    dt: DateTime;
+    dt?: DateTime;
     hideIndicator?: boolean;
     maximumTags?: number;
     hoveredTagId: Ref<Tag> | null;

--- a/src/ui/app/components/viz/usage-pie.tsx
+++ b/src/ui/app/components/viz/usage-pie.tsx
@@ -149,6 +149,7 @@ export function AppUsagePieChart({
         <PieChart>
           {/* Inner pie chart for tags */}
           <Pie
+            isAnimationActive={false}
             data={tagData}
             startAngle={0}
             cx="50%"
@@ -159,6 +160,10 @@ export function AppUsagePieChart({
           >
             {tagData.map((entry) => (
               <Cell
+                style={{
+                  outline: "none",
+                }}
+                stroke="transparent"
                 key={`tag-${entry.id}`}
                 fill={entry.color}
                 onMouseEnter={() => onTagHover?.(entry)}
@@ -169,18 +174,23 @@ export function AppUsagePieChart({
 
           {/* Outer pie chart for apps */}
           <Pie
+            isAnimationActive={false}
             data={appData}
             startAngle={0}
             cx="50%"
             cy="50%"
             innerRadius={90}
-            outerRadius={110}
+            outerRadius={130}
             dataKey="duration"
             labelLine={false}
             label={renderCustomizedLabel}
           >
             {appData.map((entry) => (
               <Cell
+                style={{
+                  outline: "none",
+                }}
+                stroke="transparent"
                 key={`app-${entry.id}`}
                 fill={entry.color}
                 opacity={

--- a/src/ui/app/components/viz/usage-pie.tsx
+++ b/src/ui/app/components/viz/usage-pie.tsx
@@ -1,0 +1,196 @@
+import type { App, Ref, Tag } from "@/lib/entities";
+import type { WithDuration } from "@/lib/entities";
+import type { EntityMap } from "@/lib/state";
+import type { ClassValue } from "clsx";
+import { cn } from "@/lib/utils";
+import { useApps, useTags } from "@/hooks/use-refresh";
+import { useMemo } from "react";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  LabelList,
+  type PieLabel,
+} from "recharts";
+import type { ContentType } from "recharts/types/component/Label";
+import AppIcon, { toDataUrl } from "@/components/app/app-icon";
+import { TagIcon } from "lucide-react";
+import _ from "lodash";
+
+const RADIAN = Math.PI / 180;
+
+export interface AppUsagePieChartProps {
+  data: EntityMap<App, WithDuration<App>>;
+  // apps to highlight, order them by index in array. will be drawn left to right = top to bottom. unhighlighted apps will be drawn on top of highlighted apps.
+  highlightedAppIds?: Ref<App>[];
+  unhighlightedAppOpacity?: number;
+  hideApps?: Record<Ref<App>, boolean>;
+
+  className?: ClassValue;
+  onHover?: (data?: WithDuration<App>) => void;
+  onTagHover?: (data?: Tag) => void;
+}
+
+// TODO make this the same as the other untagged color we use
+const UNTAGGED_COLOR = "#6B7280"; // gray-500
+
+export function AppUsagePieChart({
+  data,
+  highlightedAppIds = [],
+  unhighlightedAppOpacity = 0.5,
+  hideApps = {},
+  className,
+  onHover,
+  onTagHover,
+}: AppUsagePieChartProps) {
+  const apps = useApps(Object.keys(data).map((id) => +id as Ref<App>));
+  const tags = useTags();
+
+  const appData = useMemo(() => {
+    return _(apps)
+      .filter((app) => !hideApps[app.id])
+      .map((app) => ({
+        ...app,
+        duration: data[app.id]?.duration ?? 0,
+      }))
+      .filter((app) => app.duration > 0)
+      .orderBy(["tagId", "duration"], ["asc", "desc"])
+      .value();
+  }, [apps, data, hideApps]);
+
+  const tagData = useMemo(() => {
+    // Get all tagged apps
+    const taggedAppIds = new Set(tags.flatMap((tag) => tag.apps));
+
+    // Calculate untagged duration
+    const untaggedDuration = apps
+      .filter((app) => !taggedAppIds.has(app.id) && !hideApps[app.id])
+      .reduce((sum, app) => sum + (data[app.id]?.duration ?? 0), 0);
+
+    // Create tag data including untagged
+    const tagData = [
+      // Tags
+      ...tags.map((tag) => ({
+        ...tag,
+        duration: _(tag.apps)
+          .map((appId) => data[appId]?.duration ?? 0)
+          .sum(),
+      })),
+      // Add untagged category if there are untagged apps
+      ...(untaggedDuration > 0
+        ? [
+            {
+              id: -1 as Ref<Tag>,
+              name: "Untagged",
+              color: UNTAGGED_COLOR,
+              apps: [],
+              usages: { today: 0, week: 0, month: 0 },
+              duration: untaggedDuration,
+            },
+          ]
+        : []),
+    ].filter((tag) => tag.duration > 0);
+
+    return tagData;
+  }, [tags, apps, data, hideApps]);
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-background border rounded-lg p-2 shadow-lg">
+          <p className="font-medium">{data.name}</p>
+          <p className="text-sm text-muted-foreground">
+            Duration: {Math.round(data.duration / 1000)}s
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const renderCustomizedLabel: PieLabel = (props) => {
+    const { cx, cy, midAngle, innerRadius, outerRadius, percent, icon } = props;
+    const url = toDataUrl(icon);
+    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+    const radiusDiff = outerRadius - innerRadius;
+    const angleLengthValue = percent * 360 * RADIAN * radius;
+    const maxSize = Math.min(radiusDiff, angleLengthValue) * Math.SQRT1_2;
+    const size = Math.max(Math.min(maxSize * 0.9, 32), 0); // 10% padding
+
+    console.log("label", props);
+
+    return (
+      <image
+        x={x - size / 2}
+        y={y - size / 2}
+        width={size}
+        height={size}
+        href={url}
+        pointerEvents="none"
+      />
+    );
+  };
+
+  return (
+    <div className={cn("w-full h-full min-h-[300px]", className)}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          {/* Inner pie chart for tags */}
+          <Pie
+            data={tagData}
+            startAngle={0}
+            cx="50%"
+            cy="50%"
+            innerRadius={60}
+            outerRadius={80}
+            dataKey="duration"
+          >
+            {tagData.map((entry, index) => (
+              <Cell
+                key={`tag-${entry.id}`}
+                fill={entry.color}
+                opacity={0.8}
+                onMouseEnter={() => onTagHover?.(entry)}
+                onMouseLeave={() => onTagHover?.(undefined)}
+              />
+            ))}
+          </Pie>
+
+          {/* Outer pie chart for apps */}
+          <Pie
+            data={appData}
+            startAngle={0}
+            cx="50%"
+            cy="50%"
+            innerRadius={90}
+            outerRadius={110}
+            dataKey="duration"
+            labelLine={false}
+            label={renderCustomizedLabel}
+          >
+            {appData.map((entry, index) => (
+              <Cell
+                key={`app-${entry.id}`}
+                fill={entry.color}
+                opacity={
+                  highlightedAppIds.includes(entry.id)
+                    ? 1
+                    : unhighlightedAppOpacity
+                }
+                onMouseEnter={() => onHover?.(entry)}
+                onMouseLeave={() => onHover?.(undefined)}
+              />
+            ))}
+          </Pie>
+
+          <Tooltip content={<CustomTooltip />} />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/ui/app/components/viz/usage-pie.tsx
+++ b/src/ui/app/components/viz/usage-pie.tsx
@@ -11,12 +11,10 @@ import {
   Cell,
   ResponsiveContainer,
   Tooltip,
-  LabelList,
   type PieLabel,
+  type TooltipProps,
 } from "recharts";
-import type { ContentType } from "recharts/types/component/Label";
-import AppIcon, { toDataUrl } from "@/components/app/app-icon";
-import { TagIcon } from "lucide-react";
+import { toDataUrl } from "@/components/app/app-icon";
 import _ from "lodash";
 
 const RADIAN = Math.PI / 180;
@@ -38,7 +36,7 @@ const UNTAGGED_COLOR = "#6B7280"; // gray-500
 
 export function AppUsagePieChart({
   data,
-  highlightedAppIds = [],
+  highlightedAppIds,
   unhighlightedAppOpacity = 0.5,
   hideApps = {},
   className,
@@ -96,7 +94,8 @@ export function AppUsagePieChart({
     return tagData;
   }, [tags, apps, data, hideApps]);
 
-  const CustomTooltip = ({ active, payload }: any) => {
+  // sussy argument
+  const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
     if (active && payload && payload.length) {
       const data = payload[0].payload;
       return (
@@ -150,11 +149,10 @@ export function AppUsagePieChart({
             outerRadius={80}
             dataKey="duration"
           >
-            {tagData.map((entry, index) => (
+            {tagData.map((entry) => (
               <Cell
                 key={`tag-${entry.id}`}
                 fill={entry.color}
-                opacity={0.8}
                 onMouseEnter={() => onTagHover?.(entry)}
                 onMouseLeave={() => onTagHover?.(undefined)}
               />
@@ -173,12 +171,12 @@ export function AppUsagePieChart({
             labelLine={false}
             label={renderCustomizedLabel}
           >
-            {appData.map((entry, index) => (
+            {appData.map((entry) => (
               <Cell
                 key={`app-${entry.id}`}
                 fill={entry.color}
                 opacity={
-                  highlightedAppIds.includes(entry.id)
+                  (highlightedAppIds?.includes(entry.id) ?? true)
                     ? 1
                     : unhighlightedAppOpacity
                 }

--- a/src/ui/app/components/viz/usage-pie.tsx
+++ b/src/ui/app/components/viz/usage-pie.tsx
@@ -16,6 +16,7 @@ import {
 } from "recharts";
 import { toDataUrl } from "@/components/app/app-icon";
 import _ from "lodash";
+import { DurationText } from "@/components/time/duration-text";
 
 const RADIAN = Math.PI / 180;
 
@@ -45,6 +46,12 @@ export function AppUsagePieChart({
 }: AppUsagePieChartProps) {
   const apps = useApps(Object.keys(data).map((id) => +id as Ref<App>));
   const tags = useTags();
+
+  const totalUsage = useMemo(() => {
+    return _(apps)
+      .filter((app) => !hideApps[app.id])
+      .reduce((sum, app) => sum + (data[app.id]?.duration ?? 0), 0);
+  }, [apps, data, hideApps]);
 
   const appData = useMemo(() => {
     return _(apps)
@@ -121,8 +128,6 @@ export function AppUsagePieChart({
     const maxSize = Math.min(radiusDiff, angleLengthValue) * Math.SQRT1_2;
     const size = Math.max(Math.min(maxSize * 0.9, 32), 0); // 10% padding
 
-    console.log("label", props);
-
     return (
       <image
         x={x - size / 2}
@@ -136,7 +141,10 @@ export function AppUsagePieChart({
   };
 
   return (
-    <div className={cn("w-full h-full min-h-[300px]", className)}>
+    <div className={cn("w-full h-full min-h-[300px] relative", className)}>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <DurationText ticks={totalUsage} />
+      </div>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           {/* Inner pie chart for tags */}

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -99,7 +99,7 @@ export function VerticalLegend({
       setUncheckedApps((prev) => {
         const newState = { ...prev };
         apps
-          .filter((app) => app.tagId === id)
+          .filter((app) => app.tagId === (id === untagged.id ? null : id))
           .forEach((app) => {
             newState[app.id] = !checked;
           });
@@ -188,7 +188,9 @@ export function VerticalLegend({
       // Add apps under this tag if expanded
       if (!unexpandedTags[tagIdStr]) {
         filteredApps
-          .filter((app) => app.tagId === tag.id)
+          .filter(
+            (app) => app.tagId === (tag.id === untagged.id ? null : tag.id),
+          )
           .forEach((app) => {
             data.push({
               id: `app-${app.id}`,

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -35,16 +35,12 @@ import type { CheckedState } from "@radix-ui/react-checkbox";
 import { ScoreCircle } from "@/components/tag/score";
 import { VariableSizeList as List } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
-
-const Untagged = Symbol("untagged");
-export type AppTagId = Ref<Tag> | typeof Untagged;
+import { untagged } from "@/lib/state";
 
 type ListItem = {
   id: string;
   type: "tag" | "app" | "spacer";
-  tag?:
-    | Tag
-    | { id: typeof Untagged; name: string; color: string; score: number };
+  tag?: Tag;
   app?: App;
   isExpanded: boolean;
   nestingLevel: number;
@@ -99,18 +95,18 @@ export function VerticalLegend({
   );
 
   const checkTag = useCallback(
-    (id: AppTagId, checked: boolean) => {
+    (id: Ref<Tag>, checked: boolean) => {
       setUncheckedApps((prev) => {
         const newState = { ...prev };
         apps
-          .filter((app) => app.tagId === (id === Untagged ? null : +id))
+          .filter((app) => app.tagId === id)
           .forEach((app) => {
             newState[app.id] = !checked;
           });
         return newState;
       });
     },
-    [setUncheckedApps],
+    [setUncheckedApps, apps],
   );
 
   const showUntagged = useMemo(() => {
@@ -152,12 +148,12 @@ export function VerticalLegend({
   };
 
   const tagStatus = useCallback(
-    (tagId: AppTagId): CheckedState => {
+    (tagId: Ref<Tag>): CheckedState => {
       const allUnchecked = apps
-        .filter((app) => app.tagId === (tagId === Untagged ? null : tagId))
+        .filter((app) => app.tagId === (tagId === untagged.id ? null : tagId))
         .every((app) => !!uncheckedApps[app.id]);
       const allChecked = apps
-        .filter((app) => app.tagId === (tagId === Untagged ? null : tagId))
+        .filter((app) => app.tagId === (tagId === untagged.id ? null : tagId))
         .every((app) => !uncheckedApps[app.id]);
       return allChecked ? true : allUnchecked ? false : "indeterminate";
     },
@@ -169,19 +165,7 @@ export function VerticalLegend({
     const data: ListItem[] = [];
 
     // Add tags
-    [
-      ...tags,
-      ...(showUntagged
-        ? [
-            {
-              id: Untagged,
-              name: "Untagged",
-              color: "#000000",
-              score: 0,
-            } as const,
-          ]
-        : []),
-    ].forEach((tag, index) => {
+    [...tags, ...(showUntagged ? [untagged] : [])].forEach((tag, index) => {
       // Add spacer between tag groups
       if (index > 0) {
         data.push({
@@ -192,7 +176,7 @@ export function VerticalLegend({
         });
       }
 
-      const tagIdStr = tag.id.toString();
+      const tagIdStr = tag.id + "";
       data.push({
         id: `tag-${tagIdStr}`,
         type: "tag",
@@ -204,7 +188,7 @@ export function VerticalLegend({
       // Add apps under this tag if expanded
       if (!unexpandedTags[tagIdStr]) {
         filteredApps
-          .filter((app) => app.tagId === (tag.id === Untagged ? null : tag.id))
+          .filter((app) => app.tagId === tag.id)
           .forEach((app) => {
             data.push({
               id: `app-${app.id}`,
@@ -230,7 +214,7 @@ export function VerticalLegend({
       }
       if (item.type === "tag") {
         const tag = item.tag!;
-        const tagIdStr = tag.id.toString();
+        const tagIdStr = tag.id + "";
         return (
           <div
             style={style}
@@ -282,7 +266,15 @@ export function VerticalLegend({
         );
       }
     },
-    [listData, unexpandedTags, tagStatus, checkTag, checkApp, uncheckedApps],
+    [
+      listData,
+      unexpandedTags,
+      tagStatus,
+      checkTag,
+      checkApp,
+      uncheckedApps,
+      toggleExpandTag,
+    ],
   );
 
   // Recalculate item sizes when list data changes

--- a/src/ui/app/lib/state.ts
+++ b/src/ui/app/lib/state.ts
@@ -51,9 +51,10 @@ export async function refresh() {
 }
 
 export const untagged: Tag = {
-  id: -1 as Ref<Tag>,
+  id: null as unknown as Ref<Tag>,
   name: "Untagged",
   color: "#6B7280", // gray-500
+  score: 0,
   // below two fields are not really used.
   apps: [],
   usages: {

--- a/src/ui/app/lib/state.ts
+++ b/src/ui/app/lib/state.ts
@@ -51,7 +51,7 @@ export async function refresh() {
 }
 
 export const untagged: Tag = {
-  id: null as unknown as Ref<Tag>,
+  id: -1 as unknown as Ref<Tag>,
   name: "Untagged",
   color: "#6B7280", // gray-500
   score: 0,

--- a/src/ui/app/lib/state.ts
+++ b/src/ui/app/lib/state.ts
@@ -50,6 +50,19 @@ export async function refresh() {
   info("refresh completed");
 }
 
+export const untagged: Tag = {
+  id: -1 as Ref<Tag>,
+  name: "Untagged",
+  color: "#6B7280", // gray-500
+  // below two fields are not really used.
+  apps: [],
+  usages: {
+    today: 0,
+    week: 0,
+    month: 0,
+  },
+};
+
 // Entity store with T|undefined values. This is because
 // the store can be stale.
 export type EntityStore<T> = Record<Ref<T>, T | undefined>;

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -90,6 +90,7 @@
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.19.0",
     "vite": "^5.4.11",
+    "vite-plugin-devtools-json": "^0.1.0",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/postcss";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "path";
+import devToolsJson from "vite-plugin-devtools-json";
 
 const host = process.env.TAURI_DEV_HOST;
 
@@ -32,7 +33,7 @@ export default defineConfig({
       plugins: [tailwindcss()],
     },
   },
-  plugins: [reactRouter(), tsconfigPaths()],
+  plugins: [reactRouter(), tsconfigPaths(), devToolsJson()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./app"),


### PR DESCRIPTION
# Add Usage Pie Chart Component

This PR adds a new `UsagePieChart` component that visualizes app and tag usage data in a dual-layer pie chart. The chart displays:

- Inner ring showing tag usage
- Outer ring showing app usage with app icons
- Total usage duration in the center

Additionally:
- Made datetime optional in tooltips to support the pie chart
- Added proper handling of untagged items in tooltips and legends
- Refactored the vertical legend to use a centralized `untagged` constant
- Fixed tag tooltip to properly display untagged items

The pie chart supports highlighting specific apps, hovering interactions, and integrates with the existing tooltip components.