### PR TITLE
Web Tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,9 +599,9 @@ dependencies = [
  "bitflags 2.5.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -614,7 +614,7 @@ checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
 dependencies = [
  "bitflags 2.5.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
  "libc",
  "objc",
@@ -690,6 +690,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -711,9 +721,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.5.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -724,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.5.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -810,6 +820,19 @@ dependencies = [
  "quote",
  "smallvec",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 1.0.11",
+ "phf 0.11.3",
+ "smallvec",
 ]
 
 [[package]]
@@ -1061,6 +1084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1117,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1275,12 +1313,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1293,6 +1340,12 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1535,6 +1588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1787,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.7.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,10 +1895,22 @@ checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.11.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.1",
+ "match_token",
 ]
 
 [[package]]
@@ -1869,6 +1962,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1895,6 +1989,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2225,10 +2335,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2271,11 +2382,11 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29e4755b7b995046f510a7520c42b2fed58b77bd94d5a87a8eb43d2fd126da8"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.27.2",
+ "html5ever 0.26.0",
  "indexmap 1.9.3",
  "matches",
- "selectors",
+ "selectors 0.22.0",
 ]
 
 [[package]]
@@ -2413,6 +2524,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2663,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2945,6 +3098,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3462,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "platform"
 version = "0.5.0"
 dependencies = [
+ "reqwest",
+ "scraper",
  "util",
  "windows 0.56.0",
 ]
@@ -3619,24 +3828,28 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3648,7 +3861,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3774,6 +3989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,6 +4007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3831,13 +4061,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e65d9d888567588db4c12da1087598d0f6f8b346cc2c5abc91f05fc2dffe2"
+dependencies = [
+ "cssparser 0.34.0",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.29.1",
+ "precomputed-hash",
+ "selectors 0.26.0",
+ "tendril",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
+ "cssparser 0.27.2",
  "derive_more",
  "fxhash",
  "log",
@@ -3845,9 +4113,28 @@ dependencies = [
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.1.1",
  "smallvec",
  "thin-slice",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.5.0",
+ "cssparser 0.34.0",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "precomputed-hash",
+ "servo_arc 0.4.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -4008,6 +4295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae65c4249478a2647db249fb43e23cec56a2c8974a427e7bd8cb5a1d0964921a"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,7 +4414,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -4500,6 +4796,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4520,7 +4837,7 @@ checksum = "3731d04d4ac210cd5f344087733943b9bfb1a32654387dad4d1c70de21aee2c9"
 dependencies = [
  "bitflags 2.5.0",
  "cocoa",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4832,7 +5149,7 @@ dependencies = [
  "ctor",
  "dunce",
  "glob",
- "html5ever",
+ "html5ever 0.26.0",
  "http",
  "infer",
  "json-patch",
@@ -5029,6 +5346,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5380,6 +5707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,23 +5883,24 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -5587,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5597,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5610,9 +5944,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -5841,7 +6178,7 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5890,14 +6227,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5919,6 +6262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5926,6 +6278,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6278,7 +6639,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
+ "html5ever 0.26.0",
  "http",
  "javascriptcore-rs",
  "jni",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,6 @@ version = "0.5.0"
 dependencies = [
  "data",
  "platform",
- "rand 0.8.5",
  "scoped-futures",
  "util",
 ]
@@ -3462,6 +3461,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "platform"
 version = "0.5.0"
 dependencies = [
+ "rand 0.9.1",
  "reqwest",
  "scraper",
  "util",
@@ -3690,6 +3690,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,6 +3720,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,6 +3745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]

--- a/dev/appsettings.Debug.json
+++ b/dev/appsettings.Debug.json
@@ -1,4 +1,4 @@
 {
-  "EngineLogFilter": "Debug",
-  "UiLogFilter": "Debug"
+  "EngineLogFilter": "Debug,selectors=info,html5ever=info",
+  "UiLogFilter": "Debug,selectors=info,html5ever=info"
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,8 +142,8 @@ erDiagram
         text            company
         text            color
         int_nullable    tag_id FK
-        int             identity_is_win32     UK "UNIQUE(is_win32, path_or_aumid)"
-        text            identity_path_or_aumid   UK "UNIQUE(is_win32, path_or_aumid)"
+        int             identity_tag     UK "UNIQUE(identity_tag, identity_text0)"
+        text            identity_text0   UK "UNIQUE(identity_tag, identity_text0)"
         blob_nullable   icon
         int             created_at
         int_nullable    initialized_at "set if details are set"
@@ -162,6 +162,7 @@ erDiagram
         int             id PK
         int             app_id FK
         text            title
+        text_nullable   url
     }
 
     usages {

--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -135,10 +135,12 @@ pub struct Tag {
 #[serde(tag = "tag")]
 pub enum AlertTriggerStatus {
     /// Hit
+    #[serde(rename_all = "camelCase")]
     Hit {
         /// Timestamp
         timestamp: Timestamp,
     },
+    #[serde(rename_all = "camelCase")]
     /// Ignored
     Ignored {
         /// Timestamp
@@ -166,11 +168,13 @@ impl FromRow<'_, SqliteRow> for AlertTriggerStatus {
 #[serde(tag = "tag")]
 pub enum ReminderTriggerStatus {
     /// Hit
+    #[serde(rename_all = "camelCase")]
     Hit {
         /// Timestamp
         timestamp: Timestamp,
     },
     /// Ignored
+    #[serde(rename_all = "camelCase")]
     Ignored {
         /// Timestamp
         timestamp: Timestamp,

--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -371,6 +371,8 @@ pub struct Session {
     pub id: Ref<super::Session>,
     /// Title of Session
     pub title: String,
+    /// URL of Session
+    pub url: Option<String>,
     /// Minimum Usage of Usages
     pub start: Timestamp,
     /// Maximum Usage of Usages

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -241,6 +241,7 @@ impl Repository {
             session_id: Ref<Session>,
             usage_id: Ref<Usage>,
             session_title: String,
+            session_url: Option<String>,
             start: Timestamp,
             end: Timestamp,
         }
@@ -251,6 +252,7 @@ impl Repository {
                 u.session_id AS session_id,
                 u.id AS usage_id,
                 s.title AS session_title,
+                s.url AS session_url,
                 MAX(u.start, p.start) AS start,
                 MIN(u.end, p.end) AS end
             FROM usages u, (SELECT ? AS start, ? AS end) p
@@ -272,6 +274,7 @@ impl Repository {
                 .or_insert_with(|| infused::Session {
                     id: session_id,
                     title: usage.session_title,
+                    url: usage.session_url,
                     start: usage.start,
                     end: usage.end,
                     usages: Vec::new(),

--- a/src/data/src/db/repo_tests.rs
+++ b/src/data/src/db/repo_tests.rs
@@ -597,6 +597,7 @@ async fn usages(db: &mut Database, app_id: Ref<App>, usages: Vec<(i64, i64)>) ->
                 id: Ref::new(0),
                 app_id: app_id.clone(),
                 title: "".to_string(),
+                url: None,
             },
         )
         .await?

--- a/src/data/src/db/tests.rs
+++ b/src/data/src/db/tests.rs
@@ -45,7 +45,7 @@ async fn insert_new_app() -> Result<()> {
             (
                 r.get("initialized_at"),
                 r.get("created_at"),
-                r.get("identity_path_or_aumid"),
+                r.get("identity_text0"),
             )
         })
         .fetch_all(writer.db.executor())
@@ -89,7 +89,7 @@ async fn found_old_app() -> Result<()> {
             (
                 r.get("initialized_at"),
                 r.get("created_at"),
-                r.get("identity_path_or_aumid"),
+                r.get("identity_text0"),
             )
         })
         .fetch_all(writer.db.executor())
@@ -115,6 +115,7 @@ async fn insert_session() -> Result<()> {
         id: Default::default(),
         app_id: Ref::new(1),
         title: "TITLE".to_string(),
+        url: None,
     };
     writer.insert_session(&mut sess).await?;
 
@@ -142,6 +143,7 @@ async fn insert_usage() -> Result<()> {
         id: Default::default(),
         app_id: Ref::new(1),
         title: "TITLE".to_string(),
+        url: None,
     };
     writer.insert_session(&mut sess).await?;
     let mut usage = Usage {
@@ -175,6 +177,7 @@ async fn update_usage_after_insert_usage() -> Result<()> {
         id: Default::default(),
         app_id: Ref::new(1),
         title: "TITLE".to_string(),
+        url: None,
     };
     writer.insert_session(&mut sess).await?;
     let mut usage = Usage {
@@ -728,6 +731,7 @@ pub mod arrange {
             match &app.identity {
                 AppIdentity::Win32 { path } => path,
                 AppIdentity::Uwp { aumid } => aumid,
+                AppIdentity::Website { base_url } => base_url,
             },
             app.icon.clone(),
             0,
@@ -755,6 +759,7 @@ pub mod arrange {
             match &app.identity {
                 AppIdentity::Win32 { path } => path,
                 AppIdentity::Uwp { aumid } => aumid,
+                AppIdentity::Website { base_url } => base_url,
             },
             app.icon.clone(),
             0,
@@ -766,9 +771,10 @@ pub mod arrange {
     }
 
     pub async fn session(db: &mut Database, mut session: Session) -> Result<Session> {
-        let res = query("INSERT INTO sessions VALUES (NULL, ?, ?)")
+        let res = query("INSERT INTO sessions VALUES (NULL, ?, ?, ?)")
             .bind(session.app_id.clone())
             .bind(session.title.clone())
+            .bind(session.url.clone())
             .execute(db.executor())
             .await?;
         session.id = Ref::new(res.last_insert_rowid());
@@ -983,6 +989,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1046,6 +1053,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1127,6 +1135,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1225,6 +1234,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1324,6 +1334,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1416,6 +1427,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1508,6 +1520,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1589,6 +1602,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1670,6 +1684,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1777,6 +1792,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;
@@ -1973,6 +1989,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app1.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?
@@ -1995,6 +2012,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app2.id.clone(),
                 title: "title2".to_string(),
+                url: None,
             },
         )
         .await?
@@ -2017,6 +2035,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app3.id.clone(),
                 title: "title3".to_string(),
+                url: None,
             },
         )
         .await?
@@ -2039,6 +2058,7 @@ mod triggered_alerts {
                 id: Ref::default(),
                 app_id: app4.id.clone(),
                 title: "title4".to_string(),
+                url: None,
             },
         )
         .await?
@@ -2182,6 +2202,7 @@ mod triggered_reminders {
                 id: Ref::default(),
                 app_id: app.id.clone(),
                 title: "title".to_string(),
+                url: None,
             },
         )
         .await?;

--- a/src/data/src/entities.rs
+++ b/src/data/src/entities.rs
@@ -43,16 +43,19 @@ pub struct App {
 #[serde(tag = "tag")]
 pub enum AppIdentity {
     /// UWP App
+    #[serde(rename_all = "camelCase")]
     Uwp {
         /// AUMID of the UWP App
         aumid: String,
     },
     /// Win32 App
+    #[serde(rename_all = "camelCase")]
     Win32 {
         /// Path of the Win32 App
         path: String,
     },
     /// Website
+    #[serde(rename_all = "camelCase")]
     Website {
         /// Base URL of the Website
         base_url: String,
@@ -159,11 +162,13 @@ pub struct SystemEvent {
 #[serde(tag = "tag")]
 pub enum Target {
     /// [App] Target
+    #[serde(rename_all = "camelCase")]
     App {
         /// App Identifier
         id: Ref<App>,
     },
     /// [Tag] Target
+    #[serde(rename_all = "camelCase")]
     Tag {
         /// Tag Identifier
         id: Ref<Tag>,
@@ -212,11 +217,13 @@ pub enum TriggerAction {
     /// Kill the offending App / App in Tags
     Kill,
     /// Dim the windows of the offending App / App in Tags
+    #[serde(rename_all = "camelCase")]
     Dim {
         /// Duration to dim over
         duration: Duration,
     },
     /// Send a message to the user as a Toast notification
+    #[serde(rename_all = "camelCase")]
     Message {
         /// Contents of the Message
         content: String,

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -39,8 +39,8 @@ impl Migration for Migration1 {
                 company                         TEXT,
                 color                           TEXT,
                 tag_id                          INTEGER REFERENCES tags(id) ON DELETE SET NULL,
-                identity_is_win32               INTEGER NOT NULL,
-                identity_path_or_aumid          TEXT NOT NULL,
+                identity_tag                    INTEGER NOT NULL,
+                identity_text0                  TEXT NOT NULL,
                 icon                            BLOB,
                 created_at                      INTEGER NOT NULL,
                 initialized_at                  INTEGER,
@@ -55,7 +55,8 @@ impl Migration for Migration1 {
             "CREATE TABLE sessions (
                 id                              INTEGER PRIMARY KEY NOT NULL,
                 app_id                          INTEGER NOT NULL REFERENCES apps(id),
-                title                           TEXT NOT NULL
+                title                           TEXT NOT NULL,
+                url                             TEXT
             )",
         )
         .await
@@ -160,11 +161,9 @@ impl Migration for Migration1 {
             .await
             .context("create index interaction_period")?;
 
-        tx.execute(
-            "CREATE UNIQUE INDEX app_identity ON apps(identity_is_win32, identity_path_or_aumid)",
-        )
-        .await
-        .context("create unique index app_identity")?;
+        tx.execute("CREATE UNIQUE INDEX app_identity ON apps(identity_tag, identity_text0)")
+            .await
+            .context("create unique index app_identity")?;
 
         tx.commit().await.context("commit transaction")?;
         Ok(())

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -13,6 +13,5 @@ workspace = true
 [dependencies]
 data = { path = "../data" }
 platform = { path = "../platform" }
-rand = { version = "0.8.5", features = ["std_rng"] }
-scoped-futures = "0.1.4"
 util = { path = "../util" }
+scoped-futures = "0.1.4"

--- a/src/engine/src/cache.rs
+++ b/src/engine/src/cache.rs
@@ -77,7 +77,7 @@ impl Cache {
         self.apps.remove(&process);
         if let Some(windows) = self.windows.remove(&process) {
             self.sessions.retain(|ws, _| !windows.contains(&ws.window));
-            self.browsers.retain(|window, _| !windows.contains(&window));
+            self.browsers.retain(|window, _| !windows.contains(window));
         }
         self.processes.retain(|_, pids| {
             // remove pid from list, and remove the entry altogether if it's empty

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -240,7 +240,7 @@ impl Engine {
                         .await
                 })
                 .await?;
-            (app.clone(), is_browser.clone())
+            (app.clone(), *is_browser)
         };
 
         if !is_browser {

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -7,7 +7,9 @@ use data::entities::{
 use platform::events::{
     ForegroundChangedEvent, InteractionChangedEvent, SystemStateEvent, WindowSession,
 };
-use platform::objects::{Process, ProcessId, Timestamp, Window};
+use platform::objects::{
+    BaseWebsiteUrl, BrowserDetector, Process, ProcessId, Timestamp, WebsiteInfo, Window,
+};
 use scoped_futures::ScopedFutureExt;
 use util::error::{Context, Result};
 use util::future::runtime::Handle;
@@ -184,10 +186,17 @@ impl Engine {
     /// Get the [Session] details for the given [WindowSession]
     async fn get_session_details(
         &mut self,
-        ws: WindowSession,
+        mut ws: WindowSession,
         at: Timestamp,
     ) -> Result<Ref<Session>> {
         let mut cache = self.cache.lock().await;
+
+        // If window is browser (assume true if unknown), then we need the url.
+        // Else set the url to None.
+        if !cache.is_browser(&ws.window).unwrap_or(true) {
+            ws.url = None;
+        }
+
         let session_details = cache
             .get_or_insert_session_for_window(ws.clone(), |cache| {
                 async {
@@ -204,6 +213,9 @@ impl Engine {
                 .scope_boxed()
             })
             .await?;
+        // if !session_details.is_browser {
+        //     ws.url = None;
+        // }
 
         Ok(session_details.session.clone())
     }
@@ -214,28 +226,49 @@ impl Engine {
         db_pool: DatabasePool,
         inserter: &mut UsageWriter,
         spawner: &Handle,
-        ws: WindowSession,
+        mut ws: WindowSession,
         at: Timestamp,
     ) -> Result<SessionDetails> {
         trace!(?ws, "insert session");
 
         let pid = ws.window.pid()?;
-        let AppDetails { app } = cache
-            .get_or_insert_app_for_process(pid, |_| async {
-                Self::create_app_for_process(inserter, db_pool, spawner, pid, &ws.window, at).await
-            })
-            .await?;
+        let (mut app, is_browser) = {
+            let db_pool = db_pool.clone();
+            let AppDetails { app, is_browser } = cache
+                .get_or_insert_app_for_process(pid, |_| async {
+                    Self::create_app_for_process(inserter, db_pool, spawner, pid, &ws.window, at)
+                        .await
+                })
+                .await?;
+            (app.clone(), is_browser.clone())
+        };
+
+        if !is_browser {
+            ws.url = None;
+        }
+
+        if let Some(url) = &ws.url {
+            let base_url = WebsiteInfo::url_to_base_url(url).context("url to base url")?;
+            let AppDetails { app: web_app, .. } = cache
+                .get_or_insert_website_for_base_url(base_url.clone(), |_| async {
+                    Self::create_app_for_base_url(inserter, db_pool, spawner, base_url, at).await
+                })
+                .await?;
+            app = web_app.clone();
+        }
 
         let mut session = Session {
             id: Default::default(),
-            app_id: app.clone(),
+            app_id: app,
             title: ws.title,
+            url: ws.url,
         };
         inserter.insert_session(&mut session).await?;
 
         Ok(SessionDetails {
             session: session.id,
             pid,
+            is_browser,
         })
     }
 
@@ -251,8 +284,9 @@ impl Engine {
         trace!(?window, ?pid, "create/find app for process");
 
         let process = Process::new(pid)?;
-
         let path = process.path()?;
+        let is_browser = BrowserDetector::is_browser(&path);
+
         let identity = if process.is_uwp(Some(&path))? {
             AppIdentity::Uwp {
                 aumid: window.aumid()?,
@@ -283,6 +317,51 @@ impl Engine {
                 id
             }
         };
-        Ok(AppDetails { app: app_id })
+        Ok(AppDetails {
+            app: app_id,
+            is_browser,
+        })
+    }
+
+    async fn create_app_for_base_url(
+        inserter: &mut UsageWriter,
+        db_pool: DatabasePool,
+        spawner: &Handle,
+        base_url: BaseWebsiteUrl,
+        at: Timestamp,
+    ) -> std::result::Result<AppDetails, util::error::Error> {
+        trace!(?base_url, "create/find app for base url");
+
+        let identity = AppIdentity::Website {
+            base_url: base_url.to_string(),
+        };
+        let found_app = inserter.find_or_insert_app(&identity, at).await?;
+
+        let app_id = match found_app {
+            FoundOrInserted::Found(id) => id,
+            FoundOrInserted::Inserted(id) => {
+                {
+                    info!(?base_url, "inserted app for website");
+
+                    let id = id.clone();
+
+                    spawner.spawn(async move {
+                        AppInfoResolver::update_app(db_pool, id.clone(), identity.clone())
+                            .await
+                            .with_context(|| {
+                                format!("update app({:?}, {:?}) (website) with info", id, identity)
+                            })
+                            .error();
+                    });
+                }
+
+                id
+            }
+        };
+        // this is a website, not a browser
+        Ok(AppDetails {
+            app: app_id,
+            is_browser: false,
+        })
     }
 }

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -13,7 +13,9 @@ use engine::{Engine, Event};
 use platform::events::{
     ForegroundEventWatcher, InteractionWatcher, SystemEventWatcher, WindowSession,
 };
-use platform::objects::{EventLoop, MessageWindow, Timer, Timestamp, User, Window};
+use platform::objects::{
+    BrowserDetector, EventLoop, MessageWindow, Timer, Timestamp, User, Window,
+};
 use resolver::AppInfoResolver;
 use sentry::Sentry;
 use util::channels::{self, Receiver, Sender};
@@ -173,7 +175,10 @@ fn processor(
     event_rx: Receiver<Event>,
     alert_rx: Receiver<Timestamp>,
 ) -> Result<()> {
-    let rt = Builder::new_current_thread().enable_time().build()?;
+    let rt = Builder::new_current_thread()
+        .enable_time()
+        .enable_io()
+        .build()?;
     // let rt = Builder::new_multi_thread().enable_all().build()?;
 
     let cache = Arc::new(Mutex::new(cache::Cache::new()));
@@ -265,7 +270,14 @@ async fn update_app_infos(db_pool: DatabasePool, handle: Handle) -> Result<()> {
 fn foreground_window_session() -> Result<WindowSession> {
     loop {
         if let Some(window) = Window::foreground() {
-            return WindowSession::new(window);
+            let browser = BrowserDetector::new()?;
+            let url = if browser.is_chromium(&window).warn() {
+                Some(browser.chromium_url(&window)?)
+            } else {
+                None
+            };
+
+            return WindowSession::new(window, url).context("manual foreground window session");
         }
         // This method *MUST* be synchronous, so we use the synchronous version of sleep.
         // There is no blocking or potential for a race condition here because the

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -272,7 +272,7 @@ fn foreground_window_session() -> Result<WindowSession> {
         if let Some(window) = Window::foreground() {
             let browser = BrowserDetector::new()?;
             let url = if browser.is_chromium(&window).warn() {
-                Some(browser.chromium_url(&window)?)
+                browser.chromium_url(&window).context("get chromium url")?
             } else {
                 None
             };

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -1,8 +1,6 @@
 use data::db::{AppUpdater, DatabasePool};
 use data::entities::{App, AppIdentity, Ref};
 use platform::objects::{AppInfo, WebsiteInfo};
-use rand::prelude::SliceRandom;
-use rand::rngs::ThreadRng;
 use util::error::Result;
 use util::tracing::info;
 
@@ -39,7 +37,7 @@ impl AppInfoResolver {
             name: app_info.name,
             description: app_info.description,
             company: app_info.company,
-            color: Self::random_color(),
+            color: app_info.color,
             identity,
             tag_id: None,
             icon: app_info.logo,
@@ -48,20 +46,5 @@ impl AppInfoResolver {
         let now = platform::objects::Timestamp::now();
         updater.update_app(&app, now).await?;
         Ok(())
-    }
-
-    fn random_color() -> String {
-        // ref: https://github.com/catppuccin/catppuccin
-        // Mocha colors
-        let mut rng = ThreadRng::default();
-
-        [
-            "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7", "#f38ba8", "#eba0ac", "#fab387", "#f9e2af",
-            "#a6e3a1", "#94e2d5", "#89dceb", "#74c7ec", "#89b4fa", "#b4befe",
-            "#cdd6f4", // Text
-        ]
-        .choose_mut(&mut rng)
-        .unwrap()
-        .to_string()
     }
 }

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -1,6 +1,6 @@
 use data::db::{AppUpdater, DatabasePool};
 use data::entities::{App, AppIdentity, Ref};
-use platform::objects::AppInfo;
+use platform::objects::{AppInfo, WebsiteInfo};
 use rand::prelude::SliceRandom;
 use rand::rngs::ThreadRng;
 use util::error::Result;
@@ -15,6 +15,10 @@ impl AppInfoResolver {
         match identity {
             AppIdentity::Win32 { path } => AppInfo::from_win32(path).await,
             AppIdentity::Uwp { aumid } => AppInfo::from_uwp(aumid).await,
+            AppIdentity::Website { base_url } => {
+                let base_url = WebsiteInfo::url_to_base_url(base_url)?;
+                Ok(WebsiteInfo::from_base_url(base_url).await?.into())
+            }
         }
     }
 

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -33,6 +33,9 @@ features = [
     "Win32_System_Power",
     "Win32_System_SystemServices",
     "Win32_System_WindowsProgramming",
+    "Win32_UI_Accessibility",
+    "Win32_System_Com",
+    "Win32_System_Ole",
 
     "Foundation",
     "Foundation_Collections",

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -11,6 +11,8 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = "0.12.15"
+scraper = "0.23.1"
 util = { path = "../util" }
 
 [dependencies.windows]

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "0.9.1"
 reqwest = "0.12.15"
 scraper = "0.23.1"
 util = { path = "../util" }

--- a/src/platform/src/events/foreground.rs
+++ b/src/platform/src/events/foreground.rs
@@ -46,7 +46,7 @@ impl ForegroundEventWatcher {
     pub fn poll(&mut self, at: Timestamp) -> Result<Option<ForegroundChangedEvent>> {
         if let Some(fg) = Window::foreground() {
             let url = if self.browser.is_chromium(&fg).warn() {
-                Some(self.browser.chromium_url(&fg)?)
+                self.browser.chromium_url(&fg).context("get chromium url")?
             } else {
                 None
             };

--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -7,12 +7,16 @@ pub mod events;
 /// Objects in the Platform
 pub mod objects;
 
-use util::error::Result;
+use util::error::{Context, Result};
+use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
 
 use crate::objects::Timestamp;
 
 /// Setup platform for Windows
 pub fn setup() -> Result<()> {
     Timestamp::setup()?;
+    unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) }
+        .ok()
+        .context("com init")?;
     Ok(())
 }

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -124,7 +124,7 @@ impl AppInfo {
 pub fn random_color() -> String {
     // ref: https://github.com/catppuccin/catppuccin
     // Mocha colors
-    let mut rng = ThreadRng::default();
+    let mut rng = rand::thread_rng();
 
     [
         "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7", "#f38ba8", "#eba0ac", "#fab387", "#f9e2af",

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -1,6 +1,5 @@
 use std::mem::swap;
 
-use rand::rngs::ThreadRng;
 use rand::seq::IndexedMutRandom;
 use util::error::{Context, Result};
 use util::tracing::ResultTraceExt;
@@ -124,7 +123,7 @@ impl AppInfo {
 pub fn random_color() -> String {
     // ref: https://github.com/catppuccin/catppuccin
     // Mocha colors
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     [
         "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7", "#f38ba8", "#eba0ac", "#fab387", "#f9e2af",

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -1,5 +1,7 @@
 use std::mem::swap;
 
+use rand::rngs::ThreadRng;
+use rand::seq::IndexedMutRandom;
 use util::error::{Context, Result};
 use util::tracing::ResultTraceExt;
 use windows::core::AgileReference;
@@ -19,6 +21,8 @@ pub struct AppInfo {
     pub description: String,
     /// Company
     pub company: String,
+    /// Color
+    pub color: String,
     /// Logo as bytes
     pub logo: Option<Vec<u8>>,
 }
@@ -54,6 +58,7 @@ impl AppInfo {
             name,
             description,
             company: fv.query_value("CompanyName").warn(),
+            color: random_color(),
             logo,
         })
     }
@@ -73,6 +78,7 @@ impl AppInfo {
             name: display_info.DisplayName()?.to_string_lossy(),
             description: display_info.Description()?.to_string_lossy(),
             company: package.PublisherDisplayName()?.to_string_lossy(),
+            color: random_color(),
             logo,
         })
     }
@@ -112,6 +118,21 @@ impl AppInfo {
         reader.ReadBytes(&mut logo)?;
         Ok(logo)
     }
+}
+
+/// Generate a random color
+pub fn random_color() -> String {
+    // ref: https://github.com/catppuccin/catppuccin
+    // Mocha colors
+    let mut rng = ThreadRng::default();
+
+    [
+        "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7", "#f38ba8", "#eba0ac", "#fab387", "#f9e2af",
+        "#a6e3a1", "#94e2d5", "#89dceb", "#74c7ec", "#89b4fa", "#b4befe", "#cdd6f4", // Text
+    ]
+    .choose_mut(&mut rng)
+    .unwrap()
+    .to_string()
 }
 
 #[cfg(test)]

--- a/src/platform/src/objects/browser.rs
+++ b/src/platform/src/objects/browser.rs
@@ -1,0 +1,53 @@
+use util::error::Result;
+use windows::core::VARIANT;
+use windows::Win32::System::Com::StructuredStorage::{
+    PropVariantToStringAlloc, VariantToPropVariant,
+};
+use windows::Win32::System::Com::{CoCreateInstance, CoTaskMemFree, CLSCTX_ALL};
+use windows::Win32::UI::Accessibility::{
+    CUIAutomation, IUIAutomation, TreeScope_Descendants, UIA_ControlTypePropertyId,
+    UIA_DocumentControlTypeId, UIA_ValueValuePropertyId,
+};
+
+use crate::objects::Window;
+
+/// Detects browser usage information
+pub struct BrowserDetector {
+    automation: IUIAutomation,
+}
+
+impl BrowserDetector {
+    /// Create a new [BrowserDetector]
+    pub fn new() -> Result<Self> {
+        let automation: IUIAutomation =
+            unsafe { CoCreateInstance(&CUIAutomation, None, CLSCTX_ALL)? };
+        Ok(Self { automation })
+    }
+
+    /// Check if the [Window] is a Chromium browser
+    pub fn is_chromium(&self, window: &Window) -> Result<bool> {
+        let class = window.class()?;
+        Ok(class == "Chrome_WidgetWin_1")
+    }
+
+    /// Get the URL of the [Window], assuming it is a Chromium browser
+    pub fn chromium_url(&self, window: &Window) -> Result<String> {
+        let element = unsafe { self.automation.ElementFromHandle(window.hwnd)? };
+
+        let variant: VARIANT = UIA_DocumentControlTypeId.0.into();
+        let condition = unsafe {
+            self.automation
+                .CreatePropertyCondition(UIA_ControlTypePropertyId, &variant)?
+        };
+        let element = unsafe { element.FindFirst(TreeScope_Descendants, &condition)? };
+
+        let url_prop = unsafe { element.GetCurrentPropertyValue(UIA_ValueValuePropertyId)? };
+        let url_prop = unsafe { VariantToPropVariant(&url_prop)? };
+        let url_raw = unsafe { PropVariantToStringAlloc(&url_prop)? };
+        // This is a copy, so we are free to CoTaskMemFree the url_raw in the next line
+        let url = String::from_utf16_lossy(unsafe { url_raw.as_wide() });
+        unsafe { CoTaskMemFree(Some(url_raw.as_ptr().cast())) };
+
+        Ok(url)
+    }
+}

--- a/src/platform/src/objects/browser.rs
+++ b/src/platform/src/objects/browser.rs
@@ -24,6 +24,12 @@ impl BrowserDetector {
         Ok(Self { automation })
     }
 
+    /// Check if the path is a browser
+    pub fn is_browser(path: &str) -> bool {
+        let browsers = ["chrome.exe", "msedge.exe"];
+        browsers.iter().any(|browser| path.ends_with(browser))
+    }
+
     /// Check if the [Window] is a Chromium browser
     pub fn is_chromium(&self, window: &Window) -> Result<bool> {
         let class = window.class()?;

--- a/src/platform/src/objects/browser.rs
+++ b/src/platform/src/objects/browser.rs
@@ -59,6 +59,10 @@ impl BrowserDetector {
         let url = String::from_utf16_lossy(unsafe { url_raw.as_wide() });
         unsafe { CoTaskMemFree(Some(url_raw.as_ptr().cast())) };
 
-        Ok(Some(url))
+        if url.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(url))
+        }
     }
 }

--- a/src/platform/src/objects/browser.rs
+++ b/src/platform/src/objects/browser.rs
@@ -27,7 +27,8 @@ impl BrowserDetector {
     /// Check if the path is a browser
     pub fn is_browser(path: &str) -> bool {
         let browsers = ["chrome.exe", "msedge.exe"];
-        browsers.iter().any(|browser| path.ends_with(browser))
+        let path_lower = path.to_lowercase();
+        browsers.iter().any(|browser| path_lower.ends_with(browser))
     }
 
     /// Check if the [Window] is a Chromium browser

--- a/src/platform/src/objects/mod.rs
+++ b/src/platform/src/objects/mod.rs
@@ -8,6 +8,7 @@ mod timer;
 mod timestamp;
 mod toast;
 mod user;
+mod website_info;
 mod window;
 mod windows_hook;
 
@@ -21,5 +22,6 @@ pub use timer::*;
 pub use timestamp::*;
 pub use toast::*;
 pub use user::*;
+pub use website_info::*;
 pub use window::*;
 pub use windows_hook::*;

--- a/src/platform/src/objects/mod.rs
+++ b/src/platform/src/objects/mod.rs
@@ -1,4 +1,5 @@
 mod app_info;
+mod browser;
 mod event_loop;
 mod file_version_info;
 mod message_window;
@@ -11,6 +12,7 @@ mod window;
 mod windows_hook;
 
 pub use app_info::*;
+pub use browser::*;
 pub use event_loop::*;
 pub use file_version_info::*;
 pub use message_window::*;

--- a/src/platform/src/objects/website_info.rs
+++ b/src/platform/src/objects/website_info.rs
@@ -1,0 +1,178 @@
+use reqwest::{Client, Url};
+use scraper::{Html, Selector};
+use util::error::{Context, Result};
+use util::tracing::ResultTraceExt;
+
+use super::AppInfo;
+
+/// Information about a Website
+pub struct WebsiteInfo {
+    /// Name
+    pub name: String,
+    /// Description
+    pub description: String,
+    /// Logo as bytes
+    pub logo: Option<Vec<u8>>,
+}
+
+/// Website URL down to origin
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BaseWebsiteUrl {
+    /// HTTP(S) URL
+    Http(String),
+    /// file://, chrome://, about:blank, etc.
+    NonHttp(String),
+}
+
+impl BaseWebsiteUrl {
+    /// Convert a base URL to a string
+    pub fn to_string(&self) -> String {
+        match self {
+            BaseWebsiteUrl::Http(url) => url.clone(),
+            BaseWebsiteUrl::NonHttp(url) => url.clone(),
+        }
+    }
+}
+
+impl WebsiteInfo {
+    /// Convert a URL to a base URL
+    pub fn url_to_base_url(url: &str) -> Result<BaseWebsiteUrl> {
+        Ok(if let Ok(url) = Url::parse(url) {
+            if url.scheme() == "https" || url.scheme() == "http" {
+                BaseWebsiteUrl::Http(url.origin().unicode_serialization())
+            } else {
+                BaseWebsiteUrl::NonHttp(url.to_string())
+            }
+        } else {
+            BaseWebsiteUrl::NonHttp(url.to_string())
+        })
+    }
+
+    /// Create a new [WebsiteInfo] from a base URL
+    pub async fn from_base_url(base_url: BaseWebsiteUrl) -> Result<Self> {
+        let url = match base_url {
+            BaseWebsiteUrl::Http(url) => url,
+            BaseWebsiteUrl::NonHttp(url) => {
+                return Ok(WebsiteInfo {
+                    name: url.clone(),
+                    description: url,
+                    logo: None,
+                });
+            }
+        };
+
+        let client = Client::new();
+
+        // Get Open Graph tags + Meta information
+        let (description, site_name, logo_url) = {
+            let response = client.get(&url).send().await?;
+            let html = response.text().await?;
+            let document = Html::parse_document(&html);
+
+            let mut site_name = Self::get_site_name(&url, &document)
+                .context("get site name")
+                .warn();
+            if site_name == String::default() {
+                site_name = url.to_string();
+            }
+
+            let description = Self::get_description(&document)
+                .context("get description")
+                .warn();
+            let logo_url = Self::get_logo_url(&url, &document).context("get logo url");
+            (description, site_name, logo_url)
+        };
+
+        // Get logo. If it fails, then logo is None.
+        let logo = match logo_url {
+            Ok(logo_url) => Self::get_logo(&client, logo_url)
+                .await
+                .map(|logo| Some(logo))
+                .context("get logo")
+                .warn(),
+            logo_url => {
+                logo_url.map(|_| "").warn();
+                None
+            }
+        };
+
+        Ok(WebsiteInfo {
+            name: site_name,
+            description,
+            logo,
+        })
+    }
+
+    /// Get the description of the website
+    pub fn get_description(document: &Html) -> Result<String> {
+        let og_description = document
+            .select(&Selector::parse("meta[property='og:description']").unwrap())
+            .next();
+        if let Some(og_description) = og_description {
+            return Ok(og_description
+                .value()
+                .attr("content")
+                .unwrap_or_default()
+                .to_string());
+        }
+
+        let meta_description = document
+            .select(&Selector::parse("meta[name='description']").unwrap())
+            .next();
+        if let Some(meta_description) = meta_description {
+            return Ok(meta_description
+                .value()
+                .attr("content")
+                .unwrap_or_default()
+                .to_string());
+        }
+
+        Ok(String::new())
+    }
+
+    /// Get the name of the website
+    pub fn get_site_name(url: &str, document: &Html) -> Result<String> {
+        let og_site_name = document
+            .select(&Selector::parse("meta[property='og:site_name']").unwrap())
+            .next();
+        if let Some(og_site_name) = og_site_name {
+            return Ok(og_site_name
+                .value()
+                .attr("content")
+                .unwrap_or_default()
+                .to_string());
+        }
+        return Ok(url.to_string());
+    }
+
+    /// Get the logo URL of the website
+    pub fn get_logo_url(url: &str, document: &Html) -> Result<Url> {
+        let favicon_url = document
+            .select(&Selector::parse("link[rel='icon'], link[rel='shortcut icon']").unwrap())
+            .next()
+            .and_then(|el| el.value().attr("href").map(|s| s.to_string()))
+            .unwrap_or_else(|| "/favicon.ico".to_string());
+
+        let logo_url = Url::parse(&url)?.join(&favicon_url)?;
+        Ok(logo_url)
+    }
+
+    /// Get the logo of the website
+    pub async fn get_logo(client: &Client, logo_url: Url) -> Result<Vec<u8>> {
+        let response = client.get(logo_url).send().await?;
+        let bytes = response.bytes().await?;
+        Ok(bytes.to_vec())
+    }
+}
+
+impl From<WebsiteInfo> for AppInfo {
+    fn from(website: WebsiteInfo) -> Self {
+        AppInfo {
+            name: website.name,
+            description: website.description,
+            // TODO: company name does not exist for websites
+            company: "".to_string(),
+            logo: website.logo,
+        }
+    }
+}

--- a/src/platform/src/objects/website_info.rs
+++ b/src/platform/src/objects/website_info.rs
@@ -109,8 +109,8 @@ impl WebsiteInfo {
             let mut site_name = Self::get_site_name(&url, &document)
                 .context("get site name")
                 .warn();
-            if site_name == String::default() {
-                site_name = url.to_string();
+            if site_name.is_empty() {
+                site_name = Self::pretty_url_host(&url)?;
             }
 
             let description = Self::get_description(&document)

--- a/src/platform/src/objects/website_info.rs
+++ b/src/platform/src/objects/website_info.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use reqwest::{Client, RequestBuilder, Url};
 use scraper::{Html, Selector};
 use util::error::{Context, Result};
@@ -26,12 +28,11 @@ pub enum BaseWebsiteUrl {
     NonHttp(String),
 }
 
-impl BaseWebsiteUrl {
-    /// Convert a base URL to a string
-    pub fn to_string(&self) -> String {
+impl fmt::Display for BaseWebsiteUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BaseWebsiteUrl::Http(url) => url.clone(),
-            BaseWebsiteUrl::NonHttp(url) => url.clone(),
+            BaseWebsiteUrl::Http(url) => write!(f, "{}", url),
+            BaseWebsiteUrl::NonHttp(url) => write!(f, "{}", url),
         }
     }
 }
@@ -123,7 +124,7 @@ impl WebsiteInfo {
         let logo = match logo_url {
             Ok(logo_url) => Self::get_logo(&client, logo_url)
                 .await
-                .map(|logo| Some(logo))
+                .map(Option::Some)
                 .context("get logo")
                 .warn(),
             logo_url => {
@@ -206,7 +207,7 @@ impl WebsiteInfo {
             .and_then(|el| el.value().attr("href").map(|s| s.to_string()))
             .unwrap_or_else(|| "/favicon.ico".to_string());
 
-        let logo_url = Url::parse(&url)?.join(&favicon_url)?;
+        let logo_url = Url::parse(url)?.join(&favicon_url)?;
         Ok(logo_url)
     }
 

--- a/src/platform/src/objects/website_info.rs
+++ b/src/platform/src/objects/website_info.rs
@@ -3,7 +3,7 @@ use scraper::{Html, Selector};
 use util::error::{Context, Result};
 use util::tracing::ResultTraceExt;
 
-use super::AppInfo;
+use super::{random_color, AppInfo};
 
 /// Information about a Website
 pub struct WebsiteInfo {
@@ -11,6 +11,8 @@ pub struct WebsiteInfo {
     pub name: String,
     /// Description
     pub description: String,
+    /// Color
+    pub color: String,
     /// Logo as bytes
     pub logo: Option<Vec<u8>>,
 }
@@ -56,6 +58,7 @@ impl WebsiteInfo {
                 return Ok(WebsiteInfo {
                     name: url.clone(),
                     description: url,
+                    color: random_color(),
                     logo: None,
                 });
             }
@@ -99,6 +102,7 @@ impl WebsiteInfo {
         Ok(WebsiteInfo {
             name: site_name,
             description,
+            color: random_color(),
             logo,
         })
     }
@@ -172,6 +176,7 @@ impl From<WebsiteInfo> for AppInfo {
             description: website.description,
             // TODO: company name does not exist for websites
             company: "".to_string(),
+            color: website.color,
             logo: website.logo,
         }
     }

--- a/src/platform/src/objects/window.rs
+++ b/src/platform/src/objects/window.rs
@@ -27,7 +27,7 @@ use crate::win32;
 /// Representation of a [`Window`] on the user's desktop
 #[derive(Clone, PartialEq, Eq)]
 pub struct Window {
-    hwnd: HWND,
+    pub(crate) hwnd: HWND,
 }
 
 impl std::fmt::Debug for Window {

--- a/src/platform/src/objects/window.rs
+++ b/src/platform/src/objects/window.rs
@@ -7,8 +7,9 @@ use windows::Win32::System::Com::CoTaskMemFree;
 use windows::Win32::System::Com::StructuredStorage::PropVariantToStringAlloc;
 use windows::Win32::UI::Shell::PropertiesSystem::{IPropertyStore, SHGetPropertyStoreForWindow};
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
-    SetLayeredWindowAttributes, SetWindowLongW, GWL_EXSTYLE, LWA_ALPHA, WS_EX_LAYERED,
+    GetClassNameW, GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW,
+    GetWindowThreadProcessId, SetLayeredWindowAttributes, SetWindowLongW, GWL_EXSTYLE, LWA_ALPHA,
+    WS_EX_LAYERED,
 };
 
 use crate::buf::{buf, Buffer, WideBuffer};
@@ -84,6 +85,13 @@ impl Window {
             buf.with_length(written as usize).to_string_lossy()
         };
         Ok(title)
+    }
+
+    /// Get the class name of the [Window]
+    pub fn class(&self) -> Result<String> {
+        let mut buf = buf(256);
+        let written = win32!(val: unsafe { GetClassNameW(self.hwnd, buf.as_bytes()) })?;
+        Ok(buf.with_length(written as usize).to_string_lossy())
     }
 
     /// Get the [AUMID](https://learn.microsoft.com/en-us/windows/win32/shell/appids) of the [Window]

--- a/src/ui/app/components/viz/gantt.tsx
+++ b/src/ui/app/components/viz/gantt.tsx
@@ -374,6 +374,11 @@ export function Gantt({
           {hoverUsage?.session && (
             <div className="flex flex-col">
               <Text>{hoverUsage.session.title}</Text>
+              {hoverUsage.session.url && (
+                <Text className="text-muted-foreground text-xs">
+                  {hoverUsage.session.url}
+                </Text>
+              )}
               <div className="flex items-center text-muted-foreground gap-1 text-xs">
                 <DateTimeText ticks={hoverUsage.session.start} /> -
                 <DateTimeText ticks={hoverUsage.session.end} />
@@ -503,7 +508,11 @@ export function Gantt({
                       key={session.id}
                       className="p-4 border-t border-r h-[68px]"
                     >
-                      <Text className="text-sm">{session.title}</Text>
+                      <Text className="text-sm">
+                        {session.url
+                          ? `${session.title} - ${session.url}`
+                          : session.title}
+                      </Text>
                       <div className="text-xs text-muted-foreground">
                         {formatTime(
                           ticksToDateTime(session.start),

--- a/src/ui/app/components/viz/gantt.tsx
+++ b/src/ui/app/components/viz/gantt.tsx
@@ -486,9 +486,9 @@ export function Gantt({
                   onClick={() => toggleApp(app.id)}
                 >
                   {expanded[app.id] ? (
-                    <ChevronDown size={20} />
+                    <ChevronDown size={20} className="flex-shrink-0" />
                   ) : (
-                    <ChevronRight size={20} />
+                    <ChevronRight size={20} className="flex-shrink-0" />
                   )}
                   <AppIcon
                     buffer={app.icon}

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -46,6 +46,7 @@ export interface App {
 export interface Session {
   id: Ref<Session>;
   title: string;
+  url?: string;
   start: Timestamp;
   end: Timestamp;
   usages: Usage[];

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -22,7 +22,8 @@ export interface WithGroupedDuration<T> {
 
 export type AppIdentity =
   | { tag: "uwp"; aumid: string }
-  | { tag: "win32"; path: string };
+  | { tag: "win32"; path: string }
+  | { tag: "website"; baseUrl: string };
 
 export interface ValuePerPeriod<T> {
   today: T;

--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -165,10 +165,12 @@ function AlertListItem({ alert }: { alert: Alert }) {
                 {appTag && <MiniTagItem tag={appTag} />}
               </div>
               <span className="inline-flex gap-1 items-center text-xs text-card-foreground/50">
-                <Text className="max-w-48">{app.company}</Text>
+                {app.identity.tag !== "website" && (
+                  <Text className="max-w-48">{app.company}</Text>
+                )}
                 {app.description && (
                   <>
-                    <p>|</p>
+                    {app.identity.tag !== "website" && <p>|</p>}
                     <Text className="max-w-[40rem]">{app.description}</Text>
                   </>
                 )}

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -156,7 +156,9 @@ export default function App({ params }: Route.ComponentProps) {
                       className="min-w-0"
                     />
                   </div>
-                  <Text className="text-muted-foreground">{app.company}</Text>
+                  {app.identity.tag !== "website" && (
+                    <Text className="text-muted-foreground">{app.company}</Text>
+                  )}
                 </div>
                 <div className="flex-1" />
                 <ColorPicker
@@ -181,13 +183,19 @@ export default function App({ params }: Route.ComponentProps) {
               {/* App Identity */}
               <div className="text-sm inline-flex border-border border rounded-lg overflow-hidden max-w-fit min-w-0 bg-muted/30 items-center">
                 <div className="bg-muted px-3 py-1.5 border-r border-border font-medium">
-                  {app.identity.tag === "uwp" ? "UWP" : "Win32"}
+                  {app.identity.tag === "uwp"
+                    ? "UWP"
+                    : app.identity.tag === "win32"
+                      ? "Win32"
+                      : "Web"}
                 </div>
 
                 <Text className="font-mono pl-3 pr-1 py-1.5 text-muted-foreground">
                   {app.identity.tag === "uwp"
                     ? app.identity.aumid
-                    : app.identity.path}
+                    : app.identity.tag === "win32"
+                      ? app.identity.path
+                      : app.identity.baseUrl}
                 </Text>
                 <Button
                   variant="ghost"
@@ -196,7 +204,9 @@ export default function App({ params }: Route.ComponentProps) {
                     copy(
                       app.identity.tag === "uwp"
                         ? app.identity.aumid
-                        : app.identity.path,
+                        : app.identity.tag === "win32"
+                          ? app.identity.path
+                          : app.identity.baseUrl,
                     )
                   }
                 >

--- a/src/ui/app/routes/apps/index.tsx
+++ b/src/ui/app/routes/apps/index.tsx
@@ -254,10 +254,12 @@ function AppListItem({
           {tag && <MiniTagItem tag={tag} />}
         </div>
         <span className="inline-flex gap-1 items-center text-xs text-card-foreground/50">
-          <Text className="max-w-48">{app.company}</Text>
+          {app.identity.tag !== "website" && (
+            <Text className="max-w-48">{app.company}</Text>
+          )}
           {app.description && (
             <>
-              <p>|</p>
+              {app.identity.tag !== "website" && <p>|</p>}
               <Text className="max-w-[40rem]">{app.description}</Text>
             </>
           )}

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -159,7 +159,8 @@ pub async fn copy_from_seed_db(state: State<'_, AppState>) -> AppResult<()> {
 
     remove_db_files()?;
 
-    std::fs::copy("../../../dev/seed.db", "main.db").context("copy seed.db")?;
+    let to_file = util::config::Config::config_path("main.db")?;
+    std::fs::copy("../../../dev/seed.db", to_file).context("copy seed.db")?;
 
     // reinit state (repo)
     init_state(state).await?;

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -104,6 +104,9 @@ fn extract_query_content_connection_string() -> Result<()> {
 #[test]
 fn extract_engine_log_filter() -> Result<()> {
     let config = get_config()?;
-    assert_eq!("Debug", config.engine_log_filter());
+    assert_eq!(
+        "Debug,selectors=info,html5ever=info",
+        config.engine_log_filter()
+    );
     Ok(())
 }


### PR DESCRIPTION
# Add Website Tracking Support

This PR adds support for tracking websites.

## Features

- Add website detection and tracking for Chromium-based browsers
- Extract website information (title, URL, favicon) from browser sessions
- Add `Website` enum variant to `AppIdentity` alongside existing Win32 and UWP types
- Add URL field to Session data structure
- Implement browser detection to identify Chrome, Edge.
- Extract website metadata using scraper and reqwest
- Cache browser information across sessions for better performance
- Display website information in UI (gantt chart, app details)
- Improve site name handling for empty URLs
- Move color generation to platform layer

## UI Improvements

- Show session URL information in gantt chart
- Make gantt chart chevrons flex-shrink to prevent layout issues
- Hide empty URLs in UI
- Adapt app details view to show website-specific information