### PR TITLE
Update Rust Toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust Toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: rustfmt, clippy
       - name: Setup Rust cache
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust Toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.88.0
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Setup Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust Toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.88.0
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Setup Node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["src/ui"]
 homepage = "https://enigmatrix.me/projects/cobalt"
 authors = ["Enigmatrix"]
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 
 [workspace.lints.rust]
 missing_docs = "deny"

--- a/dev/tools/src/bin/browser.rs
+++ b/dev/tools/src/bin/browser.rs
@@ -3,10 +3,10 @@
 use clap::Parser;
 use platform::web::{BrowserDetector, WebsiteInfo};
 use tools::filters::{
-    match_running_windows, ProcessDetails, ProcessFilter, WindowDetails, WindowFilter,
+    ProcessDetails, ProcessFilter, WindowDetails, WindowFilter, match_running_windows,
 };
 use util::error::Result;
-use util::{config, future as tokio, Target};
+use util::{Target, config, future as tokio};
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]

--- a/dev/tools/src/bin/dim.rs
+++ b/dev/tools/src/bin/dim.rs
@@ -1,14 +1,14 @@
 //! Dim a window to a given opacity
 
 use clap::Parser;
-use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
+use dialoguer::theme::ColorfulTheme;
 use platform::objects::{ProcessId, Window};
 use tools::filters::{
-    match_running_windows, ProcessFilter, ProcessWindowGroup, WindowDetails, WindowFilter,
+    ProcessFilter, ProcessWindowGroup, WindowDetails, WindowFilter, match_running_windows,
 };
 use util::error::Result;
-use util::{config, Target};
+use util::{Target, config};
 use windows::Win32::Foundation::HWND;
 
 #[derive(Parser, Debug, Clone)]

--- a/dev/tools/src/bin/kill.rs
+++ b/dev/tools/src/bin/kill.rs
@@ -1,14 +1,14 @@
 //! Dim a window to a given opacity
 
 use clap::{ArgGroup, Parser};
-use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
+use dialoguer::theme::ColorfulTheme;
 use platform::objects::{Process, ProcessId, Window};
 use tools::filters::{
-    match_running_aumids, match_running_processes, ProcessDetails, ProcessFilter, WindowFilter,
+    ProcessDetails, ProcessFilter, WindowFilter, match_running_aumids, match_running_processes,
 };
 use util::error::Result;
-use util::{config, future as tokio, Target};
+use util::{Target, config, future as tokio};
 use windows::Win32::Foundation::HWND;
 
 #[derive(Parser, Debug, Clone)]

--- a/dev/tools/src/bin/tab_switch.rs
+++ b/dev/tools/src/bin/tab_switch.rs
@@ -4,17 +4,17 @@ use std::io::stdin;
 
 use platform::objects::Window;
 use platform::web::BrowserDetector;
-use tools::filters::{match_running_windows, ProcessFilter, WindowFilter};
+use tools::filters::{ProcessFilter, WindowFilter, match_running_windows};
 use util::error::Result;
 use util::tracing::info;
-use util::{config, future as tokio, Target as UtilTarget};
-use windows::core::{implement, AgileReference};
-use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
+use util::{Target as UtilTarget, config, future as tokio};
+use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance};
 use windows::Win32::UI::Accessibility::{
     CUIAutomation, IUIAutomation, IUIAutomationElement, IUIAutomationEventHandler,
-    IUIAutomationEventHandler_Impl, TreeScope_Descendants, UIA_ClassNamePropertyId,
-    UIA_SelectionItem_ElementSelectedEventId, UIA_EVENT_ID,
+    IUIAutomationEventHandler_Impl, TreeScope_Descendants, UIA_ClassNamePropertyId, UIA_EVENT_ID,
+    UIA_SelectionItem_ElementSelectedEventId,
 };
+use windows::core::{AgileReference, implement};
 
 mod tab_track_handler {
 
@@ -47,10 +47,10 @@ mod tab_track_handler {
                 .expect("Failed to get Chromium URL");
 
             let mut dim = false;
-            if let Some(url) = &url.url {
-                if !url.contains("youtube.com") {
-                    dim = true;
-                }
+            if let Some(url) = &url.url
+                && !url.contains("youtube.com")
+            {
+                dim = true;
             }
             if dim {
                 self.window.dim(0.5).unwrap();

--- a/dev/tools/src/filters.rs
+++ b/dev/tools/src/filters.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use platform::objects::{FileVersionInfo, Process, ProcessId, ProcessThreadId, Window};
 use util::error::Result;
-use windows::core::HRESULT;
 use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
+use windows::core::HRESULT;
 
 /// Filter for a process
 #[derive(Debug, Clone, Default)]
@@ -18,19 +18,18 @@ pub struct ProcessFilter {
 impl ProcessFilter {
     /// Check if a process matches the filter
     pub fn matches(&self, process: &ProcessDetails) -> bool {
-        if let Some(pid_filter) = &self.pid {
-            if process.pid != *pid_filter {
-                return true;
-            }
+        if let Some(pid_filter) = &self.pid
+            && process.pid != *pid_filter
+        {
+            return true;
         }
-        if let Some(name_filter) = &self.name {
-            if !process
+        if let Some(name_filter) = &self.name
+            && !process
                 .name
                 .to_lowercase()
                 .contains(&name_filter.to_lowercase())
-            {
-                return true;
-            }
+        {
+            return true;
         }
         false
     }
@@ -147,10 +146,10 @@ pub fn match_running_windows(
 
     for (pid, windows) in window_groups {
         let process = get_process_details(pid)?;
-        if let Some(process) = process {
-            if !process_filter.matches(&process) {
-                matches.push(ProcessWindowGroup { process, windows });
-            }
+        if let Some(process) = process
+            && !process_filter.matches(&process)
+        {
+            matches.push(ProcessWindowGroup { process, windows });
         }
     }
 

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -4,7 +4,7 @@ use sqlx::pool::PoolConnection;
 use sqlx::prelude::FromRow;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteRow};
 use sqlx::{
-    query, query_as, ConnectOptions, Connection, Executor, Row, Sqlite, SqlitePool, Transaction,
+    ConnectOptions, Connection, Executor, Row, Sqlite, SqlitePool, Transaction, query, query_as,
 };
 use util::config::Config;
 use util::error::{Context, Result};

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -64,24 +64,38 @@ impl Repository {
     fn sql_period_start_end(expr: &str, period: &Period) -> (String, String) {
         match period {
             Period::Hour => (
-                format!("unixepoch((unixepoch({expr}, 'unixepoch', 'localtime')/3600) * 3600, 'unixepoch', 'utc')"),
-                format!("unixepoch((unixepoch({expr}, 'unixepoch', 'localtime')/3600) * 3600 + 3600, 'unixepoch', 'utc')"),
+                format!(
+                    "unixepoch((unixepoch({expr}, 'unixepoch', 'localtime')/3600) * 3600, 'unixepoch', 'utc')"
+                ),
+                format!(
+                    "unixepoch((unixepoch({expr}, 'unixepoch', 'localtime')/3600) * 3600 + 3600, 'unixepoch', 'utc')"
+                ),
             ),
             Period::Day => (
                 format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', 'utc')"),
-                format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', '+1 day', 'utc')"),
+                format!(
+                    "unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', '+1 day', 'utc')"
+                ),
             ),
             Period::Week => (
-                format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', 'weekday 0', '-6 days', 'utc')"),
-                format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', 'weekday 0', '+1 day', 'utc')"),
+                format!(
+                    "unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', 'weekday 0', '-6 days', 'utc')"
+                ),
+                format!(
+                    "unixepoch({expr}, 'unixepoch', 'localtime', 'start of day', 'weekday 0', '+1 day', 'utc')"
+                ),
             ),
             Period::Month => (
                 format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of month', 'utc')"),
-                format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of month', '+1 month', 'utc')"),
+                format!(
+                    "unixepoch({expr}, 'unixepoch', 'localtime', 'start of month', '+1 month', 'utc')"
+                ),
             ),
             Period::Year => (
                 format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of year', 'utc')"),
-                format!("unixepoch({expr}, 'unixepoch', 'localtime', 'start of year', '+1 year', 'utc')"),
+                format!(
+                    "unixepoch({expr}, 'unixepoch', 'localtime', 'start of year', '+1 year', 'utc')"
+                ),
             ),
         }
     }

--- a/src/data/src/db/tests.rs
+++ b/src/data/src/db/tests.rs
@@ -1,5 +1,5 @@
 use sqlx::prelude::FromRow;
-use sqlx::{query, Row};
+use sqlx::{Row, query};
 use util::future as tokio;
 
 use super::*;

--- a/src/data/src/migrations/migration1.rs
+++ b/src/data/src/migrations/migration1.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use sqlx::Executor;
-use util::error::{bail, Context, Result};
+use util::error::{Context, Result, bail};
 
 use super::Migration;
 use crate::db::Database;

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -15,7 +15,7 @@ use util::error::{Context, Result};
 use util::future::runtime::Handle;
 use util::future::sync::Mutex;
 use util::time::ToTicks;
-use util::tracing::{debug, info, trace, ResultTraceExt};
+use util::tracing::{ResultTraceExt, debug, info, trace};
 
 use crate::cache::{AppDetails, Cache, SessionDetails};
 use crate::foreground_window_session;

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -22,8 +22,8 @@ use util::config::{self, Config};
 use util::error::{Context, Result};
 use util::future::runtime::{Builder, Handle};
 use util::future::sync::Mutex;
-use util::tracing::{error, info, ResultTraceExt};
-use util::{future, Target};
+use util::tracing::{ResultTraceExt, error, info};
+use util::{Target, future};
 
 mod cache;
 mod engine;

--- a/src/engine/src/sentry.rs
+++ b/src/engine/src/sentry.rs
@@ -8,7 +8,7 @@ use platform::objects::{Process, Progress, Timestamp as PlatformTimestamp, Toast
 use util::error::Result;
 use util::future::sync::Mutex;
 use util::time::ToTicks;
-use util::tracing::{debug, info, ResultTraceExt};
+use util::tracing::{ResultTraceExt, debug, info};
 
 use crate::cache::{Cache, KillableProcessId};
 

--- a/src/platform/src/error.rs
+++ b/src/platform/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use windows::Win32::Foundation::{
-    GetLastError, SetLastError, NO_ERROR, NTSTATUS, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS,
+    GetLastError, NO_ERROR, NTSTATUS, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS, SetLastError,
     WIN32_ERROR,
 };
 

--- a/src/platform/src/events/interaction.rs
+++ b/src/platform/src/events/interaction.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use util::config::Config;
-use util::error::{bail, Context, Result};
+use util::error::{Context, Result, bail};
 use util::time::ToTicks;
 use util::tracing::debug;
 use windows::Win32::Foundation::{LPARAM, WPARAM};

--- a/src/platform/src/events/system.rs
+++ b/src/platform/src/events/system.rs
@@ -1,12 +1,12 @@
 use util::error::{Context, Result};
-use util::tracing::{info, ResultTraceExt};
+use util::tracing::{ResultTraceExt, info};
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::Power::{
-    RegisterPowerSettingNotification, UnregisterPowerSettingNotification, HPOWERNOTIFY,
-    POWERBROADCAST_SETTING,
+    HPOWERNOTIFY, POWERBROADCAST_SETTING, RegisterPowerSettingNotification,
+    UnregisterPowerSettingNotification,
 };
 use windows::Win32::System::RemoteDesktop::{
-    WTSRegisterSessionNotification, WTSUnRegisterSessionNotification, NOTIFY_FOR_THIS_SESSION,
+    NOTIFY_FOR_THIS_SESSION, WTSRegisterSessionNotification, WTSUnRegisterSessionNotification,
 };
 use windows::Win32::System::SystemServices::GUID_MONITOR_POWER_ON;
 use windows::Win32::UI::WindowsAndMessaging::{

--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -10,7 +10,7 @@ pub mod objects;
 pub mod web;
 
 use util::error::{Context, Result};
-use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
+use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx};
 
 use crate::objects::Timestamp;
 

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -4,12 +4,12 @@ use std::path::Path;
 use rand::seq::IndexedMutRandom;
 use util::error::{Context, Result};
 use util::tracing::ResultTraceExt;
-use windows::core::AgileReference;
 use windows::ApplicationModel::{AppDisplayInfo, AppInfo as UWPAppInfo};
 use windows::Foundation::Size;
 use windows::Storage::FileProperties::ThumbnailMode;
 use windows::Storage::StorageFile;
 use windows::Storage::Streams::DataReader;
+use windows::core::AgileReference;
 
 use crate::objects::FileVersionInfo;
 
@@ -46,10 +46,10 @@ impl Icon {
         }
 
         // Then try MIME type if available
-        if let Some(mime) = &self.mime {
-            if let Some(ext) = mime2ext::mime2ext(mime) {
-                return Some(ext.to_string());
-            }
+        if let Some(mime) = &self.mime
+            && let Some(ext) = mime2ext::mime2ext(mime)
+        {
+            return Some(ext.to_string());
         }
 
         // Finally try magic bytes detection

--- a/src/platform/src/objects/event_loop.rs
+++ b/src/platform/src/objects/event_loop.rs
@@ -1,5 +1,5 @@
 use windows::Win32::UI::WindowsAndMessaging::{
-    DispatchMessageW, GetMessageW, TranslateMessage, MSG,
+    DispatchMessageW, GetMessageW, MSG, TranslateMessage,
 };
 
 /// Representation of the Win32 [EventLoop]

--- a/src/platform/src/objects/file_version_info.rs
+++ b/src/platform/src/objects/file_version_info.rs
@@ -1,11 +1,11 @@
 use std::mem::MaybeUninit;
 use std::path::PathBuf;
 
-use util::error::{bail, Context, Result};
-use windows::core::{w, PCWSTR};
+use util::error::{Context, Result, bail};
 use windows::Win32::Storage::FileSystem::{
-    GetFileVersionInfoExW, GetFileVersionInfoSizeExW, VerQueryValueW, FILE_VER_GET_LOCALISED,
+    FILE_VER_GET_LOCALISED, GetFileVersionInfoExW, GetFileVersionInfoSizeExW, VerQueryValueW,
 };
+use windows::core::{PCWSTR, w};
 
 use crate::win32;
 

--- a/src/platform/src/objects/process.rs
+++ b/src/platform/src/objects/process.rs
@@ -4,20 +4,20 @@ use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use util::error::{bail, Context, Result};
+use util::error::{Context, Result, bail};
 use util::tracing::ResultTraceExt;
-use windows::core::HSTRING;
 use windows::System::AppDiagnosticInfo;
 use windows::Wdk::System::Threading::{
-    NtQueryInformationProcess, ProcessImageFileNameWin32, PROCESSINFOCLASS,
+    NtQueryInformationProcess, PROCESSINFOCLASS, ProcessImageFileNameWin32,
 };
 use windows::Win32::Foundation::{CloseHandle, HANDLE, UNICODE_STRING, WAIT_TIMEOUT};
 use windows::Win32::System::ProcessStatus::K32EnumProcesses;
 use windows::Win32::System::Threading::{
-    IsImmersiveProcess, OpenProcess, TerminateProcess, WaitForSingleObject,
-    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+    IsImmersiveProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+    TerminateProcess, WaitForSingleObject,
 };
 use windows::Win32::UI::Shell::DoEnvironmentSubstW;
+use windows::core::HSTRING;
 
 use crate::adapt_size;
 use crate::buf::WideBuffer;
@@ -63,8 +63,7 @@ fn is_path_in_blacklist(path: impl Into<PathBuf>) -> bool {
 /// Get the blacklist for killing processes
 fn kill_blacklist() -> Vec<OsString> {
     let blacklist_str = include_str!("../data/kill_blacklist.txt");
-    let blacklist = blacklist_str.lines().map(expand_env_str).collect();
-    blacklist
+    blacklist_str.lines().map(expand_env_str).collect()
 }
 
 /// Expand environment variables in a string

--- a/src/platform/src/objects/toast.rs
+++ b/src/platform/src/objects/toast.rs
@@ -1,7 +1,7 @@
 use util::error::Result;
-use windows::core::Interface;
 use windows::Data::Xml::Dom::{XmlDocument, XmlElement};
 use windows::UI::Notifications::{ToastNotification, ToastNotificationManager};
+use windows::core::Interface;
 
 // Once we get registration settled, we can move away from a singleton pattern.
 

--- a/src/platform/src/objects/user.rs
+++ b/src/platform/src/objects/user.rs
@@ -1,8 +1,8 @@
 use util::error::*;
-use windows::core::PWSTR;
 use windows::Win32::Foundation::MAX_PATH;
 use windows::Win32::System::WindowsProgramming::GetUserNameW;
 use windows::Win32::UI::Shell::IsUserAnAdmin;
+use windows::core::PWSTR;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Represents the current user of the system.

--- a/src/platform/src/objects/window.rs
+++ b/src/platform/src/objects/window.rs
@@ -7,12 +7,12 @@ use windows::Win32::System::Com::CoTaskMemFree;
 use windows::Win32::System::Com::StructuredStorage::PropVariantToStringAlloc;
 use windows::Win32::UI::Shell::PropertiesSystem::{IPropertyStore, SHGetPropertyStoreForWindow};
 use windows::Win32::UI::WindowsAndMessaging::{
-    EnumChildWindows, EnumWindows, GetClassNameW, GetForegroundWindow, GetWindowTextLengthW,
-    GetWindowTextW, GetWindowThreadProcessId, IsWindowVisible, SetLayeredWindowAttributes,
-    SetWindowLongW, GWL_EXSTYLE, LWA_ALPHA, WS_EX_LAYERED,
+    EnumChildWindows, EnumWindows, GWL_EXSTYLE, GetClassNameW, GetForegroundWindow,
+    GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId, IsWindowVisible, LWA_ALPHA,
+    SetLayeredWindowAttributes, SetWindowLongW, WS_EX_LAYERED,
 };
 
-use crate::buf::{buf, Buffer, WideBuffer};
+use crate::buf::{Buffer, WideBuffer, buf};
 use crate::error::Win32Error;
 use crate::objects::ProcessThreadId;
 use crate::win32;
@@ -156,7 +156,7 @@ impl Window {
 }
 
 unsafe extern "system" fn push_visible_window_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
-    let windows = &mut *(lparam.0 as *mut Vec<Window>);
+    let windows = unsafe { &mut *(lparam.0 as *mut Vec<Window>) };
 
     // Only add windows that are visible
     if unsafe { IsWindowVisible(hwnd).as_bool() } {
@@ -167,7 +167,7 @@ unsafe extern "system" fn push_visible_window_callback(hwnd: HWND, lparam: LPARA
 }
 
 unsafe extern "system" fn push_window_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
-    let windows = &mut *(lparam.0 as *mut Vec<Window>);
+    let windows = unsafe { &mut *(lparam.0 as *mut Vec<Window>) };
     windows.push(Window::new(hwnd));
 
     BOOL(1) // Continue enumeration

--- a/src/platform/src/objects/windows_hook.rs
+++ b/src/platform/src/objects/windows_hook.rs
@@ -4,7 +4,7 @@ use util::error::{Context, Result};
 use util::tracing::ResultTraceExt;
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, SetWindowsHookExW, UnhookWindowsHookEx, HHOOK, WINDOWS_HOOK_ID,
+    CallNextHookEx, HHOOK, SetWindowsHookExW, UnhookWindowsHookEx, WINDOWS_HOOK_ID,
 };
 
 /// Instance of a Windows hook attached to a [WindowsHookType].
@@ -36,7 +36,7 @@ impl<T: WindowsHookType> WindowsHook<T> {
 
     unsafe extern "system" fn trampoline(ncode: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
         T::callback(ncode, wparam, lparam);
-        CallNextHookEx(None, ncode, wparam, lparam)
+        unsafe { CallNextHookEx(None, ncode, wparam, lparam) }
     }
 }
 

--- a/src/platform/src/web/browser.rs
+++ b/src/platform/src/web/browser.rs
@@ -1,11 +1,10 @@
 use reqwest::Url;
 use util::error::{Context, Result};
 use util::tracing::{debug, info, warn};
-use windows::core::{AgileReference, Interface};
 use windows::Win32::System::Com::StructuredStorage::{
     PropVariantToStringAlloc, VariantToPropVariant,
 };
-use windows::Win32::System::Com::{CoCreateInstance, CoTaskMemFree, CLSCTX_ALL};
+use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance, CoTaskMemFree};
 use windows::Win32::System::Variant::VARIANT;
 use windows::Win32::UI::Accessibility::{
     AutomationElementMode_None, CUIAutomation, IUIAutomation, IUIAutomationCacheRequest,
@@ -13,6 +12,7 @@ use windows::Win32::UI::Accessibility::{
     TreeTraversalOptions_LastToFirstOrder, UIA_AutomationIdPropertyId, UIA_ClassNamePropertyId,
     UIA_NamePropertyId, UIA_ValueValuePropertyId,
 };
+use windows::core::{AgileReference, Interface};
 
 use crate::objects::Window;
 
@@ -124,7 +124,7 @@ impl BrowserDetector {
                 return Ok(BrowserUrl {
                     url: None,
                     incognito: false,
-                })
+                });
             }
         };
         let name = perf(
@@ -191,7 +191,7 @@ impl BrowserDetector {
                 return Ok(BrowserUrl {
                     url: None,
                     incognito,
-                })
+                });
             }
         };
 

--- a/src/platform/src/web/website_info.rs
+++ b/src/platform/src/web/website_info.rs
@@ -2,10 +2,10 @@ use std::fmt;
 
 use reqwest::{Client, RequestBuilder, Url};
 use scraper::{Html, Selector};
-use util::error::{bail, Context, Result};
+use util::error::{Context, Result, bail};
 use util::tracing::ResultTraceExt;
 
-use crate::objects::{random_color, AppInfo, Icon};
+use crate::objects::{AppInfo, Icon, random_color};
 
 /// Information about a Website
 pub struct WebsiteInfo {

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -10,7 +10,7 @@ use util::tracing;
 use util::tracing::log::warn;
 
 use crate::error::AppResult;
-use crate::state::{init_state, AppState, Initable, QueryOptions};
+use crate::state::{AppState, Initable, QueryOptions, init_state};
 
 #[tauri::command]
 #[tracing::instrument(err, skip(state))]

--- a/src/ui/src-tauri/src/state.rs
+++ b/src/ui/src-tauri/src/state.rs
@@ -1,9 +1,9 @@
-use data::db::repo::Repository;
 use data::db::DatabasePool;
+use data::db::repo::Repository;
 use serde::{Deserialize, Serialize};
-use tauri::async_runtime::RwLock;
 use tauri::State;
-use util::config::{get_config, Config};
+use tauri::async_runtime::RwLock;
+use util::config::{Config, get_config};
 use util::error::Result;
 use util::tracing;
 

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -44,7 +44,7 @@ impl Config {
     pub fn config_path(segment: &str) -> Result<String> {
         #[cfg(debug_assertions)]
         {
-            use crate::{Target, TARGET};
+            use crate::{TARGET, Target};
 
             let target = TARGET.lock().unwrap().clone();
             match target {

--- a/src/util/src/tracing.rs
+++ b/src/util/src/tracing.rs
@@ -2,11 +2,11 @@ pub use tracing::*;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt::format::FmtSpan;
 pub use tracing_subscriber::prelude::*;
-use tracing_subscriber::{fmt, registry, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, registry};
 
 use crate::config::Config;
 use crate::error::*;
-use crate::{Target, TARGET};
+use crate::{TARGET, Target};
 
 /// Extension trait for [Result] to log the error, warn, info, debug,
 /// or trace straight to the log.


### PR DESCRIPTION
### TL;DR

Update Rust edition from 2021 to 2024 and reformat imports across the codebase.

### What changed?

- Updated Rust edition from 2021 to 2024 in Cargo.toml
- Reformatted imports across multiple files to follow the new Rust 2024 style:
  - Grouped imports by crate
  - Alphabetized items within import groups
  - Adopted the new `if let Some(x) = y && condition` syntax pattern
- Fixed code to work with the new edition's features