### PR TITLE
Browser DevTool

### DIFF
--- a/dev/tools/Cargo.toml
+++ b/dev/tools/Cargo.toml
@@ -19,6 +19,9 @@ dialoguer = "0.11.0"
 name = "dim"
 path = "src/bin/dim.rs" 
 
+[[bin]]
+name = "browser"
+path = "src/bin/browser.rs" 
 
 [[bin]]
 name = "kill"

--- a/dev/tools/src/bin/browser.rs
+++ b/dev/tools/src/bin/browser.rs
@@ -91,7 +91,27 @@ fn main() -> Result<()> {
         browsers.push(browser);
     }
 
-    dbg!(&browsers);
+    // Print out the browsers
+
+    for browser in &browsers {
+        for window in &browser.windows {
+            for tab in &window.tabs {
+                println!("{}", tab_to_string(tab, window, browser));
+            }
+        }
+    }
 
     Ok(())
+}
+
+fn tab_to_string(tab: &TabDetails, window: &BrowserWindow, browser: &Browser) -> String {
+    format!(
+        "{}{} - {} (hwnd: {:08x}) - {} (pid: {})",
+        tab.url.as_deref().unwrap_or("<UNKNOWN>"),
+        if tab.incognito { " [Incognito]" } else { "" },
+        window.window.title,
+        window.window.window.hwnd.0,
+        browser.process.name,
+        browser.process.pid
+    )
 }

--- a/dev/tools/src/bin/browser.rs
+++ b/dev/tools/src/bin/browser.rs
@@ -1,0 +1,29 @@
+//! List out browser information
+
+use clap::Parser;
+use util::error::Result;
+use util::{config, Target};
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Browser name
+    #[arg(long)]
+    app: Option<String>,
+
+    /// Browser window title
+    #[arg(long)]
+    title: Option<String>,
+}
+
+fn main() -> Result<()> {
+    util::set_target(Target::Engine);
+    let config = config::get_config()?;
+    util::setup(&config)?;
+    platform::setup()?;
+
+    let args = Args::parse();
+    dbg!(&args);
+
+    Ok(())
+}

--- a/dev/tools/src/bin/browser.rs
+++ b/dev/tools/src/bin/browser.rs
@@ -1,6 +1,10 @@
 //! List out browser information
 
 use clap::Parser;
+use platform::objects::BrowserDetector;
+use tools::filters::{
+    match_running_windows, ProcessDetails, ProcessFilter, WindowDetails, WindowFilter,
+};
 use util::error::Result;
 use util::{config, Target};
 
@@ -16,6 +20,24 @@ struct Args {
     title: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct Browser {
+    pub process: ProcessDetails,
+    pub windows: Vec<BrowserWindow>,
+}
+
+#[derive(Debug, Clone)]
+struct BrowserWindow {
+    pub window: WindowDetails,
+    pub tabs: Vec<TabDetails>,
+}
+
+#[derive(Debug, Clone)]
+struct TabDetails {
+    pub url: Option<String>,
+    pub incognito: bool,
+}
+
 fn main() -> Result<()> {
     util::set_target(Target::Engine);
     let config = config::get_config()?;
@@ -23,7 +45,53 @@ fn main() -> Result<()> {
     platform::setup()?;
 
     let args = Args::parse();
-    dbg!(&args);
+    let window_group = match_running_windows(
+        &WindowFilter {
+            title: args.title,
+            ..Default::default()
+        },
+        &ProcessFilter {
+            name: args.app,
+            ..Default::default()
+        },
+    )?;
+
+    let detect = BrowserDetector::new()?;
+
+    let mut browsers = vec![];
+    for window_group in window_group {
+        let mut browser_windows = vec![];
+        for window in window_group.windows {
+            if !detect.is_chromium(&window.window)? {
+                continue;
+            }
+            let info = detect.chromium_url(&window.window)?;
+
+            let browser_window = BrowserWindow {
+                window,
+                tabs: vec![TabDetails {
+                    url: info.url,
+                    incognito: info.incognito,
+                }],
+            };
+
+            browser_windows.push(browser_window);
+        }
+        if browser_windows.is_empty() {
+            continue;
+        }
+        if !BrowserDetector::is_browser(&window_group.process.path) {
+            continue;
+        }
+
+        let browser = Browser {
+            process: window_group.process,
+            windows: browser_windows,
+        };
+        browsers.push(browser);
+    }
+
+    dbg!(&browsers);
 
     Ok(())
 }

--- a/dev/tools/src/bin/dim.rs
+++ b/dev/tools/src/bin/dim.rs
@@ -3,12 +3,13 @@
 use clap::Parser;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
-use platform::objects::ProcessId;
+use platform::objects::{ProcessId, Window};
 use tools::filters::{
     match_running_windows, ProcessFilter, ProcessWindowGroup, WindowDetails, WindowFilter,
 };
 use util::error::Result;
 use util::{config, Target};
+use windows::Win32::Foundation::HWND;
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
@@ -52,6 +53,12 @@ fn main() -> Result<()> {
     platform::setup()?;
 
     let args = Args::parse();
+    if let Some(handle) = args.handle {
+        let handle = u32::from_str_radix(&handle, 16)?;
+        let window = Window::new(HWND(handle as _));
+        window.dim(args.opacity)?;
+        return Ok(());
+    }
     let matches = match_running_windows(
         &WindowFilter {
             handle: args.handle,

--- a/dev/tools/src/filters.rs
+++ b/dev/tools/src/filters.rs
@@ -7,6 +7,7 @@ use windows::core::HRESULT;
 use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
 
 /// Filter for a process
+#[derive(Debug, Clone, Default)]
 pub struct ProcessFilter {
     /// Process ID
     pub pid: Option<ProcessId>,


### PR DESCRIPTION
This PR adds a new `browser` binary tool that detects and lists information about running browser instances. The tool:

- Identifies Chromium-based browsers running on the system
- Displays detailed information about each browser tab including:
  - URL of the current page
  - Incognito status
  - Window title and handle
  - Process name and ID

The implementation leverages the existing `BrowserDetector` to identify browser windows and extract tab information.