### PR TITLE
Chromium Sentry Dim/Kill

### DIFF
--- a/dev/tools/src/bin/close_tab.rs
+++ b/dev/tools/src/bin/close_tab.rs
@@ -1,0 +1,89 @@
+//! Dim a window to a given opacity
+
+use clap::Parser;
+use dialoguer::Select;
+use dialoguer::theme::ColorfulTheme;
+use platform::web::BrowserDetector;
+use tools::filters::{
+    ProcessFilter, ProcessWindowGroup, WindowDetails, WindowFilter, match_running_windows,
+};
+use util::error::Result;
+use util::{Target, config};
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Window title text to filter by
+    #[arg()]
+    title: Option<String>,
+}
+
+fn main() -> Result<()> {
+    util::set_target(Target::Engine);
+    let config = config::get_config()?;
+    util::setup(&config)?;
+    platform::setup()?;
+
+    let args = Args::parse();
+    let matches = match_running_windows(
+        &WindowFilter {
+            title: args.title,
+            ..Default::default()
+        },
+        &ProcessFilter {
+            name: Some("Google Chrome".to_string()),
+            ..Default::default()
+        },
+    )?;
+
+    let browser = BrowserDetector::new()?;
+    if let Some(details) = select_window(&matches)? {
+        browser.close_current_tab(&details.window)?;
+    } else {
+        eprintln!("No windows found matching the criteria");
+    }
+
+    Ok(())
+}
+
+fn select_window(groups: &[ProcessWindowGroup]) -> Result<Option<&WindowDetails>> {
+    if groups.is_empty() {
+        return Ok(None);
+    }
+
+    // Flatten all windows into a single list with process info
+    let mut all_windows = Vec::new();
+    for group in groups {
+        for window in &group.windows {
+            all_windows.push((group, window));
+        }
+    }
+
+    if all_windows.is_empty() {
+        return Ok(None);
+    }
+
+    if all_windows.len() == 1 {
+        return Ok(Some(all_windows[0].1));
+    }
+
+    // Create selection items
+    let items: Vec<String> = all_windows
+        .iter()
+        .map(|(group, window)| {
+            format!(
+                "{} (pid: {}) - \"{}\" (hwnd: {:08x})",
+                group.process.name, group.process.pid, window.title, window.window.hwnd.0 as usize
+            )
+        })
+        .collect();
+
+    // Show selection prompt
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select a window to dim")
+        .items(&items)
+        .default(0)
+        .interact()?;
+
+    Ok(Some(all_windows[selection].1))
+}

--- a/dev/tools/src/bin/tab_track.rs
+++ b/dev/tools/src/bin/tab_track.rs
@@ -1,0 +1,91 @@
+//! List out browser information
+
+use std::sync::Mutex;
+
+use platform::events::WindowTitleWatcher;
+use platform::objects::{EventLoop, Target, Window};
+use platform::web::{BrowserDetector, BrowserUrl};
+use tools::filters::{ProcessFilter, WindowFilter, match_running_windows};
+use util::error::Result;
+// use util::tracing::info;
+use util::{Target as UtilTarget, config, future as tokio};
+
+// fn perf<T>(f: impl Fn() -> T, act: &str) -> T {
+//     let start = std::time::Instant::now();
+//     let result = f();
+//     info!("{}: {:?}", act, start.elapsed());
+//     result
+// }
+
+struct UnsafeSyncSendBrowserDetect {
+    browser: BrowserDetector,
+}
+
+impl UnsafeSyncSendBrowserDetect {
+    fn new() -> Result<Self> {
+        let browser = BrowserDetector::new()?;
+        Ok(Self { browser })
+    }
+
+    pub fn chromium_url(&self, window: &Window) -> Result<BrowserUrl> {
+        self.browser.chromium_url(window)
+    }
+}
+
+unsafe impl Send for UnsafeSyncSendBrowserDetect {}
+unsafe impl Sync for UnsafeSyncSendBrowserDetect {}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    util::set_target(UtilTarget::Engine);
+    let config = config::get_config()?;
+    util::setup(&config)?;
+    platform::setup()?;
+
+    let window_group = match_running_windows(
+        &WindowFilter {
+            ..Default::default()
+        },
+        &ProcessFilter {
+            name: Some("Google Chrome".to_string()),
+            ..Default::default()
+        },
+    )?;
+    let chrome = window_group.first().unwrap();
+
+    let browser = UnsafeSyncSendBrowserDetect::new()?;
+
+    let m = Mutex::new(());
+
+    let _h = WindowTitleWatcher::new(
+        Target::Id(chrome.process.pid),
+        Box::new(move |window| {
+            let start = std::time::Instant::now();
+            let _guard = m.lock().unwrap();
+
+            let browser_info = browser.chromium_url(&window)?;
+
+            let dimset = if let Some(url) = browser_info.url {
+                if !url.contains("youtube") {
+                    window.dim(0.5f64)?;
+                } else {
+                    window.dim(1.0f64)?;
+                }
+                Some(url)
+            } else {
+                None
+            };
+            println!(
+                "{:08x}:{:?}, {:?}",
+                window.hwnd.0 as usize,
+                dimset,
+                start.elapsed()
+            );
+            Ok(())
+        }),
+    )?;
+
+    EventLoop::new().run();
+
+    Ok(())
+}

--- a/src/engine/src/cache.rs
+++ b/src/engine/src/cache.rs
@@ -33,6 +33,8 @@ pub struct Store {
 pub struct WebsiteCache {
     // This never gets cleared, but it's ok since it's a small set of urls?
     websites: HashMap<BaseWebsiteUrl, AppDetails>,
+    // This never gets cleared, but it's ok since it's a small set of apps?
+    apps: HashMap<Ref<App>, BaseWebsiteUrl>,
     // Web state
     state: web::State,
 }
@@ -86,6 +88,7 @@ impl Cache {
             },
             web: WebsiteCache {
                 websites: HashMap::new(),
+                apps: HashMap::new(),
                 state: browser_state,
             },
             platform: PlatformCache {
@@ -95,8 +98,8 @@ impl Cache {
         }
     }
 
-    /// Get all processes for an [App].
-    pub fn processes_for_app(&self, app: &Ref<App>) -> HashSet<KillableProcessId> {
+    /// Get all processes for an [App]. Will return nothing for websites.
+    pub fn platform_processes_for_app(&self, app: &Ref<App>) -> HashSet<KillableProcessId> {
         let entry = self.platform.processes.get(app);
         if let Some(entry) = entry {
             match &entry.identity {
@@ -118,8 +121,8 @@ impl Cache {
         }
     }
 
-    /// Get all windows for an [App].
-    pub fn windows_for_app(&self, app: &Ref<App>) -> impl Iterator<Item = &Window> {
+    /// Get all windows for an [App]. Will return nothing for websites.
+    pub fn platform_windows_for_app(&self, app: &Ref<App>) -> impl Iterator<Item = &Window> {
         self.platform
             .processes
             .get(app)
@@ -132,6 +135,11 @@ impl Cache {
                     .into_iter()
                     .flat_map(|windows| windows.iter())
             })
+    }
+
+    /// Get the websites for an [App]. If the app is not a website, will return nothing.
+    pub fn websites_for_app(&self, app: &Ref<App>) -> impl Iterator<Item = &BaseWebsiteUrl> {
+        self.web.apps.get(app).into_iter()
     }
 
     /// Remove a process and associated windows from the [Cache].
@@ -277,12 +285,28 @@ impl Cache {
         }
 
         let created = { create(self).await? };
+        self.web.apps.insert(created.app.clone(), base_url.clone());
         Ok(self.web.websites.entry(base_url).or_insert(created))
     }
 
     pub async fn is_browser(&self, window: &Window) -> Option<bool> {
         let state = self.web.state.read().await;
         state.browser_windows.get(window).copied()
+    }
+
+    /// Get all browser windows.
+    pub async fn browser_windows(&self) -> HashSet<Window> {
+        let state = self.web.state.read().await;
+        state
+            .browser_windows
+            .iter()
+            .filter_map(
+                |(window, is_browser)| {
+                    if *is_browser { Some(window) } else { None }
+                },
+            )
+            .cloned()
+            .collect()
     }
 
     // pub async fn get_or_insert_session_for_window(&mut self, window: Window, create: impl Future<Output = Result<SessionDetails>>) -> Result<&SessionDetails> {

--- a/src/engine/src/cache.rs
+++ b/src/engine/src/cache.rs
@@ -111,9 +111,11 @@ impl Cache {
                     .iter()
                     .map(|ptid| KillableProcessId::Win32(ptid.pid))
                     .collect(),
-                // TODO handle Website entries
                 _ => {
-                    todo!()
+                    panic!(
+                        "unsupported app identity for `platform_processes_for_app`: {:?}",
+                        entry.identity
+                    );
                 }
             }
         } else {

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -211,9 +211,7 @@ async fn sentry_loop(
         loop {
             let tab_change = tab_change_rx.recv_async().await?;
             let mut sentry = _sentry.lock().await;
-            sentry
-                .dim_alerted_browser_windows_matching_tab_change(tab_change)
-                .await?;
+            sentry.handle_tab_change(tab_change).await?;
         }
     });
 

--- a/src/platform/src/events/mod.rs
+++ b/src/platform/src/events/mod.rs
@@ -1,7 +1,9 @@
 mod foreground;
 mod interaction;
+mod name;
 mod system;
 
 pub use foreground::*;
 pub use interaction::*;
+pub use name::*;
 pub use system::*;

--- a/src/platform/src/events/mod.rs
+++ b/src/platform/src/events/mod.rs
@@ -2,8 +2,10 @@ mod foreground;
 mod interaction;
 mod name;
 mod system;
+mod tab;
 
 pub use foreground::*;
 pub use interaction::*;
 pub use name::*;
 pub use system::*;
+pub use tab::*;

--- a/src/platform/src/events/name.rs
+++ b/src/platform/src/events/name.rs
@@ -1,0 +1,43 @@
+use util::error::Result;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
+use windows::Win32::UI::WindowsAndMessaging::{EVENT_OBJECT_NAMECHANGE, OBJID_WINDOW};
+
+use crate::objects::{Target, WinEvent, WinEventHook, Window};
+
+type ProcessTarget = Target;
+
+/// Watches for name changes of windows
+pub struct WindowTitleWatcher {
+    _hook: WinEventHook,
+}
+
+impl WindowTitleWatcher {
+    /// Create a new [WindowTitleWatcher]
+    pub fn new(
+        target: ProcessTarget,
+        on_name_change: Box<dyn Fn(Window) -> Result<()> + Send + Sync>,
+    ) -> Result<Self> {
+        let name_change_proc = move |_hwineventhook: HWINEVENTHOOK,
+                                     _event: u32,
+                                     hwnd: HWND,
+                                     id_object: i32,
+                                     _id_child: i32,
+                                     _id_event_thread: u32,
+                                     _dwms_event_time: u32| {
+            if id_object != OBJID_WINDOW.0 {
+                return;
+            }
+            let window = Window::new(hwnd);
+            on_name_change(window).expect("on_name_change");
+        };
+
+        let _hook = WinEventHook::new(
+            WinEvent::Event(EVENT_OBJECT_NAMECHANGE),
+            target,
+            Target::All,
+            Box::new(name_change_proc),
+        )?;
+        Ok(Self { _hook })
+    }
+}

--- a/src/platform/src/events/tab.rs
+++ b/src/platform/src/events/tab.rs
@@ -42,7 +42,7 @@ impl BrowserTabWatcher {
 
         // Add any new browsers to the list, watch them for title changes
         for pid in pids {
-            if !self.browser_pids.contains_key(&pid) {
+            if !self.browser_pids.contains_key(pid) {
                 let tab_change_tx = self.tab_change_tx.clone();
                 let callback = Box::new(move |window: Window| {
                     tab_change_tx.send(TabChange::Tab { window })?;

--- a/src/platform/src/events/tab.rs
+++ b/src/platform/src/events/tab.rs
@@ -1,0 +1,71 @@
+use std::collections::{HashMap, HashSet};
+
+use util::channels::Sender;
+use util::error::Result;
+
+use crate::events::WindowTitleWatcher;
+use crate::objects::{ProcessId, Target, Window};
+use crate::web;
+
+/// Watches a browser (by PID) for tab changes. Changes should be reported as fast as possible.
+pub struct BrowserTabWatcher {
+    browser_pids: HashMap<ProcessId, WindowTitleWatcher>,
+    browser_state: web::State,
+    tab_change_tx: Sender<TabChange>,
+}
+
+/// Probable change to the focused tab in some browser window.
+#[derive(Debug, Clone)]
+pub enum TabChange {
+    /// User has switched to a different tab on a window.
+    Tab {
+        /// Window where the tab changed
+        window: Window,
+    },
+    /// Periodic tick to check for changes in all browser windows.
+    Tick,
+}
+
+impl BrowserTabWatcher {
+    /// Create a new [BrowserTabWatcher]
+    pub fn new(tab_change_tx: Sender<TabChange>, browser_state: web::State) -> Result<Self> {
+        Ok(Self {
+            browser_pids: HashMap::new(),
+            browser_state,
+            tab_change_tx,
+        })
+    }
+
+    fn update_browsers(&mut self, pids: &HashSet<ProcessId>) -> Result<()> {
+        // Remove any browsers that are no longer in the list
+        self.browser_pids.retain(|pid, _| pids.contains(pid));
+
+        // Add any new browsers to the list, watch them for title changes
+        for pid in pids {
+            if !self.browser_pids.contains_key(&pid) {
+                let tab_change_tx = self.tab_change_tx.clone();
+                let callback = Box::new(move |window: Window| {
+                    tab_change_tx.send(TabChange::Tab { window })?;
+                    Ok(())
+                });
+                self.browser_pids
+                    .insert(*pid, WindowTitleWatcher::new(Target::Id(*pid), callback)?);
+            }
+        }
+        Ok(())
+    }
+
+    /// Send a tick to recheck all browser windows and update browser PID subscriptions.
+    pub fn tick(&mut self) -> Result<()> {
+        {
+            let pids = {
+                let state = self.browser_state.blocking_read();
+                state.browser_processes.clone() // unfortunately we need to clone here
+            };
+            self.update_browsers(&pids)?;
+        }
+
+        self.tab_change_tx.send(TabChange::Tick)?;
+        Ok(())
+    }
+}

--- a/src/platform/src/objects/mod.rs
+++ b/src/platform/src/objects/mod.rs
@@ -7,6 +7,7 @@ mod timer;
 mod timestamp;
 mod toast;
 mod user;
+mod win_event_hook;
 mod window;
 mod windows_hook;
 
@@ -19,5 +20,6 @@ pub use timer::*;
 pub use timestamp::*;
 pub use toast::*;
 pub use user::*;
+pub use win_event_hook::*;
 pub use window::*;
 pub use windows_hook::*;

--- a/src/platform/src/objects/win_event_hook.rs
+++ b/src/platform/src/objects/win_event_hook.rs
@@ -1,0 +1,117 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use util::error::{Context, Result};
+use util::tracing::ResultTraceExt;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::UI::Accessibility::{HWINEVENTHOOK, SetWinEventHook, UnhookWinEvent};
+use windows::Win32::UI::WindowsAndMessaging::{WINEVENT_OUTOFCONTEXT, WINEVENT_SKIPOWNPROCESS};
+
+use crate::win32;
+
+/// Windows Event Hook
+/// ref: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwineventhook
+pub struct WinEventHook {
+    hook: HWINEVENTHOOK,
+}
+
+/// Windows Event
+pub enum WinEvent {
+    /// A single event
+    Event(u32),
+    /// A range of events
+    Range(u32, u32),
+}
+
+/// Target for the hook - pid/tid
+pub enum Target {
+    /// All processes/threads
+    All,
+    /// A specific process/thread
+    Id(u32),
+}
+
+type Callback = Box<dyn Fn(HWINEVENTHOOK, u32, HWND, i32, i32, u32, u32) + Send + Sync>;
+
+thread_local! {
+    static CALLBACKS: RefCell<HashMap<*mut c_void, Callback>> = RefCell::new(HashMap::new());
+}
+
+impl WinEventHook {
+    /// Create a new [WinEventHook]
+    pub fn new(
+        event: WinEvent,
+        process: Target,
+        thread: Target,
+        callback: Callback,
+    ) -> Result<Self> {
+        let (event_min, event_max) = match event {
+            WinEvent::Event(event) => (event, event),
+            WinEvent::Range(event_min, event_max) => (event_min, event_max),
+        };
+        let pid = match process {
+            Target::All => 0,
+            Target::Id(pid) => pid,
+        };
+        let tid = match thread {
+            Target::All => 0,
+            Target::Id(thread) => thread,
+        };
+        let hook = win32!(ptr: unsafe {
+            SetWinEventHook(
+                event_min,
+                event_max,
+                None,
+                Some(Self::callback),
+                pid,
+                tid,
+                WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS,
+            ).0
+        })?;
+        let hook = HWINEVENTHOOK(hook);
+
+        CALLBACKS.with_borrow_mut(|map| {
+            map.insert(hook.0, callback);
+        });
+        Ok(Self { hook })
+    }
+
+    unsafe extern "system" fn callback(
+        hwineventhook: HWINEVENTHOOK,
+        event: u32,
+        hwnd: HWND,
+        id_object: i32,
+        id_child: i32,
+        id_event_thread: u32,
+        dwms_event_time: u32,
+    ) {
+        CALLBACKS.with_borrow(|map| {
+            if let Some(callback) = map.get(&hwineventhook.0) {
+                callback(
+                    hwineventhook,
+                    event,
+                    hwnd,
+                    id_object,
+                    id_child,
+                    id_event_thread,
+                    dwms_event_time,
+                );
+            }
+        });
+    }
+}
+
+impl Drop for WinEventHook {
+    fn drop(&mut self) {
+        unsafe {
+            UnhookWinEvent(self.hook)
+                .ok()
+                .context("unhook win event hook")
+                .warn();
+            CALLBACKS.with_borrow_mut(|map| {
+                map.remove(&self.hook.0);
+            });
+        };
+    }
+}

--- a/src/platform/src/web/browser.rs
+++ b/src/platform/src/web/browser.rs
@@ -41,7 +41,7 @@ pub struct BrowserDetector {
 }
 
 /// Detected browser URL with extra information
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BrowserUrl {
     /// The URL
     pub url: Option<String>,

--- a/src/platform/src/web/browser.rs
+++ b/src/platform/src/web/browser.rs
@@ -8,9 +8,11 @@ use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance, CoTaskMemFree};
 use windows::Win32::System::Variant::VARIANT;
 use windows::Win32::UI::Accessibility::{
     AutomationElementMode_None, CUIAutomation, IUIAutomation, IUIAutomationCacheRequest,
-    IUIAutomationCondition, IUIAutomationElement, IUIAutomationElement9, TreeScope_Descendants,
-    TreeTraversalOptions_LastToFirstOrder, UIA_AutomationIdPropertyId, UIA_ClassNamePropertyId,
-    UIA_NamePropertyId, UIA_ValueValuePropertyId,
+    IUIAutomationCondition, IUIAutomationElement, IUIAutomationElement9,
+    IUIAutomationInvokePattern, TreeScope_Children, TreeScope_Descendants,
+    TreeTraversalOptions_LastToFirstOrder, UIA_AutomationIdPropertyId, UIA_ButtonControlTypeId,
+    UIA_ClassNamePropertyId, UIA_ControlTypePropertyId, UIA_InvokePatternId, UIA_NamePropertyId,
+    UIA_SelectionItemIsSelectedPropertyId, UIA_TabItemControlTypeId, UIA_ValueValuePropertyId,
 };
 use windows::core::{AgileReference, Interface};
 
@@ -231,6 +233,85 @@ impl BrowserDetector {
             url: if url.is_empty() { None } else { Some(url) },
             incognito,
         })
+    }
+
+    /// Close the current tab in the given [Window]
+    pub fn close_current_tab(&self, window: &Window) -> Result<()> {
+        let element: IUIAutomationElement9 = perf(
+            || unsafe { self.automation.resolve()?.ElementFromHandle(window.hwnd) }?.cast(),
+            "ElementFromHandle",
+        )?;
+
+        let tab_condition = unsafe {
+            let is_tab = self.automation.resolve()?.CreatePropertyCondition(
+                UIA_ControlTypePropertyId,
+                &UIA_TabItemControlTypeId.0.into(),
+            )?;
+            let is_selected = self
+                .automation
+                .resolve()?
+                .CreatePropertyCondition(UIA_SelectionItemIsSelectedPropertyId, &true.into())?;
+            self.automation
+                .resolve()?
+                .CreateAndCondition(&is_tab, &is_selected)?
+        };
+
+        let tab = self.uia_find_result(perf(
+            || unsafe { element.FindFirst(TreeScope_Descendants, &tab_condition) },
+            "tab - FindFirst",
+        ))?;
+
+        let tab = match tab {
+            Some(tab) => tab,
+            None => {
+                return Ok(());
+            }
+        };
+
+        let close_button_condition = unsafe {
+            self.automation.resolve()?.CreatePropertyCondition(
+                UIA_ControlTypePropertyId,
+                &UIA_ButtonControlTypeId.0.into(),
+            )
+        }?;
+
+        let close_buttons = perf(
+            || unsafe { tab.FindAll(TreeScope_Children, &close_button_condition) },
+            "close_button - FindFirst",
+        )?;
+
+        let mut close_button = None;
+        let len = unsafe { close_buttons.Length()? };
+        for i in 0..len {
+            let button: IUIAutomationElement9 = unsafe { close_buttons.GetElement(i)?.cast()? };
+            let class_name = self.variant_to_string(perf(
+                || unsafe { button.GetCurrentPropertyValue(UIA_ClassNamePropertyId) },
+                "button - GetCurrentPropertyValue(UIA_ClassNamePropertyId)",
+            )?)?;
+            if class_name.contains("CloseButton") {
+                close_button = Some(button);
+                break;
+            }
+        }
+
+        let close_button = match close_button {
+            Some(close_button) => close_button,
+            None => {
+                return Ok(());
+            }
+        };
+
+        // Click the close button
+        let invoke_pattern: IUIAutomationInvokePattern = perf(
+            || unsafe { close_button.GetCurrentPatternAs(UIA_InvokePatternId) },
+            "close_button - GetCurrentPatternAs(UIA_InvokePatternId)",
+        )?;
+        perf(
+            || unsafe { invoke_pattern.Invoke() },
+            "invoke_pattern - Invoke",
+        )?;
+
+        Ok(())
     }
 
     fn variant_to_string(&self, value: VARIANT) -> Result<String> {


### PR DESCRIPTION
### TL;DR

Added browser tab tracking, dimming and closing current tab functionality to improve focus management for website-based alerts.

### What changed?

- Added a new `tab_track.rs` tool to monitor browser tabs and adjust window dimming and tab closing based on URL content
- Enhanced the `Cache` with methods to track browser processes, windows, and websites
- Implemented `BrowserTabWatcher` to detect tab changes in browser windows
- Created `WindowTitleWatcher` to monitor window title changes
- Added `WinEventHook` to interface with Windows event system
- Updated the Sentry system to dim browser windows based on website URLs
- Modified the engine to handle tab change events and update browser information
- Added `close_tab.rs` tool to close browser tabs programmatically