### PR TITLE
Expand Web State

### DIFF
--- a/src/engine/src/desktop.rs
+++ b/src/engine/src/desktop.rs
@@ -228,37 +228,6 @@ impl DesktopStateInner {
         Ok(self.web.websites.entry(base_url).or_insert(created))
     }
 
-    // TODO: remove these two methods
-
-    pub async fn is_browser(&self, window: &Window) -> Option<bool> {
-        let state = self.web.state.read().await;
-        state.browser_windows.get(window).map(|s| s.is_some())
-    }
-
-    /// Get all browser windows.
-    pub async fn browser_windows(&self) -> SmallHashSet<Window> {
-        let state = self.web.state.read().await;
-        state
-            .browser_windows
-            .iter()
-            .filter_map(
-                |(window, state)| {
-                    if state.is_some() { Some(window) } else { None }
-                },
-            )
-            .cloned()
-            .collect()
-    }
-
-    // pub async fn get_or_insert_session_for_window(&mut self, window: Window, create: impl Future<Output = Result<SessionDetails>>) -> Result<&SessionDetails> {
-
-    //     unimplemented!()
-    // }
-
-    // pub async fn get_or_insert_app_for_process(&mut self, process: Process, create: impl Future<Output = Result<AppDetails>>) -> Result<&AppDetails> {
-    //     unimplemented!()
-    // }
-
     /// Remove a process and associated windows from the [Cache].
     pub async fn remove_process(&mut self, process: ProcessId) {
         let removed_windows = self

--- a/src/engine/src/desktop.rs
+++ b/src/engine/src/desktop.rs
@@ -228,9 +228,11 @@ impl DesktopStateInner {
         Ok(self.web.websites.entry(base_url).or_insert(created))
     }
 
+    // TODO: remove these two methods
+
     pub async fn is_browser(&self, window: &Window) -> Option<bool> {
         let state = self.web.state.read().await;
-        state.browser_windows.get(window).copied()
+        state.browser_windows.get(window).map(|s| s.is_some())
     }
 
     /// Get all browser windows.
@@ -240,8 +242,8 @@ impl DesktopStateInner {
             .browser_windows
             .iter()
             .filter_map(
-                |(window, is_browser)| {
-                    if *is_browser { Some(window) } else { None }
+                |(window, state)| {
+                    if state.is_some() { Some(window) } else { None }
                 },
             )
             .cloned()

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -198,20 +198,10 @@ impl Engine {
     /// Get the [Session] details for the given [WindowSession]
     async fn get_session_details(
         &mut self,
-        mut session: ForegroundWindowSessionInfo,
+        session: ForegroundWindowSessionInfo,
         at: Timestamp,
     ) -> Result<Ref<Session>> {
         let mut desktop_state = self.desktop_state.write().await;
-
-        // If window is browser (assume true if unknown), then we need the url.
-        // Else set the url to None.
-        if !desktop_state
-            .is_browser(&session.window_session.window)
-            .await
-            .unwrap_or(true)
-        {
-            session.window_session.url = None;
-        }
 
         let session_details = desktop_state
             .get_or_insert_session_for_window(session.clone(), |desktop_state| {

--- a/src/platform/src/events/foreground.rs
+++ b/src/platform/src/events/foreground.rs
@@ -1,6 +1,7 @@
 use util::config::Config;
 use util::error::{Context, ContextCompat, Result};
 use util::tracing::ResultTraceExt;
+use windows::core::AgileReference;
 
 use crate::objects::{Process, Timestamp, Window};
 use crate::web;
@@ -130,17 +131,19 @@ impl ForegroundEventWatcher {
 
         // TODO: instead of Option's context("no element") we should use backon retries
         let state = if is_browser {
-            let element = detect.get_chromium_element(window)?;
+            let window_element = detect.get_chromium_element(window)?;
             let is_incognito = detect
-                .chromium_incognito(&element)
+                .chromium_incognito(&window_element)
                 .context("get chromium incognito")?
                 .context("no element")?;
             let last_url = detect
-                .chromium_url(&element)
+                .chromium_url(&window_element)
                 .context("get chromium url")?
                 .context("no element")?;
             let last_title = window.title()?;
+            let window_element = AgileReference::new(&window_element)?;
             Some(web::BrowserWindowState {
+                window_element,
                 is_incognito,
                 last_url,
                 last_title,

--- a/src/platform/src/events/foreground.rs
+++ b/src/platform/src/events/foreground.rs
@@ -1,5 +1,5 @@
 use util::config::Config;
-use util::error::{Context, Result};
+use util::error::{Context, ContextCompat, Result};
 use util::tracing::ResultTraceExt;
 
 use crate::objects::{Process, Timestamp, Window};
@@ -75,23 +75,13 @@ impl ForegroundEventWatcher {
         track_incognito: bool,
     ) -> Result<Option<ForegroundWindowSessionInfo>> {
         if let Some(window) = Window::foreground() {
-            let (is_browser, fetched_path) =
-                Self::browser_window_session(&window, detect, web_state)?;
+            let (state, fetched_path) = Self::browser_window_session(&window, detect, web_state)?;
 
-            let (title, url) = if is_browser {
-                let element = detect.get_chromium_element(&window)?;
-                let incognito = detect
-                    .chromium_incognito(&element)
-                    .context("get chromium incognito")?;
-                if let Some(incognito) = incognito
-                    && incognito
-                    && !track_incognito
-                {
+            let (title, url) = if let Some(state) = state {
+                if state.is_incognito && !track_incognito {
                     ("<Incognito>".to_string(), None)
                 } else {
-                    let url = detect.chromium_url(&element).context("get chromium url")?;
-                    let title = window.title()?;
-                    (title, url)
+                    (state.last_title, Some(state.last_url))
                 }
             } else {
                 (window.title()?, None)
@@ -111,11 +101,11 @@ impl ForegroundEventWatcher {
         window: &Window,
         detect: &web::Detect,
         mut web_state: web::WriteLockedState<'_>,
-    ) -> Result<(bool, Option<String>)> {
-        let is_browser = web_state.browser_windows.get(window).cloned();
-        if let Some(is_browser) = is_browser {
+    ) -> Result<(Option<web::BrowserWindowState>, Option<String>)> {
+        let state = web_state.browser_windows.get(window);
+        if let Some(state) = state {
             // We know already if it's a browser or not
-            return Ok((is_browser, None));
+            return Ok((state.clone(), None));
         }
 
         // Educated guess. Note that VSCode will pass this check since it's a chromium app.
@@ -138,8 +128,31 @@ impl ForegroundEventWatcher {
             (false, None)
         };
 
-        web_state.browser_windows.insert(window.clone(), is_browser);
+        // TODO: instead of Option's context("no element") we should use backon retries
+        let state = if is_browser {
+            let element = detect.get_chromium_element(window)?;
+            let is_incognito = detect
+                .chromium_incognito(&element)
+                .context("get chromium incognito")?
+                .context("no element")?;
+            let last_url = detect
+                .chromium_url(&element)
+                .context("get chromium url")?
+                .context("no element")?;
+            let last_title = window.title()?;
+            Some(web::BrowserWindowState {
+                is_incognito,
+                last_url,
+                last_title,
+            })
+        } else {
+            None
+        };
 
-        Ok((is_browser, fetched_path))
+        web_state
+            .browser_windows
+            .insert(window.clone(), state.clone());
+
+        Ok((state, fetched_path))
     }
 }

--- a/src/platform/src/web/state.rs
+++ b/src/platform/src/web/state.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use util::ds::{SmallHashMap, SmallHashSet};
 use util::future::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use windows::Win32::UI::Accessibility::IUIAutomationElement9;
+use windows::core::AgileReference;
 
 use crate::objects::{ProcessId, Window};
 
@@ -18,8 +20,10 @@ pub struct StateInner {
 }
 
 /// State of a browser window
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct BrowserWindowState {
+    /// UI Automation element of the window
+    pub window_element: AgileReference<IUIAutomationElement9>,
     /// Whether the window is in incognito mode
     pub is_incognito: bool,
     /// Last URL of the window

--- a/src/platform/src/web/state.rs
+++ b/src/platform/src/web/state.rs
@@ -10,9 +10,22 @@ use crate::objects::{ProcessId, Window};
 pub struct StateInner {
     /// Cache of whether a window is a browser or not.
     /// Not present means that we don't know if it's a browser or not.
-    pub browser_windows: SmallHashMap<Window, bool>,
+    /// Value = None means it's not a browser window.
+    /// Value = Some(BrowserWindowState) means it's a browser window and this is the state.
+    pub browser_windows: SmallHashMap<Window, Option<BrowserWindowState>>,
     /// Processes that are known to be browsers.
     pub browser_processes: SmallHashSet<ProcessId>,
+}
+
+/// State of a browser window
+#[derive(Debug, Default, Clone)]
+pub struct BrowserWindowState {
+    /// Whether the window is in incognito mode
+    pub is_incognito: bool,
+    /// Last URL of the window
+    pub last_url: String,
+    /// Last title of the window
+    pub last_title: String,
 }
 
 /// Shared state of browsers and websites seen in the desktop

--- a/src/platform/src/web/state.rs
+++ b/src/platform/src/web/state.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use util::ds::{SmallHashMap, SmallHashSet};
+use util::error::Result;
 use util::future::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use windows::Win32::UI::Accessibility::IUIAutomationElement9;
 use windows::core::AgileReference;
@@ -30,6 +31,24 @@ pub struct BrowserWindowState {
     pub last_url: String,
     /// Last title of the window
     pub last_title: String,
+}
+
+impl StateInner {
+    /// Get the UI Automation element for the [Window]
+    pub fn get_browser_window_element(
+        &self,
+        window: &Window,
+    ) -> Result<Option<IUIAutomationElement9>> {
+        let Some(state) = self.browser_windows.get(window) else {
+            return Ok(None);
+        };
+
+        let Some(state) = state else {
+            return Ok(None);
+        };
+
+        Ok(Some(state.window_element.resolve()?))
+    }
 }
 
 /// Shared state of browsers and websites seen in the desktop


### PR DESCRIPTION
### TL;DR

Refactored browser window state tracking to store more information about browser windows, including URL, title, and incognito status.

### What changed?

- Changed `browser_windows` map to store `Option<BrowserWindowState>` instead of just a boolean
- Added `BrowserWindowState` struct to store window element, incognito status, URL, and title
- Updated `TabChange` to include the URL when a tab changes
- Modified `Sentry` to use the stored browser window state instead of detecting it each time
- Added `web_state` parameter to `Sentry` constructor and `sentry_loop` function
- Updated browser window detection to store more information about the window
- Added `get_browser_window_element` helper method to retrieve UI Automation elements