### PR TITLE
Minor Engine Refactors

### DIFF
--- a/dev/tools/src/bin/browser.rs
+++ b/dev/tools/src/bin/browser.rs
@@ -1,7 +1,7 @@
 //! List out browser information
 
 use clap::Parser;
-use platform::web::{BrowserDetector, WebsiteInfo};
+use platform::web;
 use tools::filters::{
     ProcessDetails, ProcessFilter, WindowDetails, WindowFilter, match_running_windows,
 };
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         },
     )?;
 
-    let detect = BrowserDetector::new()?;
+    let detect = web::Detect::new()?;
 
     let mut browsers = vec![];
     for window_group in window_group {
@@ -72,10 +72,10 @@ async fn main() -> Result<()> {
             let url = detect.chromium_url(&element)?;
             let incognito = detect.chromium_incognito(&element)?;
             let (name, description) = if let Some(url) = &url {
-                let base_url = WebsiteInfo::url_to_base_url(url)?;
-                let website_info = WebsiteInfo::from_base_url(base_url.clone())
+                let base_url = web::WebsiteInfo::url_to_base_url(url)?;
+                let website_info = web::WebsiteInfo::from_base_url(base_url.clone())
                     .await
-                    .unwrap_or(WebsiteInfo::default_from_url(base_url));
+                    .unwrap_or(web::WebsiteInfo::default_from_url(base_url));
                 (Some(website_info.name), Some(website_info.description))
             } else {
                 (None, None)

--- a/dev/tools/src/bin/close_tab.rs
+++ b/dev/tools/src/bin/close_tab.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 use dialoguer::Select;
 use dialoguer::theme::ColorfulTheme;
-use platform::web::BrowserDetector;
+use platform::web;
 use tools::filters::{
     ProcessFilter, ProcessWindowGroup, WindowDetails, WindowFilter, match_running_windows,
 };
@@ -36,10 +36,10 @@ fn main() -> Result<()> {
         },
     )?;
 
-    let browser = BrowserDetector::new()?;
+    let detect = web::Detect::new()?;
     if let Some(details) = select_window(&matches)? {
-        let element = browser.get_chromium_element(&details.window)?;
-        browser.close_current_tab(&element)?;
+        let element = detect.get_chromium_element(&details.window)?;
+        detect.close_current_tab(&element)?;
     } else {
         eprintln!("No windows found matching the criteria");
     }

--- a/dev/tools/src/bin/tab_switch.rs
+++ b/dev/tools/src/bin/tab_switch.rs
@@ -3,7 +3,7 @@
 use std::io::stdin;
 
 use platform::objects::Window;
-use platform::web::BrowserDetector;
+use platform::web;
 use tools::filters::{ProcessFilter, WindowFilter, match_running_windows};
 use util::error::Result;
 use util::tracing::info;
@@ -41,7 +41,7 @@ mod tab_track_handler {
             _sender: windows_core::Ref<'_, IUIAutomationElement>,
             _eventid: UIA_EVENT_ID,
         ) -> windows::core::Result<()> {
-            let detect = BrowserDetector::new().expect("Failed to create browser detector");
+            let detect = web::Detect::new().expect("Failed to create browser detector");
             let element = detect
                 .get_chromium_element(&self.window)
                 .expect("Failed to get Chromium element");

--- a/dev/tools/src/bin/tab_track.rs
+++ b/dev/tools/src/bin/tab_track.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 
 use platform::events::WindowTitleWatcher;
 use platform::objects::{EventLoop, Target, Window};
-use platform::web::BrowserDetector;
+use platform::web;
 use tools::filters::{ProcessFilter, WindowFilter, match_running_windows};
 use util::error::Result;
 // use util::tracing::info;
@@ -18,18 +18,18 @@ use util::{Target as UtilTarget, config, future as tokio};
 // }
 
 struct UnsafeSyncSendBrowserDetect {
-    browser: BrowserDetector,
+    detect: web::Detect,
 }
 
 impl UnsafeSyncSendBrowserDetect {
     fn new() -> Result<Self> {
-        let browser = BrowserDetector::new()?;
-        Ok(Self { browser })
+        let detect = web::Detect::new()?;
+        Ok(Self { detect })
     }
 
     pub fn chromium_url(&self, window: &Window) -> Result<Option<String>> {
-        let element = self.browser.get_chromium_element(window)?;
-        self.browser.chromium_url(&element)
+        let element = self.detect.get_chromium_element(window)?;
+        self.detect.chromium_url(&element)
     }
 }
 

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -15,7 +15,7 @@ use platform::events::{
     WindowSession,
 };
 use platform::objects::{Duration, EventLoop, MessageWindow, Timer, Timestamp, User};
-use platform::web::{self, BrowserDetector};
+use platform::web;
 use resolver::AppInfoResolver;
 use sentry::Sentry;
 use util::channels::{self, Receiver, Sender};
@@ -406,10 +406,10 @@ async fn update_app_infos(db_pool: DatabasePool, handle: Handle) -> Result<()> {
 
 /// Get the foreground [Window], and makes it into a [WindowSession] blocking until one is present.
 fn foreground_window_session(config: &Config, web_state: web::State) -> Result<WindowSession> {
-    let browser = BrowserDetector::new()?;
+    let detect = web::Detect::new()?;
     loop {
         let session = ForegroundEventWatcher::foreground_window_session(
-            &browser,
+            &detect,
             web_state.blocking_write(),
             config.track_incognito(),
         )?;
@@ -428,10 +428,10 @@ async fn foreground_window_session_async(
     config: &Config,
     web_state: web::State,
 ) -> Result<WindowSession> {
-    let browser = BrowserDetector::new()?;
+    let detect = web::Detect::new()?;
     loop {
         let session = ForegroundEventWatcher::foreground_window_session(
-            &browser,
+            &detect,
             web_state.write().await,
             config.track_incognito(),
         )?;

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -21,7 +21,7 @@ use sentry::Sentry;
 use util::channels::{self, Receiver, Sender};
 use util::config::{self, Config};
 use util::error::{Context, Result};
-use util::future::runtime::{Builder, Handle};
+use util::future::runtime::{Builder, Handle, Runtime};
 use util::future::sync::Mutex;
 use util::future::task::JoinHandle;
 use util::retry::{ExponentialBuilder, Retryable, RetryableWithContext};
@@ -37,13 +37,24 @@ mod sentry;
 
 /// Entry point for the engine
 pub fn main() {
-    if let Err(report) = real_main() {
+    let (config, rt) = match setup() {
+        Ok(v) => v,
+        Err(e) => {
+            error!("fatal error caught in setup: {:?}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let web_state = web::default_state();
+    let desktop_state = desktop::new_desktop_state(web_state.clone());
+
+    if let Err(report) = run(&config, rt.handle().clone(), web_state, desktop_state) {
         error!("fatal error caught in main: {:?}", report);
         std::process::exit(1);
     }
 }
 
-fn real_main() -> Result<()> {
+fn setup() -> Result<(Config, Runtime)> {
     util::set_target(Target::Engine);
     let config = config::get_config()?;
     util::setup(&config)?;
@@ -51,20 +62,26 @@ fn real_main() -> Result<()> {
     platform::setup()?;
     info!("running as {:?}", User::current()?);
 
-    let web_state = web::default_state();
-    let desktop_state = desktop::new_desktop_state(web_state.clone());
-
-    let (event_tx, event_rx) = channels::unbounded();
-    let (alert_tx, alert_rx) = channels::unbounded();
-    let (tab_change_tx, tab_change_rx) = channels::unbounded();
-
     let rt = Builder::new_multi_thread()
         .enable_time()
         .enable_io()
         .build()?;
 
+    Ok((config, rt))
+}
+
+fn run(
+    config: &Config,
+    rt: Handle,
+    web_state: web::State,
+    desktop_state: desktop::DesktopState,
+) -> Result<()> {
+    let (event_tx, event_rx) = channels::unbounded();
+    let (alert_tx, alert_rx) = channels::unbounded();
+    let (tab_change_tx, tab_change_rx) = channels::unbounded();
+
     let start = Timestamp::now();
-    let window_session = foreground_window_session(&config, web_state.clone())?;
+    let window_session = foreground_window_session(config, web_state.clone())?;
 
     let ev_thread = {
         let config = config.clone();
@@ -87,11 +104,11 @@ fn real_main() -> Result<()> {
             })?
     };
 
-    rt.block_on(processor(ProcessorArgs {
+    rt.clone().block_on(processor(ProcessorArgs {
         desktop_state,
         web_state,
-        config,
-        rt: rt.handle().clone(),
+        config: config.clone(),
+        rt,
         window_session,
         start,
         event_rx,

--- a/src/platform/src/web/browser.rs
+++ b/src/platform/src/web/browser.rs
@@ -7,8 +7,9 @@ use windows::Win32::UI::Accessibility::{
     IUIAutomationCondition, IUIAutomationElement, IUIAutomationElement9,
     IUIAutomationInvokePattern, TreeScope_Children, TreeScope_Descendants,
     TreeTraversalOptions_LastToFirstOrder, UIA_AutomationIdPropertyId, UIA_ButtonControlTypeId,
-    UIA_ClassNamePropertyId, UIA_ControlTypePropertyId, UIA_InvokePatternId, UIA_NamePropertyId,
-    UIA_SelectionItemIsSelectedPropertyId, UIA_TabItemControlTypeId, UIA_ValueValuePropertyId,
+    UIA_ClassNamePropertyId, UIA_ControlTypePropertyId, UIA_DocumentControlTypeId,
+    UIA_InvokePatternId, UIA_NamePropertyId, UIA_SelectionItemIsSelectedPropertyId,
+    UIA_TabItemControlTypeId, UIA_ValueValuePropertyId,
 };
 use windows::core::{AgileReference, Interface};
 
@@ -55,7 +56,13 @@ impl BrowserDetector {
                 .CreatePropertyCondition(UIA_ClassNamePropertyId, &"BrowserRootView".into())?
         };
         let root_web_area_cond = unsafe {
-            automation.CreatePropertyCondition(UIA_AutomationIdPropertyId, &"RootWebArea".into())?
+            let control_cond = automation.CreatePropertyCondition(
+                UIA_ControlTypePropertyId,
+                &UIA_DocumentControlTypeId.0.into(),
+            )?;
+            let class_cond = automation
+                .CreatePropertyCondition(UIA_AutomationIdPropertyId, &"RootWebArea".into())?;
+            automation.CreateAndCondition(&control_cond, &class_cond)?
         };
         let omnibox_cond = unsafe {
             automation

--- a/src/platform/src/web/detect.rs
+++ b/src/platform/src/web/detect.rs
@@ -38,7 +38,7 @@ fn perf<T>(f: impl FnOnce() -> T, name: &str) -> T {
 
 /// Detects browser usage information
 #[derive(Clone)]
-pub struct BrowserDetector {
+pub struct Detect {
     automation: AgileReference<IUIAutomation>,
     browser_root_view_cond: AgileReference<IUIAutomationCondition>,
     root_web_area_cond: AgileReference<IUIAutomationCondition>,
@@ -46,7 +46,7 @@ pub struct BrowserDetector {
     cache_request: AgileReference<IUIAutomationCacheRequest>,
 }
 
-impl BrowserDetector {
+impl Detect {
     /// Create a new [BrowserDetector]
     pub fn new() -> Result<Self> {
         let automation: IUIAutomation =

--- a/src/platform/src/web/mod.rs
+++ b/src/platform/src/web/mod.rs
@@ -1,7 +1,7 @@
-mod browser;
+mod detect;
 mod state;
 mod website_info;
 
-pub use browser::*;
+pub use detect::*;
 pub use state::*;
 pub use website_info::*;


### PR DESCRIPTION
# Refactor Web Browser Detection and Engine Initialization

This PR refactors the browser detection module and engine initialization process:

- Renamed `BrowserDetector` to `web::Detect` for better clarity
- Split engine initialization into separate `setup()` and `run()` functions
- Improved browser detection by using more specific conditions for RootWebArea
- Updated imports across multiple tools to use the new naming convention
- Simplified web module imports by using qualified paths

These changes improve code organization and make the browser detection more reliable.