### PR TITLE
Engine Fixes: Tool Target

### DIFF
--- a/dev/tools/src/bin/browser.rs
+++ b/dev/tools/src/bin/browser.rs
@@ -42,7 +42,9 @@ struct TabDetails {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    util::set_target(Target::Engine);
+    util::set_target(Target::Tool {
+        name: "browser".to_string(),
+    });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;

--- a/dev/tools/src/bin/close_tab.rs
+++ b/dev/tools/src/bin/close_tab.rs
@@ -19,7 +19,9 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    util::set_target(Target::Engine);
+    util::set_target(Target::Tool {
+        name: "close_tab".to_string(),
+    });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;

--- a/dev/tools/src/bin/dim.rs
+++ b/dev/tools/src/bin/dim.rs
@@ -47,7 +47,9 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    util::set_target(Target::Engine);
+    util::set_target(Target::Tool {
+        name: "dim".to_string(),
+    });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;

--- a/dev/tools/src/bin/kill.rs
+++ b/dev/tools/src/bin/kill.rs
@@ -37,7 +37,9 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    util::set_target(Target::Engine);
+    util::set_target(Target::Tool {
+        name: "kill".to_string(),
+    });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;

--- a/dev/tools/src/bin/tab_switch.rs
+++ b/dev/tools/src/bin/tab_switch.rs
@@ -110,7 +110,9 @@ impl TabSelectionEventHandler {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    util::set_target(UtilTarget::Engine);
+    util::set_target(UtilTarget::Tool {
+        name: "tab_switch".to_string(),
+    });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;

--- a/dev/tools/src/bin/tab_track.rs
+++ b/dev/tools/src/bin/tab_track.rs
@@ -38,7 +38,9 @@ unsafe impl Sync for UnsafeSyncSendBrowserDetect {}
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    util::set_target(UtilTarget::Engine);
+    util::set_target(UtilTarget::Tool {
+        name: "tab_track".to_string(),
+    });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
 
 use super::repo_crud::APP_DUR;
 use super::*;
@@ -324,8 +323,7 @@ impl Repository {
             .execute(self.db.executor())
             .await?;
 
-        let dir_path = Config::icons_dir()?;
-        let dir = Path::new(&dir_path);
+        let dir = Config::icons_dir()?;
 
         for icon in icons {
             let path = dir.join(icon.icon);

--- a/src/engine/src/resolver.rs
+++ b/src/engine/src/resolver.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use data::db::{AppUpdater, DatabasePool};
 use data::entities::{App, AppIdentity, Ref};
 use platform::objects::AppInfo;
@@ -54,7 +52,7 @@ impl AppInfoResolver {
             let id = app.0.to_string();
             let ext = icon.deduce_ext();
             let file_name = format!("{}.{}", id, ext.unwrap_or("bin".to_string()));
-            let icon_path = Path::new(&icons_dir).join(&file_name);
+            let icon_path = icons_dir.join(&file_name);
             fs::write(&icon_path, icon.data).await?;
             Some(file_name)
         } else {

--- a/src/platform/src/web/detect.rs
+++ b/src/platform/src/web/detect.rs
@@ -86,10 +86,9 @@ impl Detect {
 
     /// Check if the path is a browser. Not meant to be super-accurate, but should be good enough.
     pub fn is_chromium_exe(&self, path: &str) -> bool {
-        let path_lower = path.to_lowercase();
         BROWSERS
             .iter()
-            .any(|browser| path_lower.to_lowercase() == browser.to_lowercase())
+            .any(|browser| path.to_lowercase() == browser.to_lowercase())
     }
 
     /// Check if the [Window] is a Chromium browser

--- a/src/ui/src-tauri/src/config.rs
+++ b/src/ui/src-tauri/src/config.rs
@@ -28,5 +28,9 @@ pub async fn config_set_track_incognito(state: State<'_, AppState>, value: bool)
 #[tauri::command]
 #[tracing::instrument(err)]
 pub async fn get_icons_dir() -> AppResult<String> {
-    Ok(Config::icons_dir().context("get icons dir")?)
+    let path = Config::icons_dir().context("get icons dir")?;
+    Ok(std::path::absolute(path)
+        .context("get absolute path")?
+        .to_string_lossy()
+        .to_string())
 }

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -117,9 +117,9 @@ fn check_and_remove_file(file: &str) -> util::error::Result<()> {
         .map(|f| f.is_file())
         .unwrap_or(false)
     {
-        std::fs::remove_file(&file).context(format!("remove {}", &file))?;
+        std::fs::remove_file(&file).context(format!("remove {:?}", &file))?;
     } else {
-        warn!("file {} not found", file);
+        warn!("file {:?} not found", file);
     }
     Ok(())
 }
@@ -127,9 +127,9 @@ fn check_and_remove_file(file: &str) -> util::error::Result<()> {
 fn check_and_remove_dir(dir: &str) -> util::error::Result<()> {
     let dir = util::config::Config::config_path(dir)?;
     if std::fs::metadata(&dir).map(|f| f.is_dir()).unwrap_or(false) {
-        std::fs::remove_dir_all(&dir).context(format!("remove {}", &dir))?;
+        std::fs::remove_dir_all(&dir).context(format!("remove {:?}", &dir))?;
     } else {
-        warn!("dir {} not found", dir);
+        warn!("dir {:?} not found", dir);
     }
     Ok(())
 }
@@ -143,7 +143,7 @@ fn check_and_copy_file(dir: &Path, file: &str) -> util::error::Result<()> {
     {
         std::fs::copy(from_file, to_file).context(format!("copy {file}"))?;
     } else {
-        warn!("file {} not found", file);
+        warn!("file {file} not found");
     }
     Ok(())
 }

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -60,15 +60,10 @@ impl Config {
         #[cfg(not(debug_assertions))]
         {
             use std::io::{Error, ErrorKind};
-            dirs::data_local_dir()
+            Ok(dirs::data_local_dir()
                 .ok_or(Error::new(ErrorKind::NotFound, "data local dir"))?
                 .join("me.enigmatrix.cobalt")
-                .join(segment)
-                .into_os_string()
-                .into_string()
-                .map_err(|oss| {
-                    Error::new(ErrorKind::Other, format!("convert path to utf8: {:?}", oss))
-                })
+                .join(segment))
         }
     }
 

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -51,6 +51,7 @@ impl Config {
             match target {
                 Target::Engine => Ok(PathBuf::from(segment)),
                 Target::Ui => Ok(PathBuf::from("../../../").join(segment)),
+                Target::Tool { .. } => Ok(PathBuf::from(segment)),
             }
         }
 

--- a/src/util/src/lib.rs
+++ b/src/util/src/lib.rs
@@ -30,6 +30,11 @@ pub enum Target {
     /// Engine module target
     #[default]
     Engine,
+    /// Tool target
+    Tool {
+        /// Name of the tool
+        name: String,
+    },
 }
 
 static INIT: Once = Once::new();

--- a/src/util/src/tracing.rs
+++ b/src/util/src/tracing.rs
@@ -60,8 +60,10 @@ impl<T: Default> ResultTraceExt<T> for Result<T> {
 pub fn setup(config: &Config) -> Result<()> {
     let target = TARGET.lock().unwrap().clone();
     let (filter_directives, log_file) = match target {
-        Target::Ui => (config.ui_log_filter(), "Cobalt.Ui"),
-        Target::Engine => (config.engine_log_filter(), "Cobalt.Engine"),
+        Target::Ui => (config.ui_log_filter(), "Cobalt.Ui".to_string()),
+        Target::Engine => (config.engine_log_filter(), "Cobalt.Engine".to_string()),
+        // TODO: what should the log filter directive be for this?
+        Target::Tool { name, .. } => (config.engine_log_filter(), format!("Cobalt.Tool.{name}")),
     };
 
     let rolling = RollingFileAppender::builder()


### PR DESCRIPTION
# Tool Target

This PR improves path handling throughout the codebase by:

- Changing `Config::icons_dir()` and other path-related methods to return `PathBuf` instead of `String`
- Updating all callers to use proper path manipulation methods
- Adding a new `Target::Tool` variant with a name field to better identify different tools in logs
- Updating all tool binaries to use the new `Target::Tool` variant with their specific names
- Improving error messages by using debug formatting for paths
- Fixing a redundant `to_lowercase()` call in `is_chromium_exe()`
- Ensuring the `get_icons_dir()` command returns an absolute path

These changes make path handling more robust and improve logging for tools.