### PR TITLE
Better Chromium Url Detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,7 @@ dependencies = [
  "rand 0.9.1",
  "reqwest",
  "scraper",
+ "url",
  "util",
  "windows 0.56.0",
 ]

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 rand = "0.9.1"
 reqwest = "0.12.15"
 scraper = "0.23.1"
+url = "2.5.4"
 util = { path = "../util" }
 
 [dependencies.windows]


### PR DESCRIPTION
# Improved Browser URL Detection

This PR enhances browser URL detection with several improvements:

- Searches through all document elements instead of just the first one
- Extracts the `variant_to_string` helper method to reduce code duplication
- Falls back to the address/search bar (omnibox) when no document is available
- Adds proper URL parsing with the `url` crate to handle URLs without protocols
- Automatically prepends "https://" to URLs that are missing a protocol

These changes make the browser detection more robust, especially during page loading or when tabs are restored from energy-saving mode.