### PR TITLE
Fix first installation issues

### DIFF
--- a/src/ui/src-tauri/installer/startup-task.wxs
+++ b/src/ui/src-tauri/installer/startup-task.wxs
@@ -1,31 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
-    <!-- Engine component in INSTALLDIR -->
-    <DirectoryRef Id="INSTALLDIR">
-      <Component Id="EngineExe" Guid="024c72e8-2922-4a01-bc3b-b68db4970f13">
-          <CreateFolder />
-          <Shortcut Id="EngineShortcut"
-                    Name="Cobalt.Engine"
-                    Description="Cobalt Engine Shortcut"
-                    Advertise="no"
-                    Directory="INSTALLDIR"
-                    Target="[INSTALLDIR]engine.exe"
-                    WorkingDirectory="INSTALLDIR" />
-      </Component>
-    </DirectoryRef>
-
     <!-- Registry entry for startup -->
     <DirectoryRef Id="TARGETDIR">
       <Component Id="EngineStartup" Guid="*">
         <RegistryKey Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\Run" Action="createAndRemoveOnUninstall">
-          <RegistryValue Name="Cobalt.Engine" Type="string" Value="&quot;[INSTALLDIR]Cobalt.Engine.lnk&quot;" KeyPath="yes" />
+          <RegistryValue Name="Cobalt.Engine" Type="string" Value="&quot;[INSTALLDIR]engine.exe&quot;" KeyPath="yes" />
         </RegistryKey>
       </Component>
     </DirectoryRef>
     
     <!-- Launch engine after installation/upgrade/repair -->
     <CustomAction Id="LaunchEngine" 
+                  Impersonate="yes"
                   ExeCommand="[INSTALLDIR]engine.exe" 
                   Directory="INSTALLDIR"
                   Return="asyncNoWait" />

--- a/src/ui/src-tauri/tauri.conf.json
+++ b/src/ui/src-tauri/tauri.conf.json
@@ -54,7 +54,7 @@
       "wix": {
         "template": "./installer/main.wxs",
         "fragmentPaths": ["./installer/startup-task.wxs"],
-        "componentRefs": ["EngineExe", "EngineStartup"],
+        "componentRefs": ["EngineStartup"],
         "bannerPath": "./installer/banner.png",
         "dialogImagePath": "./installer/install_dialog.png"
       }

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -60,10 +60,15 @@ impl Config {
         #[cfg(not(debug_assertions))]
         {
             use std::io::{Error, ErrorKind};
-            Ok(dirs::data_local_dir()
+            let parent = dirs::data_local_dir()
                 .ok_or(Error::new(ErrorKind::NotFound, "data local dir"))?
-                .join("me.enigmatrix.cobalt")
-                .join(segment))
+                .join("me.enigmatrix.cobalt");
+
+            if !parent.try_exists()? {
+                std::fs::create_dir(&parent)?;
+            }
+
+            Ok(parent.join(segment))
         }
     }
 
@@ -119,7 +124,7 @@ impl Config {
         Self::config_path("main.db")
     }
 
-    /// Returns the connection string to the query context database
+    /// Returns the path to the logs directory
     pub fn logs_dir(&self) -> Result<PathBuf> {
         Self::config_path("logs")
     }


### PR DESCRIPTION
### TL;DR

Fix Windows installer startup and ensure data directory exists when accessing configuration paths.

### What changed?

- Modified the Windows installer configuration to directly run the engine executable on startup instead of using a shortcut
- Added `Impersonate="yes"` to the `LaunchEngine` custom action in the WiX installer
- Removed the unnecessary `EngineExe` component and its reference in the Tauri configuration
- Enhanced the `config_path` method in `Config` to check if the parent directory exists and create it if needed
- Fixed the documentation comment for the `logs_dir` method to correctly describe its purpose