### PR TITLE
ECharts Pie Chart

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.19.0",
         "vite": "^5.4.11",
+        "vite-plugin-devtools-json": "^0.1.0",
         "vite-tsconfig-paths": "^5.1.4",
       },
     },
@@ -1331,6 +1332,8 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
     "valibot": ["valibot@0.41.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
@@ -1344,6 +1347,8 @@
     "vite": ["vite@5.4.11", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q=="],
 
     "vite-node": ["vite-node@3.0.0-beta.2", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.0", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0 || ^6.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg=="],
+
+    "vite-plugin-devtools-json": ["vite-plugin-devtools-json@0.1.0", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" } }, "sha512-KvdgPBUAAhwnpOgXmJhs6KI4/IPn6xUppLGm20D0Uvp/doZ9TpTYYfzSHX0TgvdsSlTAwzZfzDse+ujGskp68g=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 

--- a/src/ui/app/components/viz/app-usage-pie.tsx
+++ b/src/ui/app/components/viz/app-usage-pie.tsx
@@ -1,0 +1,317 @@
+import type { App, Tag, Ref, WithDuration } from "@/lib/entities";
+import { untagged, useAppState, type EntityMap } from "@/lib/state";
+import type { ClassValue } from "clsx";
+import { useTheme } from "@/components/theme-provider";
+import { useApps, useRefresh, useTags } from "@/hooks/use-refresh";
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as echarts from "echarts";
+import _ from "lodash";
+import { Tooltip } from "@/components/viz/tooltip";
+import { AppUsageChartTooltipContent } from "./app-usage-chart-tooltip";
+import { DateTime } from "luxon";
+import { cn } from "@/lib/utils";
+import { DEFAULT_ICON_SVG_URL } from "../app/app-icon";
+import { toDataUrl } from "../app/app-icon";
+
+interface GlobalModel {
+  getSeriesByIndex: (index: number) => echarts.SeriesModel;
+}
+
+interface RadiusAxis {
+  dataToRadius: (data: number) => number;
+  polar: PolarAxis;
+}
+
+interface PolarAxis {
+  getAngleAxis: () => AngleAxis;
+}
+
+interface AngleAxis {
+  dataToAngle: (data: number) => number;
+}
+export interface AppUsagePieChartProps {
+  data: EntityMap<App, WithDuration<App>>;
+  // apps to highlight, order them by index in array. will be drawn left to right = top to bottom. unhighlighted apps will be drawn on top of highlighted apps.
+  highlightedAppIds?: Ref<App>[];
+  unhighlightedAppOpacity?: number;
+  hideApps?: Record<Ref<App>, boolean>;
+  animationsEnabled?: boolean;
+
+  className?: ClassValue;
+  onHover?: (data?: WithDuration<App>) => void;
+  onTagHover?: (data?: Tag) => void;
+}
+
+export function AppUsagePieChart({
+  data,
+  highlightedAppIds,
+  unhighlightedAppOpacity = 0.3,
+  hideApps,
+  animationsEnabled = true,
+  className,
+  onHover,
+}: AppUsagePieChartProps) {
+  const { theme } = useTheme();
+
+  const [hoverSeries, setHoverSeries] = useState<EntityMap<App, number>>({});
+  const [hoveredData, setHoveredData] = useState<{
+    date: DateTime;
+    appId?: Ref<App>;
+  } | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstanceRef = useRef<echarts.ECharts | null>(null);
+
+  const appIds = useMemo(
+    () => Object.keys(data).map((id) => +id as Ref<App>),
+    [data],
+  );
+  const apps = useApps(appIds);
+  const tags = useTags();
+
+  const totalUsage = useMemo(() => {
+    return _(apps)
+      .filter((app) => !hideApps?.[app.id])
+      .reduce((sum, app) => sum + (data[app.id]?.duration ?? 0), 0);
+  }, [apps, data, hideApps]);
+
+  const payload = useMemo(() => {
+    return _.mapValues(data, (duration) => duration?.duration ?? 0);
+  }, [data]);
+
+  const tagPayload = useMemo(() => {
+    return _(apps)
+      .map((app) => [app.tagId ?? -1, data[app.id]?.duration ?? 0])
+      .groupBy(0)
+      .mapValues((x) => x.reduce((sum, [, duration]) => sum + duration, 0))
+      .value();
+  }, [apps, data]);
+
+  const appData = useMemo(() => {
+    return _(apps)
+      .filter((app) => !hideApps?.[app.id])
+      .map((app) => ({
+        ...app,
+        duration: data[app.id]?.duration ?? 0,
+      }))
+      .filter((app) => app.duration > 0)
+      .orderBy(["tagId", "duration"], ["asc", "desc"])
+      .value();
+  }, [apps, data, hideApps]);
+
+  const tagData = useMemo(() => {
+    // Get all tagged apps
+    const taggedAppIds = new Set(tags.flatMap((tag) => tag.apps));
+
+    // Calculate untagged duration
+    const untaggedDuration = apps
+      .filter((app) => !taggedAppIds.has(app.id) && !hideApps?.[app.id])
+      .reduce((sum, app) => sum + (data[app.id]?.duration ?? 0), 0);
+
+    // Create tag data including untagged
+    const tagData = [
+      // Tags
+      ...tags.map((tag) => ({
+        ...tag,
+        duration: _(tag.apps)
+          .map((appId) => data[appId]?.duration ?? 0)
+          .sum(),
+      })),
+      // Add untagged category if there are untagged apps
+      ...(untaggedDuration > 0
+        ? [
+            {
+              ...untagged,
+              duration: untaggedDuration,
+            },
+          ]
+        : []),
+    ].filter((tag) => tag.duration > 0);
+
+    return tagData;
+  }, [tags, apps, data, hideApps]);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    const chart = echarts.init(chartRef.current, undefined, {});
+    chartInstanceRef.current = chart;
+
+    const tagSeries = tagData
+      .filter((tag) => tag.duration)
+      .map(
+        (tag) =>
+          ({
+            type: "bar",
+            coordinateSystem: "polar",
+            stack: "tags",
+            data: [
+              {
+                id: tag.id,
+                name: tag.name,
+                value: tag.duration,
+                itemStyle: {
+                  color: tag.color,
+                },
+              },
+            ],
+          }) satisfies echarts.SeriesOption,
+      );
+
+    const appSeries = appData
+      .filter((app) => app.duration)
+      .map(
+        (app) =>
+          ({
+            type: "bar",
+            coordinateSystem: "polar",
+            stack: "apps",
+            labelLayout(params) {
+              const model = (chart["getModel"] as () => GlobalModel)();
+              const series = model.getSeriesByIndex(params.seriesIndex);
+              const radiusAxis = series.getBaseAxis() as unknown as RadiusAxis;
+              const value = series.getRawValue(params.dataIndex!);
+              const radius = radiusAxis.dataToRadius(value as number);
+              const angleAxis = radiusAxis.polar.getAngleAxis();
+              const angle =
+                angleAxis.dataToAngle(0) -
+                angleAxis.dataToAngle(value as number);
+
+              // const radiusDiff = outerRadius - innerRadius;
+              const radiusDiff = 0.35 * radius; // TODO use a better way
+
+              const percent = angle;
+
+              const angleLengthValue = (percent / 360) * 2 * Math.PI * radius;
+              const maxSize =
+                Math.min(radiusDiff, angleLengthValue) * Math.SQRT1_2;
+              const size = Math.max(Math.min(maxSize * 0.9, 32), 0); // 10% padding
+
+              console.log(
+                value,
+                radius,
+                angle,
+                angleLengthValue,
+                size,
+                radiusAxis,
+                angleAxis,
+                series,
+              );
+              return {
+                width: size,
+                height: size,
+              };
+            },
+            data: [
+              {
+                id: app.id,
+                name: app.name,
+                value: app.duration,
+                itemStyle: {
+                  color: app.color,
+                },
+                label: {
+                  show: true,
+                  rotate: 0,
+                  position: "middle",
+                  backgroundColor: {
+                    image: toDataUrl(app.icon) ?? DEFAULT_ICON_SVG_URL,
+                  },
+                  formatter: () => {
+                    return `{empty|}`;
+                  },
+                  rich: {
+                    empty: {},
+                  },
+                },
+              },
+            ],
+          }) satisfies echarts.SeriesOption,
+      );
+
+    const option: echarts.EChartsOption = {
+      animation: animationsEnabled,
+      // animationDuration: 300,
+
+      angleAxis: {
+        max: "dataMax",
+        show: false,
+      },
+      polar: {
+        radius: ["30%", "90%"],
+      },
+      radiusAxis: {
+        type: "category",
+        data: ["tags"],
+        show: false,
+      },
+      tooltip: {
+        trigger: "item",
+      },
+      series: [...tagSeries, ...appSeries],
+    } satisfies echarts.EChartsOption;
+
+    // chart.getZr().on("mousemove", (params) => {
+    //   const pos = [params.offsetX, params.offsetY];
+    //   const isInGrid = chart.containPixel("grid", pos);
+    //   if (isInGrid) {
+    //     const pointerData = chart.convertFromPixel("grid", pos);
+    //     setHoveredData({
+    //       date: ticksToDateTime(xaxisRange[pointerData[0]]),
+    //     });
+    //   } else if (!isInGrid) {
+    //     setHoveredData(null);
+    //     onHover?.(undefined);
+    //   }
+    // });
+
+    // chart.on("mousemove", (params) => {
+    //   const appId = +(params.seriesId ?? 0) as Ref<App>;
+    //   setHoveredData({ date: ticksToDateTime(+params.name), appId });
+    //   if (onHover) {
+    //     onHover({
+    //       id: appId,
+    //       duration: params.value as number,
+    //       group: params.axisValue as number,
+    //     });
+    //   }
+    // });
+
+    const resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(() => chart.resize());
+    });
+
+    chart.on("finished", () => {
+      resizeObserver.observe(chartRef.current!);
+    });
+
+    chart.setOption(option);
+
+    return () => {
+      chart.dispose();
+      resizeObserver.disconnect();
+    };
+  }, [
+    data,
+    appData,
+    tagData,
+    onHover,
+    animationsEnabled,
+    highlightedAppIds,
+    unhighlightedAppOpacity,
+    theme,
+  ]);
+
+  return (
+    <div ref={chartRef} className={cn("w-full h-full", className)}>
+      <Tooltip targetRef={chartRef} show={!!hoveredData}>
+        <AppUsageChartTooltipContent
+          hoveredAppId={hoveredData?.appId ?? null}
+          payload={hoverSeries}
+          dt={hoveredData?.date ?? DateTime.fromSeconds(0)}
+          maximumApps={10}
+          highlightedAppIds={highlightedAppIds}
+        />
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -99,7 +99,7 @@ export function VerticalLegend({
       setUncheckedApps((prev) => {
         const newState = { ...prev };
         apps
-          .filter((app) => app.tagId === id)
+          .filter((app) => app.tagId === (id === untagged.id ? null : id))
           .forEach((app) => {
             newState[app.id] = !checked;
           });
@@ -188,7 +188,9 @@ export function VerticalLegend({
       // Add apps under this tag if expanded
       if (!unexpandedTags[tagIdStr]) {
         filteredApps
-          .filter((app) => app.tagId === tag.id)
+          .filter(
+            (app) => app.tagId === (tag.id === untagged.id ? null : tag.id),
+          )
           .forEach((app) => {
             data.push({
               id: `app-${app.id}`,

--- a/src/ui/app/lib/state.ts
+++ b/src/ui/app/lib/state.ts
@@ -51,7 +51,7 @@ export async function refresh() {
 }
 
 export const untagged: Tag = {
-  id: null as unknown as Ref<Tag>,
+  id: -1 as unknown as Ref<Tag>,
   name: "Untagged",
   color: "#6B7280", // gray-500
   score: 0,

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -90,6 +90,7 @@
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.19.0",
     "vite": "^5.4.11",
+    "vite-plugin-devtools-json": "^0.1.0",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/postcss";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "path";
+import devToolsJson from "vite-plugin-devtools-json";
 
 const host = process.env.TAURI_DEV_HOST;
 
@@ -32,7 +33,7 @@ export default defineConfig({
       plugins: [tailwindcss()],
     },
   },
-  plugins: [reactRouter(), tsconfigPaths()],
+  plugins: [reactRouter(), tsconfigPaths(), devToolsJson()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./app"),


### PR DESCRIPTION
# Add App Usage Pie Chart Component

This PR introduces a new `AppUsagePieChart` component that visualizes app usage data using echarts. The chart features:

- Concentric polar charts showing both tag and app usage
- Interactive tooltips for both apps and tags
- App icons displayed within the chart
- Ability to highlight specific apps
- Customizable opacity for non-highlighted apps
- Event handlers for app and tag hover states

Additionally, this PR fixes the handling of untagged apps in the `VerticalLegend` component and updates the `untagged` constant to use a specific ID (-1) instead of null.