### PR TITLE
Persist State across back nav for some pages

### DIFF
--- a/src/ui/app/components/alert/choose-target.tsx
+++ b/src/ui/app/components/alert/choose-target.tsx
@@ -51,6 +51,7 @@ export function ChooseTarget({
   const [, setQuery, filteredApps, filteredTags] = useTargetsSearch(
     allApps,
     allTags,
+    undefined,
   );
   const setOpen = useCallback(
     (open: boolean) => {

--- a/src/ui/app/components/app/choose-multi-apps.tsx
+++ b/src/ui/app/components/app/choose-multi-apps.tsx
@@ -57,7 +57,7 @@ export function ChooseMultiApps({
   const allApps = useApps();
   const valueApps = useApps(value);
 
-  const [, setQuery, filteredApps] = useAppsSearch(allApps);
+  const [, setQuery, filteredApps] = useAppsSearch(allApps, undefined);
   const setOpen = useCallback(
     (open: boolean) => {
       setOpenInner(open);

--- a/src/ui/app/components/tag/choose-tag.tsx
+++ b/src/ui/app/components/tag/choose-tag.tsx
@@ -37,7 +37,7 @@ export function ChooseTag({
   const createTag = useAppState((state) => state.createTag);
   const allTags = useTags();
 
-  const [, setQuery, filteredTags] = useTagsSearch(allTags);
+  const [, setQuery, filteredTags] = useTagsSearch(allTags, undefined);
   const setOpen = useCallback(
     (open: boolean) => {
       setOpenInner(open);

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -58,7 +58,7 @@ export function VerticalLegend({
   className?: ClassValue;
 }) {
   const apps = useApps(appIds);
-  const [query, setQuery, filteredApps] = useAppsSearch(apps);
+  const [query, setQuery, filteredApps] = useAppsSearch(apps, undefined);
   const tagIds = useMemo(() => {
     return _(filteredApps)
       .map((app) => app.tagId)

--- a/src/ui/app/hooks/use-history-state.tsx
+++ b/src/ui/app/hooks/use-history-state.tsx
@@ -1,0 +1,116 @@
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+function getHistoryValue<S>(key: string): S | undefined {
+  return (history.state as Record<string, S | undefined> | undefined)?.[key];
+}
+
+function updateHistoryValue<S>(key: string, value: S) {
+  history.replaceState(
+    {
+      ...history.state,
+      [key]: value,
+    },
+    "",
+  );
+}
+
+/**
+ * Like {@link useState}, but persists in the history state. This is useful for
+ * back-button navigation. `key` is the key to use in the history state
+ * and must be unique per page. `key` should not change after the first render.
+ */
+export function useHistoryState<S>(
+  initialState: S | (() => S),
+  key: string | undefined,
+): [S, Dispatch<SetStateAction<S>>] {
+  const [rawState, rawSetState] = useState<S>(() => {
+    if (key) {
+      // If the state is already set in history, return it
+      const historyValue = getHistoryValue<S>(key);
+      if (historyValue) return historyValue;
+    }
+
+    // Otherwise, set the state and return the initial value,
+    // making sure to update the history state.
+    const retValue =
+      typeof initialState === "function"
+        ? (initialState as () => S)()
+        : initialState;
+
+    if (key) {
+      updateHistoryValue(key, retValue);
+    }
+
+    return retValue;
+  });
+
+  const setState = useCallback(
+    (value: SetStateAction<S>) => {
+      rawSetState((prevValue) => {
+        const newValue =
+          typeof value === "function"
+            ? (value as (prev: S) => S)(prevValue)
+            : value;
+        if (key) {
+          updateHistoryValue(key, newValue);
+        }
+        return newValue;
+      });
+    },
+    [rawSetState, key],
+  );
+
+  return [rawState, setState];
+}
+
+/**
+ * Same as {@link useHistoryState}, but never changes the returned value when
+ * the setter is called - instead only the history state is updated. So it's
+ * more similar to `useRef` than `useState`.
+ */
+export function useHistoryRef<S>(
+  initialState: S | (() => S),
+  key: string | undefined,
+): [S, Dispatch<SetStateAction<S>>] {
+  const [rawState] = useState<S>(() => {
+    if (key) {
+      // If the state is already set in history, return it
+      const historyValue = getHistoryValue<S>(key);
+      if (historyValue) return historyValue;
+    }
+
+    // Otherwise, set the state and return the initial value,
+    // making sure to update the history state.
+    const retValue =
+      typeof initialState === "function"
+        ? (initialState as () => S)()
+        : initialState;
+
+    if (key) {
+      updateHistoryValue(key, retValue);
+    }
+    return retValue;
+  });
+
+  const setState = useCallback(
+    (value: SetStateAction<S>) => {
+      if (!key) return;
+      const historyValue = getHistoryValue<S>(key);
+
+      const newValue =
+        typeof value === "function"
+          ? (value as (prev: S) => S)(historyValue!)
+          : value;
+
+      updateHistoryValue(key, newValue);
+    },
+    [key],
+  );
+
+  return [rawState, setState];
+}

--- a/src/ui/app/routes/alerts/create.tsx
+++ b/src/ui/app/routes/alerts/create.tsx
@@ -15,6 +15,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AppUsageBarChart } from "@/components/viz/app-usage-chart";
 import { useZodForm } from "@/hooks/use-form";
+import { useHistoryRef } from "@/hooks/use-history-state";
 import { useTargetApps } from "@/hooks/use-refresh";
 import { useAppDurationsPerPeriod } from "@/hooks/use-repo";
 import { useIntervalControlsWithDefault } from "@/hooks/use-time";
@@ -42,14 +43,27 @@ import {
 import { useFieldArray } from "react-hook-form";
 import { useNavigate } from "react-router";
 
+const defaultFormValues = {
+  ignoreTrigger: false,
+  reminders: [],
+} as unknown as FormValues;
+
 export default function CreateAlerts() {
+  const [savedFormValues, setSavedFormValues] = useHistoryRef<FormValues>(
+    defaultFormValues,
+    "formState",
+  );
   const form = useZodForm({
     schema: alertSchema,
-    defaultValues: {
-      ignoreTrigger: false,
-      reminders: [],
-    },
+    defaultValues: savedFormValues,
   });
+
+  // Persist form values to history
+  const formValues = form.watch();
+  useEffect(() => {
+    setSavedFormValues(formValues);
+  }, [formValues, setSavedFormValues]);
+
   const createAlert = useAppState((state) => state.createAlert);
   const navigate = useNavigate();
   const target = form.watch("target");

--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -20,6 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHistoryRef } from "@/hooks/use-history-state";
 import { useAlerts, useApp, useApps, useTag } from "@/hooks/use-refresh";
 import { useAlertsSearch } from "@/hooks/use-search";
 import type { Alert, Reminder } from "@/lib/entities";
@@ -28,15 +29,33 @@ import { MiniTagItem } from "@/routes/apps";
 import { MiniAppItem } from "@/routes/tags";
 import type { ClassValue } from "clsx";
 import { Plus, TagIcon } from "lucide-react";
-import { memo, useMemo, type CSSProperties, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useMemo,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { NavLink } from "react-router";
 import AutoSizer from "react-virtualized-auto-sizer";
-import { FixedSizeList as List } from "react-window";
+import { FixedSizeList as List, type ListOnScrollProps } from "react-window";
 
 export default function Alerts() {
   const alerts = useAlerts();
-  const [search, setSearch, alertsFiltered] = useAlertsSearch(alerts);
+  const [search, setSearch, alertsFiltered] = useAlertsSearch(alerts, "query");
   const alertsSorted = alertsFiltered; // TODO: sort
+
+  const [scrollOffset, setScrollOffset] = useHistoryRef<number>(
+    0,
+    "scrollOffset",
+  );
+
+  const setScrollOffsetFromEvent = useCallback(
+    (e: ListOnScrollProps) => {
+      setScrollOffset(e.scrollOffset);
+    },
+    [setScrollOffset],
+  );
 
   const ListItem = memo(
     ({ index, style }: { index: number; style: CSSProperties }) => (
@@ -80,6 +99,8 @@ export default function Alerts() {
         <AutoSizer>
           {({ height, width }) => (
             <List
+              initialScrollOffset={scrollOffset}
+              onScroll={setScrollOffsetFromEvent}
               itemData={alertsSorted} // this is to trigger a rerender on sort/filter
               height={height}
               width={width}


### PR DESCRIPTION
### TL;DR

Added history state persistence for search queries, scroll positions, and form values to improve navigation experience.

### What changed?

- Created new hooks `useHistoryState` and `useHistoryRef` to persist state in browser history
- Modified search hooks to accept a key parameter for history state persistence
- Updated all search components to use the new history-aware hooks
- Added scroll position persistence for list views (apps, tags, alerts)
- Implemented form state persistence for alert creation and editing forms
- Updated all relevant components to pass appropriate keys to search hooks

### Why make this change?

This change significantly improves the user experience by preserving UI state during navigation. When users navigate away from a page and then return (either via links or the browser's back button), they'll find:

- Their search queries are preserved
- Their scroll positions are maintained
- Their form inputs are retained

This prevents frustrating loss of context and work when navigating through the application, making the experience feel more like a native app rather than a traditional website where state is lost between page transitions.