### PR TITLE
Add driver_web_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -4362,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5671,6 +5671,8 @@ dependencies = [
  "dialoguer",
  "engine",
  "platform",
+ "serde",
+ "serde_json",
  "util",
  "windows 0.59.0",
  "windows-core 0.59.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,6 +5669,7 @@ version = "0.5.0"
 dependencies = [
  "clap",
  "dialoguer",
+ "engine",
  "platform",
  "util",
  "windows 0.59.0",

--- a/dev/tools/Cargo.toml
+++ b/dev/tools/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 clap = { version = "4.4", features = ["derive"] }
 util = { path = "../../src/util" }
 platform = { path = "../../src/platform" }
+engine = { path = "../../src/engine" }
 dialoguer = "0.11.0"
 
 [dependencies.windows-core]

--- a/dev/tools/Cargo.toml
+++ b/dev/tools/Cargo.toml
@@ -14,6 +14,8 @@ util = { path = "../../src/util" }
 platform = { path = "../../src/platform" }
 engine = { path = "../../src/engine" }
 dialoguer = "0.11.0"
+serde = "1.0.219"
+serde_json = "1.0.140"
 
 [dependencies.windows-core]
 version = "0.59"

--- a/dev/tools/src/bin/driver_web_state.rs
+++ b/dev/tools/src/bin/driver_web_state.rs
@@ -1,0 +1,147 @@
+//! Driver to poll the [web::State] as the engine is runningand save it to a file
+
+use std::thread;
+use std::time::UNIX_EPOCH;
+
+use engine::desktop;
+use platform::objects::Window;
+use platform::web;
+use util::ds::SmallHashMap;
+use util::error::Result;
+use util::tracing::error;
+use util::{Target, config, future as tokio};
+
+fn main() -> Result<()> {
+    util::set_target(Target::Engine);
+    let config = config::get_config()?;
+    util::setup(&config)?;
+    platform::setup()?;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_time()
+        .enable_io()
+        .build()?;
+
+    let web_state = web::default_state();
+    let desktop_state = desktop::new_desktop_state(web_state.clone());
+
+    let _web_state = web_state.clone();
+    thread::spawn(move || {
+        let mut driver = Driver::new(_web_state);
+        loop {
+            let ts = std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            let events = driver.step(ts);
+            for event in events {
+                println!("{event:?}");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    });
+
+    if let Err(report) = engine::run(&config, rt.handle().clone(), web_state, desktop_state) {
+        error!("fatal error caught in main: {:?}", report);
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+struct Driver {
+    current_state: RecordedState,
+    state: web::State,
+}
+
+impl Driver {
+    fn new(state: web::State) -> Self {
+        let current_state = RecordedState::from(&*state.blocking_read());
+        Self {
+            state,
+            current_state,
+        }
+    }
+
+    fn step(&mut self, ts: u64) -> Vec<Event> {
+        let new_state = RecordedState::from(&*self.state.blocking_read());
+        let events = self.current_state.diff(&new_state, ts);
+        self.current_state = new_state;
+        events
+    }
+}
+
+/// Shared inner state of browsers and websites seen in the desktop
+#[derive(Debug, Default)]
+struct RecordedState {
+    pub browser_windows: SmallHashMap<Window, Option<BrowserWindowContext>>,
+    // pub browser_processes: SmallHashSet<ProcessId>,
+}
+
+impl From<&web::StateInner> for RecordedState {
+    fn from(state: &web::StateInner) -> Self {
+        Self {
+            browser_windows: state
+                .browser_windows
+                .iter()
+                .map(|(window, state)| {
+                    (
+                        window.clone(),
+                        state.clone().map(|state| BrowserWindowContext {
+                            is_incognito: state.is_incognito,
+                            url: state.last_url.clone(),
+                            title: state.last_title.clone(),
+                        }),
+                    )
+                })
+                .collect(),
+            // browser_processes: state.browser_processes.clone(),
+        }
+    }
+}
+
+impl RecordedState {
+    fn diff(&self, new_state: &RecordedState, ts: u64) -> Vec<Event> {
+        let mut events = Vec::new();
+
+        for (window, ctx) in &new_state.browser_windows {
+            let Some(ctx) = ctx else { continue };
+            let old_ctx = self.browser_windows.get(window);
+            let change = if let Some(old_state) = old_ctx {
+                let old_ctx = old_state
+                    .as_ref()
+                    .expect("browser window should remain browser window from start");
+                old_ctx != ctx
+            } else {
+                true
+            };
+
+            if change {
+                events.push(Event::BrowserWindowContextChanged {
+                    context: ctx.clone(),
+                    timestamp: ts,
+                });
+            }
+        }
+
+        events
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct BrowserWindowContext {
+    pub is_incognito: bool,
+    pub url: String,
+    pub title: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum Event {
+    BrowserWindowContextChanged {
+        context: BrowserWindowContext,
+        timestamp: u64,
+    },
+    // WindowFocused {
+    //     window: Window,
+    //     timestamp: u64,
+    // },
+}

--- a/src/engine/src/desktop.rs
+++ b/src/engine/src/desktop.rs
@@ -62,28 +62,36 @@ pub struct PlatformCache {
 /// Details about a [App].
 #[derive(Debug, Default)]
 pub struct AppEntry {
+    /// All [ProcessThreadId]s that are known to be a part of this app
     pub process_threads: SmallHashSet<ProcessThreadId>,
+    /// Identity of the app
     pub identity: AppIdentity,
 }
 
 /// Details about a [Session].
 #[derive(Debug)]
 pub struct SessionDetails {
+    /// Session Id
     pub session: Ref<Session>,
+    /// Process Thread Id
     pub ptid: ProcessThreadId,
 }
 
 /// Details about a [App].
 #[derive(Debug)]
 pub struct AppDetails {
+    /// App Id
     pub app: Ref<App>,
+    /// Identity of the app
     pub identity: AppIdentity,
 }
 
 /// A process that can be killed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum KillableProcessId {
+    /// Win32 Process Id
     Win32(ProcessId),
+    /// Aumid
     Aumid(String),
 }
 

--- a/src/engine/src/engine.rs
+++ b/src/engine/src/engine.rs
@@ -32,28 +32,42 @@ pub struct Engine {
 
 /// Events that the [Engine] can handle.
 pub enum Event {
+    /// System Event
     System {
+        /// System State Event
         event: SystemStateEvent,
+        /// Last interaction before this system event - so that we can write/end the interaction period
         last_interaction: Option<InteractionChangedEvent>,
+        /// Time of occurance
         now: Timestamp,
     },
+    /// Foreground Changed Event
     ForegroundChanged(ForegroundChangedEvent),
+    /// Interaction Changed Event
     InteractionChanged(InteractionChangedEvent),
+    /// Tick Event (manual update)
     Tick(Timestamp),
 }
 
 /// Args for creating a new [Engine].
 #[derive(Clone)]
 pub struct EngineArgs {
+    /// Desktop State
     pub desktop_state: DesktopState,
+    /// Web State
     pub web_state: web::State,
 
+    /// Config
     pub config: Config,
 
+    /// Spawner for async tasks
     pub spawner: Handle,
+    /// Database Pool
     pub db_pool: DatabasePool,
 
+    /// Starting Session
     pub session: ForegroundWindowSessionInfo,
+    /// Start time
     pub start: Timestamp,
 }
 

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -30,10 +30,14 @@ use util::{Target, future};
 
 use crate::engine::EngineArgs;
 
-mod desktop;
-mod engine;
-mod resolver;
-mod sentry;
+/// Desktop State
+pub mod desktop;
+/// Engine for processing events
+pub mod engine;
+/// Resolver for app info
+pub mod resolver;
+/// Sentry for alerting
+pub mod sentry;
 
 /// Entry point for the engine
 pub fn main() {
@@ -70,7 +74,8 @@ fn setup() -> Result<(Config, Runtime)> {
     Ok((config, rt))
 }
 
-fn run(
+/// Run the engine
+pub fn run(
     config: &Config,
     rt: Handle,
     web_state: web::State,


### PR DESCRIPTION
### TL;DR

Added a new tool to monitor and record browser state changes.

### What changed?

- Created a new binary `driver_web_state.rs` that polls the web state while the engine is running and saves changes to a JSON file
- Added dependencies on `engine`, `serde`, and `serde_json` to the tools package
- Made several engine modules public to allow access from the new tool
- Added documentation comments to various engine structs and enums