### PR TITLE
Engine Fixups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "backon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1838,18 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -5963,6 +5986,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "util"
 version = "0.5.0"
 dependencies = [
+ "backon",
  "color-eyre",
  "dirs 6.0.0",
  "flume",

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -43,6 +43,7 @@ pub enum Event {
 }
 
 /// Args for creating a new [Engine].
+#[derive(Clone)]
 pub struct EngineArgs {
     pub desktop: DesktopState,
     pub web_state: web::State,

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -62,19 +62,21 @@ fn real_main() -> Result<()> {
         let config = config.clone();
         let fg = fg.clone();
         let browser_state = browser_state.clone();
-        thread::spawn(move || {
-            event_loop(
-                &config,
-                browser_state,
-                event_tx,
-                alert_tx,
-                tab_change_tx,
-                fg,
-                now,
-            )
-            .context("event loop")
-            .error();
-        })
+        thread::Builder::new()
+            .name("event_loop_thread".to_string())
+            .spawn(move || {
+                event_loop(
+                    &config,
+                    browser_state,
+                    event_tx,
+                    alert_tx,
+                    tab_change_tx,
+                    fg,
+                    now,
+                )
+                .context("event loop")
+                .error();
+            })?
     };
 
     processor(

--- a/src/engine/src/sentry.rs
+++ b/src/engine/src/sentry.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 use data::db::{AlertManager, Database, TriggeredAlert};
 use data::entities::{
@@ -9,15 +8,14 @@ use platform::events::TabChange;
 use platform::objects::{Process, Progress, Timestamp as PlatformTimestamp, ToastManager, Window};
 use platform::web::{BaseWebsiteUrl, BrowserDetector, WebsiteInfo};
 use util::error::Result;
-use util::future::sync::Mutex;
 use util::time::ToTicks;
 use util::tracing::{ResultTraceExt, debug, info};
 
-use crate::cache::{Cache, KillableProcessId};
+use crate::desktop::{DesktopState, KillableProcessId};
 
 /// Watcher to track [TriggeredAlert]s and [TriggeredReminder]s and take action on them.
 pub struct Sentry {
-    cache: Arc<Mutex<Cache>>,
+    desktop: DesktopState,
     mgr: AlertManager,
     // Invariant: the website_actions map is *wholly* updated. That is, run() executes
     // and updates this after clearing it with *all* alerts' websites. This is easily
@@ -72,10 +70,10 @@ impl Ord for WebsiteAction {
 
 impl Sentry {
     /// Create a new [Sentry] with the given [Cache] and [Database].
-    pub fn new(cache: Arc<Mutex<Cache>>, db: Database) -> Result<Self> {
+    pub fn new(desktop: DesktopState, db: Database) -> Result<Self> {
         let mgr = AlertManager::new(db)?;
         Ok(Self {
-            cache,
+            desktop,
             mgr,
             website_actions: HashMap::new(),
         })
@@ -88,8 +86,8 @@ impl Sentry {
         let changed_browser_windows = match tab_change {
             TabChange::Tab { window } => HashSet::from_iter(vec![window]),
             TabChange::Tick => {
-                let cache = self.cache.lock().await;
-                cache.browser_windows().await
+                let desktop = self.desktop.read().await;
+                desktop.browser_windows().await
             }
         };
 
@@ -124,11 +122,11 @@ impl Sentry {
 
     /// Run the [Sentry] to check for triggered alerts and reminders and take action on them.
     pub async fn run(&mut self, now: PlatformTimestamp) -> Result<()> {
-        // Retain alive entries in cache before we start processing
+        // Retain alive entries in desktop before we start processing
         // - avoids dimming dead windows / killing dead processes
         {
-            let mut cache = self.cache.lock().await;
-            cache.retain_cache().await?;
+            let mut desktop = self.desktop.write().await;
+            desktop.retain_cache().await?;
         }
 
         // Reset the website actions - it will get repopulated by the alerts
@@ -193,14 +191,14 @@ impl Sentry {
                             let process = Process::new_killable(pid)?;
                             self.handle_kill_action(&process).warn();
 
-                            let mut cache = self.cache.lock().await;
-                            cache.remove_process(pid).await;
+                            let mut desktop = self.desktop.write().await;
+                            desktop.remove_process(pid).await;
                         }
                         KillableProcessId::Aumid(aumid) => {
                             Process::kill_uwp(&aumid).await.warn();
 
-                            let mut cache = self.cache.lock().await;
-                            cache.remove_app(app).await;
+                            let mut desktop = self.desktop.write().await;
+                            desktop.remove_app(app).await;
                         }
                     }
                 }
@@ -309,11 +307,11 @@ impl Sentry {
     ) -> Result<(Vec<(Ref<App>, KillableProcessId)>, Vec<BaseWebsiteUrl>)> {
         let target_apps = self.mgr.target_apps(target).await?;
 
-        let cache = self.cache.lock().await;
+        let desktop = self.desktop.read().await;
         let processes = target_apps
             .iter()
             .flat_map(move |app| {
-                cache
+                desktop
                     .platform_processes_for_app(app)
                     .into_iter()
                     .map(|pid| (app.clone(), pid))
@@ -321,10 +319,10 @@ impl Sentry {
             .collect();
 
         // yes, we lock twice here ...
-        let cache = self.cache.lock().await;
+        let desktop = self.desktop.read().await;
         let websites = target_apps
             .iter()
-            .flat_map(move |app| cache.websites_for_app(app).cloned().collect::<Vec<_>>())
+            .flat_map(move |app| desktop.websites_for_app(app).cloned().collect::<Vec<_>>())
             .collect();
         Ok((processes, websites))
     }
@@ -336,11 +334,11 @@ impl Sentry {
     ) -> Result<(Vec<Window>, Vec<BaseWebsiteUrl>)> {
         let target_apps = self.mgr.target_apps(target).await?;
 
-        let cache = self.cache.lock().await;
+        let desktop = self.desktop.read().await;
         let windows = target_apps
             .iter()
             .flat_map(move |app| {
-                cache
+                desktop
                     .platform_windows_for_app(app)
                     .cloned()
                     .collect::<Vec<_>>() // ew
@@ -348,10 +346,10 @@ impl Sentry {
             .collect();
 
         // yes, we lock twice here ...
-        let cache = self.cache.lock().await;
+        let desktop = self.desktop.read().await;
         let websites = target_apps
             .iter()
-            .flat_map(move |app| cache.websites_for_app(app).cloned().collect::<Vec<_>>())
+            .flat_map(move |app| desktop.websites_for_app(app).cloned().collect::<Vec<_>>())
             .collect();
         Ok((windows, websites))
     }

--- a/src/engine/src/sentry.rs
+++ b/src/engine/src/sentry.rs
@@ -15,7 +15,7 @@ use crate::desktop::{DesktopState, KillableProcessId};
 
 /// Watcher to track [TriggeredAlert]s and [TriggeredReminder]s and take action on them.
 pub struct Sentry {
-    desktop: DesktopState,
+    desktop_state: DesktopState,
     mgr: AlertManager,
     // Invariant: the website_actions map is *wholly* updated. That is, run() executes
     // and updates this after clearing it with *all* alerts' websites. This is easily
@@ -70,10 +70,10 @@ impl Ord for WebsiteAction {
 
 impl Sentry {
     /// Create a new [Sentry] with the given [Cache] and [Database].
-    pub fn new(desktop: DesktopState, db: Database) -> Result<Self> {
+    pub fn new(desktop_state: DesktopState, db: Database) -> Result<Self> {
         let mgr = AlertManager::new(db)?;
         Ok(Self {
-            desktop,
+            desktop_state,
             mgr,
             website_actions: HashMap::new(),
         })
@@ -86,8 +86,8 @@ impl Sentry {
         let changed_browser_windows = match tab_change {
             TabChange::Tab { window } => HashSet::from_iter(vec![window]),
             TabChange::Tick => {
-                let desktop = self.desktop.read().await;
-                desktop.browser_windows().await
+                let desktop_state = self.desktop_state.read().await;
+                desktop_state.browser_windows().await
             }
         };
 
@@ -122,11 +122,11 @@ impl Sentry {
 
     /// Run the [Sentry] to check for triggered alerts and reminders and take action on them.
     pub async fn run(&mut self, now: PlatformTimestamp) -> Result<()> {
-        // Retain alive entries in desktop before we start processing
+        // Retain alive entries in desktop_state before we start processing
         // - avoids dimming dead windows / killing dead processes
         {
-            let mut desktop = self.desktop.write().await;
-            desktop.retain_cache().await?;
+            let mut desktop_state = self.desktop_state.write().await;
+            desktop_state.retain_cache().await?;
         }
 
         // Reset the website actions - it will get repopulated by the alerts
@@ -191,14 +191,14 @@ impl Sentry {
                             let process = Process::new_killable(pid)?;
                             self.handle_kill_action(&process).warn();
 
-                            let mut desktop = self.desktop.write().await;
-                            desktop.remove_process(pid).await;
+                            let mut desktop_state = self.desktop_state.write().await;
+                            desktop_state.remove_process(pid).await;
                         }
                         KillableProcessId::Aumid(aumid) => {
                             Process::kill_uwp(&aumid).await.warn();
 
-                            let mut desktop = self.desktop.write().await;
-                            desktop.remove_app(app).await;
+                            let mut desktop_state = self.desktop_state.write().await;
+                            desktop_state.remove_app(app).await;
                         }
                     }
                 }
@@ -307,11 +307,11 @@ impl Sentry {
     ) -> Result<(Vec<(Ref<App>, KillableProcessId)>, Vec<BaseWebsiteUrl>)> {
         let target_apps = self.mgr.target_apps(target).await?;
 
-        let desktop = self.desktop.read().await;
+        let desktop_state = self.desktop_state.read().await;
         let processes = target_apps
             .iter()
             .flat_map(move |app| {
-                desktop
+                desktop_state
                     .platform_processes_for_app(app)
                     .into_iter()
                     .map(|pid| (app.clone(), pid))
@@ -319,10 +319,15 @@ impl Sentry {
             .collect();
 
         // yes, we lock twice here ...
-        let desktop = self.desktop.read().await;
+        let desktop_state = self.desktop_state.read().await;
         let websites = target_apps
             .iter()
-            .flat_map(move |app| desktop.websites_for_app(app).cloned().collect::<Vec<_>>())
+            .flat_map(move |app| {
+                desktop_state
+                    .websites_for_app(app)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
             .collect();
         Ok((processes, websites))
     }
@@ -334,11 +339,11 @@ impl Sentry {
     ) -> Result<(Vec<Window>, Vec<BaseWebsiteUrl>)> {
         let target_apps = self.mgr.target_apps(target).await?;
 
-        let desktop = self.desktop.read().await;
+        let desktop_state = self.desktop_state.read().await;
         let windows = target_apps
             .iter()
             .flat_map(move |app| {
-                desktop
+                desktop_state
                     .platform_windows_for_app(app)
                     .cloned()
                     .collect::<Vec<_>>() // ew
@@ -346,10 +351,15 @@ impl Sentry {
             .collect();
 
         // yes, we lock twice here ...
-        let desktop = self.desktop.read().await;
+        let desktop_state = self.desktop_state.read().await;
         let websites = target_apps
             .iter()
-            .flat_map(move |app| desktop.websites_for_app(app).cloned().collect::<Vec<_>>())
+            .flat_map(move |app| {
+                desktop_state
+                    .websites_for_app(app)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
             .collect();
         Ok((windows, websites))
     }

--- a/src/platform/src/events/tab.rs
+++ b/src/platform/src/events/tab.rs
@@ -9,7 +9,7 @@ use crate::web;
 /// Watches a browser (by PID) for tab changes. Changes should be reported as fast as possible.
 pub struct BrowserTabWatcher {
     browser_pids: SmallHashMap<ProcessId, WindowTitleWatcher>,
-    browser_state: web::State,
+    web_state: web::State,
     tab_change_tx: Sender<TabChange>,
 }
 
@@ -27,10 +27,10 @@ pub enum TabChange {
 
 impl BrowserTabWatcher {
     /// Create a new [BrowserTabWatcher]
-    pub fn new(tab_change_tx: Sender<TabChange>, browser_state: web::State) -> Result<Self> {
+    pub fn new(tab_change_tx: Sender<TabChange>, web_state: web::State) -> Result<Self> {
         Ok(Self {
             browser_pids: SmallHashMap::new(),
-            browser_state,
+            web_state,
             tab_change_tx,
         })
     }
@@ -58,7 +58,7 @@ impl BrowserTabWatcher {
     pub fn tick(&mut self) -> Result<()> {
         {
             let pids = {
-                let state = self.browser_state.blocking_read();
+                let state = self.web_state.blocking_read();
                 state.browser_processes.clone() // unfortunately we need to clone here
             };
             self.update_browsers(&pids)?;

--- a/src/util/Cargo.toml
+++ b/src/util/Cargo.toml
@@ -20,3 +20,4 @@ tracing-appender = "0.2.3"
 tokio = { version = "1.43", features = ["macros", "rt-multi-thread"] }
 dirs = "6.0.0"
 serde_json = "1.0.140"
+backon = "1.5.1"

--- a/src/util/src/lib.rs
+++ b/src/util/src/lib.rs
@@ -10,6 +10,8 @@ pub mod ds;
 pub mod error;
 /// Async base
 pub mod future;
+/// Retry helpers
+pub mod retry;
 ///  Common timesystem traits
 pub mod time;
 /// Logging, tracing helpers

--- a/src/util/src/retry.rs
+++ b/src/util/src/retry.rs
@@ -1,0 +1,1 @@
+pub use backon::*;


### PR DESCRIPTION
### TL;DR

Refactored the engine's state management by introducing a shared `DesktopState` and implementing retry mechanisms for more robust operation.

### What changed?

- Renamed `Cache` to `DesktopStateInner` and wrapped it in an `Arc<RwLock<>>` as `DesktopState` for better concurrency
- Moved cache.rs to desktop.rs to better reflect its purpose
- Restructured the engine initialization with clearer `EngineArgs` instead of `EngineOptions`
- Added retry mechanisms using the `backon` crate for both the engine and sentry loops
- Improved error handling and recovery for critical components
- Reorganized code structure to make desktop state management more consistent
- Renamed browser_state to web_state for naming consistency