### PR TITLE
Improve error handling for app and website info retrieval

### DIFF
--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -1,4 +1,5 @@
 use std::mem::swap;
+use std::path::Path;
 
 use rand::seq::IndexedMutRandom;
 use util::error::{Context, Result};
@@ -32,6 +33,19 @@ pub const WIN32_IMAGE_SIZE: u32 = 64;
 pub const UWP_IMAGE_SIZE: f32 = 256.0;
 
 impl AppInfo {
+    /// Create a default [AppInfo] from a Win32 path
+    pub fn default_from_win32_path(path: &str) -> Self {
+        let path = Path::new(path);
+        let file = path.file_name().expect("file name").to_string_lossy();
+        Self {
+            name: file.to_string(),
+            description: file.to_string(),
+            company: "".to_string(),
+            color: random_color(),
+            logo: None,
+        }
+    }
+
     /// Create a new [AppInfo] of a Win32 program from its path
     pub async fn from_win32(path: &str) -> Result<Self> {
         let file = AgileReference::new(&StorageFile::GetFileFromPathAsync(&path.into())?.await?)?;


### PR DESCRIPTION
# Improve error handling for app and website info retrieval

This PR adds graceful fallbacks when retrieving app and website information fails:

- Adds default app info generation for Win32 applications when metadata can't be retrieved
- Adds default website info generation when website data can't be fetched
- Improves error handling in the resolver to continue with default values instead of failing
- Refactors `pretty_url_host` to handle parsing errors and return a string directly
- Adds warning logs when falling back to default information

These changes ensure the application continues to function even when metadata retrieval fails.