### PR TITLE
Minor Fixes

### DIFF
--- a/dev/tools/src/bin/driver_web_state.rs
+++ b/dev/tools/src/bin/driver_web_state.rs
@@ -184,5 +184,5 @@ fn time_now() -> u64 {
     std::time::SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_secs()
+        .as_millis() as u64
 }

--- a/src/ui/app/components/app/app-icon.tsx
+++ b/src/ui/app/components/app/app-icon.tsx
@@ -8,7 +8,7 @@ import {
   Tag as TagStatic,
 } from "lucide-static";
 import normalize from "path-normalize";
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 export const DEFAULT_ICON_SVG_URL = "data:image/svg+xml," + CircleHelpStatic;
 export const TAG_ICON_URL = "data:image/svg+xml," + TagStatic;
@@ -45,8 +45,10 @@ export default function AppIcon({
   className?: ClassValue;
 }) {
   const [hasError, setHasError] = useState(false);
-  const icon = useMemo(() => {
-    return appIconUrl(appIcon);
+  const [icon, setIcon] = useState<string | null>(null);
+  useEffect(() => {
+    setHasError(false);
+    setIcon(appIconUrl(appIcon));
   }, [appIcon]);
 
   if (!icon || hasError) {


### PR DESCRIPTION
### TL;DR

Improved URL handling in Chrome detection and fixed timestamp precision in driver web state.

### What changed?

- Changed `time_now()` to use milliseconds instead of seconds for more precise timestamps
- Enhanced URL detection in Chrome by:
  - Adding detection for the omnibox icon to determine if a URL is HTTP or HTTPS
  - Implementing URL elision and un-elision to properly handle URLs shown in the Chrome omnibox
  - Adding logic to handle special cases like localhost URLs
  - Stripping "www." from hosts when appropriate
  - Ensuring paths end with "/" when needed
- Added comprehensive test cases for URL handling
- Fixed app icon loading in the UI to properly reset error state when the icon changes