### PR TITLE
Store icon file extensions as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,15 @@ dependencies = [
 
 [[package]]
 name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
+name = "infer"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
@@ -2710,6 +2719,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime2ext"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf6f36070878c42c5233846cd3de24cf9016828fd47bc22957a687298bb21fc"
 
 [[package]]
 name = "minimal-lexical"
@@ -3585,6 +3600,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "platform"
 version = "0.5.0"
 dependencies = [
+ "infer 0.15.0",
+ "mime2ext",
  "rand 0.9.1",
  "reqwest",
  "scraper",
@@ -5234,7 +5251,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "http",
- "infer",
+ "infer 0.16.0",
  "minisign-verify",
  "osakit",
  "percent-encoding",
@@ -5312,7 +5329,7 @@ dependencies = [
  "glob",
  "html5ever 0.26.0",
  "http",
- "infer",
+ "infer 0.16.0",
  "json-patch",
  "kuchikiki",
  "log",

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "lucide-static": "^0.477.0",
         "luxon": "^3.5.0",
         "parse-duration": "^2.1.2",
+        "path-normalize": "^6.0.13",
         "pretty-ms": "^9.2.0",
         "react": "^19.0.0",
         "react-colorful": "^5.6.1",
@@ -1075,6 +1076,8 @@
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-normalize": ["path-normalize@6.0.13", "", {}, "sha512-PfC1Pc+IEhI77UEN731pj2nMs9gHAV36IA6IW6VdXWjoQesf+jtO9hdMUqTRS6mwR0T5rmyUrQzd5vw0VwL1Lw=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,6 +14,7 @@ Cobalt is an application usage tracking tool that monitors window focus and appl
 The Threat Model is somewhat smaller since it's a desktop application (both UI and engine run as Medium IL, unprivileged programs) that doesn't store any data on a server (all data is local).
 
 The main threats that we consider are other unprivileged applications, through interaction of our app or modifications to the filesystem that Cobalt uses, cause system instability (e.g. system crashes), or privilege escalation.
+The other main threat is unsafe handling of icons, since we download them from visited websites and save them to disk / get them from running applications, as well as display it to the user in the UI (which is a webview). If there is a possible XSS by rendering website favicons in the webview, that is a reportable vulnerability (though we heavily mitigate this possibility).
 
 Leakage of usage data (main.db) by another unprivileged application is not considered a vulnerability - similar to Chrome's History SQLite files, other unprivileged applications can read it.
 

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -245,6 +245,7 @@ impl AppUpdater {
                     description = ?,
                     company = ?,
                     color = ?,
+                    icon = ?,
                     updated_at = ?,
                     initialized_at = ?
                 WHERE id = ?",
@@ -253,6 +254,7 @@ impl AppUpdater {
         .bind(&app.description)
         .bind(&app.company)
         .bind(&app.color)
+        .bind(&app.icon)
         .bind(ts.now().to_ticks())
         .bind(ts.now().to_ticks())
         .bind(&app.id)

--- a/src/data/src/entities.rs
+++ b/src/data/src/entities.rs
@@ -21,6 +21,8 @@ pub struct App {
     pub company: String,
     /// Color
     pub color: Color,
+    /// File name of the app's icon (with extension)
+    pub icon: Option<String>,
     #[sqlx(flatten)]
     /// Unique identity of an [App]
     pub identity: AppIdentity,

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -39,6 +39,7 @@ impl Migration for Migration1 {
                 description                     TEXT,
                 company                         TEXT,
                 color                           TEXT,
+                icon                            TEXT,
                 tag_id                          INTEGER REFERENCES tags(id) ON DELETE SET NULL,
                 identity_tag                    INTEGER NOT NULL,
                 identity_text0                  TEXT NOT NULL,

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -48,10 +48,10 @@ impl AppInfoResolver {
         let mut updater = AppUpdater::new(db)?;
 
         // Store icon in filesystem if present
-        let icon = if let Some(icon_data) = app_info.icon {
+        let icon = if let Some(icon) = app_info.icon {
             let icons_dir = Config::icons_dir()?;
             let icon_path = Path::new(&icons_dir).join(app.0.to_string());
-            fs::write(&icon_path, icon_data).await?;
+            fs::write(&icon_path, icon.data).await?;
             Some(icon_path.to_string_lossy().to_string())
         } else {
             None

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -48,7 +48,7 @@ impl AppInfoResolver {
         let mut updater = AppUpdater::new(db)?;
 
         // Store icon in filesystem if present
-        let icon = if let Some(icon_data) = app_info.logo {
+        let icon = if let Some(icon_data) = app_info.icon {
             let icons_dir = Config::icons_dir()?;
             let icon_path = Path::new(&icons_dir).join(app.0.to_string());
             fs::write(&icon_path, icon_data).await?;

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -50,9 +50,12 @@ impl AppInfoResolver {
         // Store icon in filesystem if present
         let icon = if let Some(icon) = app_info.icon {
             let icons_dir = Config::icons_dir()?;
-            let icon_path = Path::new(&icons_dir).join(app.0.to_string());
+            let id = app.0.to_string();
+            let ext = icon.deduce_ext();
+            let file_name = format!("{}.{}", id, ext.unwrap_or("bin".to_string()));
+            let icon_path = Path::new(&icons_dir).join(&file_name);
             fs::write(&icon_path, icon.data).await?;
-            Some(icon_path.to_string_lossy().to_string())
+            Some(file_name)
         } else {
             None
         };

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -16,6 +16,8 @@ reqwest = "0.12.15"
 scraper = "0.23.1"
 url = "2.5.4"
 util = { path = "../util" }
+mime2ext = "0.1.52"
+infer = "0.15.0"
 
 [dependencies.windows]
 version = "0.56"

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -37,6 +37,30 @@ pub struct Icon {
     pub mime: Option<String>,
 }
 
+impl Icon {
+    /// Deduce the extension of the icon from the mime type or file magic bytes
+    pub fn deduce_ext(&self) -> Option<String> {
+        // First try explicit extension if available
+        if let Some(ext) = &self.ext {
+            return Some(ext.clone());
+        }
+
+        // Then try MIME type if available
+        if let Some(mime) = &self.mime {
+            if let Some(ext) = mime2ext::mime2ext(mime) {
+                return Some(ext.to_string());
+            }
+        }
+
+        // Finally try magic bytes detection
+        if let Some(kind) = infer::get(&self.data) {
+            return Some(kind.extension().to_string());
+        }
+
+        None
+    }
+}
+
 /// Image size for Win32 apps
 pub const WIN32_IMAGE_SIZE: u32 = 64;
 /// Image size for UWP apps

--- a/src/ui/app/components/alert/choose-target.tsx
+++ b/src/ui/app/components/alert/choose-target.tsx
@@ -140,7 +140,7 @@ export function ChooseTarget({
                   })}
                   onSelect={() => onValueChanged({ tag: "app", id: app.id })}
                 >
-                  <AppIcon id={app.id} className="w-4 h-4 shrink-0" />
+                  <AppIcon appIcon={app.icon} className="w-4 h-4 shrink-0" />
                   <Text>{app.name}</Text>
                   <MiniTagItem tagId={app.tagId} />
                 </CommandItem>
@@ -178,7 +178,7 @@ function ChooseTargetTrigger({
     >
       {value?.tag === "app" && app ? (
         <>
-          <AppIcon id={app.id} className="w-5 h-5 shrink-0" />
+          <AppIcon appIcon={app.icon} className="w-5 h-5 shrink-0" />
           <Text>{app.name}</Text>
         </>
       ) : value?.tag === "tag" && tag ? (

--- a/src/ui/app/components/app/app-icon.tsx
+++ b/src/ui/app/components/app/app-icon.tsx
@@ -5,16 +5,19 @@ import type { ClassValue } from "clsx";
 import { CircleHelp as CircleHelpStatic } from "lucide-static";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { iconsDir } from "@/lib/state";
+import normalize from "path-normalize";
 
 export const DEFAULT_ICON_SVG_URL = "data:image/svg+xml," + CircleHelpStatic;
 
-function appIconUrl(appIcon: string) {
-  return convertFileSrc(`${iconsDir}/${appIcon}`);
+function appIconUrl(appIcon?: string) {
+  if (!appIcon) return null;
+  const fileName = normalize(appIcon);
+  return convertFileSrc(`${iconsDir}/${fileName}`);
 }
 
-export function htmlImgElement(appIcon: string): HTMLImageElement {
+export function htmlImgElement(appIcon?: string): HTMLImageElement {
   const img = new Image();
-  img.src = appIconUrl(appIcon);
+  img.src = appIconUrl(appIcon) ?? DEFAULT_ICON_SVG_URL;
   img.onerror = () => {
     img.src = DEFAULT_ICON_SVG_URL;
     img.onerror = null;

--- a/src/ui/app/components/app/app-icon.tsx
+++ b/src/ui/app/components/app/app-icon.tsx
@@ -8,13 +8,13 @@ import { iconsDir } from "@/lib/state";
 
 export const DEFAULT_ICON_SVG_URL = "data:image/svg+xml," + CircleHelpStatic;
 
-export function toDataUrl(appId: number) {
-  return convertFileSrc(`${iconsDir}/${appId}`);
+function appIconUrl(appIcon: string) {
+  return convertFileSrc(`${iconsDir}/${appIcon}`);
 }
 
-export function htmlImgElement(appId: number): HTMLImageElement {
+export function htmlImgElement(appIcon: string): HTMLImageElement {
   const img = new Image();
-  img.src = toDataUrl(appId);
+  img.src = appIconUrl(appIcon);
   img.onerror = () => {
     img.src = DEFAULT_ICON_SVG_URL;
     img.onerror = null;
@@ -23,16 +23,16 @@ export function htmlImgElement(appId: number): HTMLImageElement {
 }
 
 export default function AppIcon({
-  id,
+  appIcon,
   className,
 }: {
-  id: number;
+  appIcon: string;
   className?: ClassValue;
 }) {
   const [hasError, setHasError] = useState(false);
   const icon = useMemo(() => {
-    return toDataUrl(id);
-  }, [id]);
+    return appIconUrl(appIcon);
+  }, [appIcon]);
 
   if (!icon || hasError) {
     return <CircleHelp className={cn(className)} />;

--- a/src/ui/app/components/app/app-list-item.tsx
+++ b/src/ui/app/components/app/app-list-item.tsx
@@ -12,7 +12,7 @@ export function AppBadge({ app, remove }: { app: App; remove?: () => void }) {
         backgroundColor: "rgba(255, 255, 255, 0.1)",
       }}
     >
-      <AppIcon id={app.id} className="h-5 w-5 mr-2" />
+      <AppIcon appIcon={app.icon} className="h-5 w-5 mr-2" />
       <Text className="text-base">{app.name}</Text>
       {remove && (
         <XIcon

--- a/src/ui/app/components/app/choose-multi-apps.tsx
+++ b/src/ui/app/components/app/choose-multi-apps.tsx
@@ -138,7 +138,7 @@ export function ChooseMultiApps({
                     <CheckIcon className="h-4 w-4" />
                   </div>
                   <AppIcon
-                    id={app.id}
+                    appIcon={app.icon}
                     className="mr-2 h-4 w-4 text-muted-foreground"
                   />
                   <Text>{app.name}</Text>

--- a/src/ui/app/components/viz/app-usage-chart-tooltip.tsx
+++ b/src/ui/app/components/viz/app-usage-chart-tooltip.tsx
@@ -23,7 +23,7 @@ function HoverCard({
 }) {
   return (
     <div className="flex items-center gap-2 py-2">
-      <AppIcon id={app.id} className="w-6 h-6 shrink-0 ml-2 mr-1" />
+      <AppIcon appIcon={app.icon} className="w-6 h-6 shrink-0 ml-2 mr-1" />
       <div className="flex flex-col">
         <Text className="text-base max-w-52">{app.name}</Text>
         {at && (
@@ -139,7 +139,10 @@ export const AppUsageChartTooltipContent = React.forwardRef<
                   >
                     <>
                       {!hideIndicator && (
-                        <AppIcon id={app.id} className="w-4 h-4 shrink-0" />
+                        <AppIcon
+                          appIcon={app.icon}
+                          className="w-4 h-4 shrink-0"
+                        />
                       )}
                       <div className="flex flex-1 justify-between items-center">
                         <div className="grid gap-1.5">

--- a/src/ui/app/components/viz/app-usage-chart.tsx
+++ b/src/ui/app/components/viz/app-usage-chart.tsx
@@ -244,7 +244,7 @@ export function AppUsageBarChart({
             show: !singleAppId,
             position: "inside",
             backgroundColor: {
-              image: htmlImgElement(app.id),
+              image: htmlImgElement(app.icon),
             },
             formatter: () => {
               return `{empty|}`;

--- a/src/ui/app/components/viz/app-usage-pie.tsx
+++ b/src/ui/app/components/viz/app-usage-pie.tsx
@@ -217,7 +217,7 @@ export function AppUsagePieChart({
                 rotate: 0,
                 position: "middle",
                 backgroundColor: {
-                  image: htmlImgElement(app.id),
+                  image: htmlImgElement(app.icon),
                 },
                 formatter: () => {
                   return `{empty|}`;

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -970,7 +970,7 @@ function AppInfoBar({
         ) : (
           <ChevronRight size={20} className="flex-shrink-0" />
         )}
-        <AppIcon id={app.id} className="ml-2 w-6 h-6 shrink-0" />
+        <AppIcon appIcon={app.icon} className="ml-2 w-6 h-6 shrink-0" />
         <Text className="font-semibold ml-4">{app.name}</Text>
       </div>
       <div className="h-px bg-border absolute bottom-[-0.5px] left-0 right-0" />

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -262,7 +262,7 @@ export function VerticalLegend({
               className="w-1 h-4 shrink-0 rounded-sm"
               style={{ backgroundColor: app.color }}
             />
-            <AppIcon id={app.id} className="h-4 w-4 shrink-0" />
+            <AppIcon appIcon={app.icon} className="h-4 w-4 shrink-0" />
             <Text className="text-sm text-muted-foreground">{app.name}</Text>
           </div>
         );

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -38,6 +38,7 @@ export interface App {
   company: string;
   color: Color;
   identity: AppIdentity;
+  icon: string;
   tagId: Ref<Tag> | null;
   usages: ValuePerPeriod<Duration>;
 }

--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -156,7 +156,7 @@ function AlertListItem({ alert }: { alert: Alert }) {
       <div className="h-20 flex items-center gap-2 p-4 @container">
         {alert.target.tag === "app" && app ? (
           <>
-            <AppIcon id={app.id} className="mx-2 h-10 w-10 shrink-0" />
+            <AppIcon appIcon={app.icon} className="mx-2 h-10 w-10 shrink-0" />
 
             <div className="flex flex-col min-w-0">
               <div className="inline-flex items-center gap-2">

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -123,7 +123,7 @@ export default function App({ params }: Route.ComponentProps) {
             <BreadcrumbSeparator className="hidden md:block" />
             <BreadcrumbItem>
               <BreadcrumbPage className="inline-flex items-center">
-                <AppIcon id={app.id} className="w-5 h-5 mr-2" />
+                <AppIcon appIcon={app.icon} className="w-5 h-5 mr-2" />
                 <Text>{app.name}</Text>
               </BreadcrumbPage>
             </BreadcrumbItem>
@@ -138,7 +138,7 @@ export default function App({ params }: Route.ComponentProps) {
             <div className="flex flex-col gap-4">
               {/* Header with name and icon */}
               <div className="flex items-center gap-4">
-                <AppIcon id={app.id} className="w-12 h-12 shrink-0" />
+                <AppIcon appIcon={app.icon} className="w-12 h-12 shrink-0" />
                 <div className="min-w-0 shrink flex flex-col">
                   <div className="min-w-0 flex gap-4">
                     <EditableText

--- a/src/ui/app/routes/apps/index.tsx
+++ b/src/ui/app/routes/apps/index.tsx
@@ -248,7 +248,7 @@ function AppListItem({
         "bg-card text-card-foreground hover:bg-muted/75 border-border border",
       )}
     >
-      <AppIcon id={app.id} className="mx-2 h-10 w-10 shrink-0" />
+      <AppIcon appIcon={app.icon} className="mx-2 h-10 w-10 shrink-0" />
 
       <div className="flex flex-col min-w-0">
         <div className="inline-flex items-center gap-2">

--- a/src/ui/app/routes/tags/index.tsx
+++ b/src/ui/app/routes/tags/index.tsx
@@ -65,7 +65,7 @@ export function MiniAppItem({
         backgroundColor: "rgba(255, 255, 255, 0.1)",
       }}
     >
-      <AppIcon id={app?.id} className="w-4 h-4" />
+      <AppIcon appIcon={app?.icon} className="w-4 h-4" />
       <Text className="max-w-52 text-xs">{app?.name ?? ""}</Text>
     </div>
   );

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -50,6 +50,7 @@
     "lucide-static": "^0.477.0",
     "luxon": "^3.5.0",
     "parse-duration": "^2.1.2",
+    "path-normalize": "^6.0.13",
     "pretty-ms": "^9.2.0",
     "react": "^19.0.0",
     "react-colorful": "^5.6.1",


### PR DESCRIPTION
### TL;DR

Added support for app icons with proper file extensions and improved icon handling throughout the application.

### What changed?

- Enhanced the `AppInfo` and `WebsiteInfo` structures to store icons with proper file extensions and MIME types
- Added an `icon` field to the `App` entity to store the icon filename with extension
- Updated the database schema to include the icon field
- Implemented file extension detection using MIME types and magic bytes with the `infer` and `mime2ext` crates
- Modified the UI components to use the new icon field instead of just the app ID
- Updated the security documentation to mention icon handling as part of the threat model
- Added path normalization for icon paths in the UI