### PR TITLE
Get Score, Get Score Per Period commands

### DIFF
--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -70,6 +70,16 @@ pub struct WithGroupedDuration<T: Table> {
     pub duration: Duration,
 }
 
+/// Duration grouped into target, period chunks
+#[derive(Clone, Debug, Default, PartialEq, Eq, FromRow, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WithGroup<T> {
+    /// Time Period group
+    pub group: crate::table::Timestamp,
+    /// Value
+    pub value: T,
+}
+
 /// Value per common periods
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, FromRow)]
 #[serde(rename_all = "camelCase")]

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -32,6 +32,9 @@ pub mod repo;
 /// Repository module (mostly just CRUD)
 pub mod repo_crud;
 
+/// Repository module (mostly just statistics fetching)
+pub mod repo_stat;
+
 /// Entities with extra information embedded.
 pub mod infused;
 
@@ -374,6 +377,8 @@ impl AlertManager {
     }
 }
 
+#[cfg(test)]
+mod repo_stat_tests;
 #[cfg(test)]
 mod repo_tests;
 #[cfg(test)]

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -60,7 +60,7 @@ impl Repository {
             .collect())
     }
 
-    fn sql_period_start_end(expr: &str, period: &Period) -> (String, String) {
+    pub(crate) fn sql_period_start_end(expr: &str, period: &Period) -> (String, String) {
         match period {
             Period::Hour => (
                 format!(
@@ -99,7 +99,7 @@ impl Repository {
         }
     }
 
-    fn sql_period_next(expr: &str, period: &Period) -> String {
+    pub(crate) fn sql_period_next(expr: &str, period: &Period) -> String {
         match period {
             Period::Hour => format!("(({expr}) + 3600)"),
             Period::Day => format!("unixepoch({expr}, 'unixepoch', '+1 day')"),
@@ -109,11 +109,11 @@ impl Repository {
         }
     }
 
-    fn sql_ticks_to_unix(expr: &str) -> String {
+    pub(crate) fn sql_ticks_to_unix(expr: &str) -> String {
         format!("((({expr}) / 10000 - 62135596800000)/1000)")
     }
 
-    fn sql_unix_to_ticks(expr: &str) -> String {
+    pub(crate) fn sql_unix_to_ticks(expr: &str) -> String {
         format!("((({expr}) * 1000 + 62135596800000)*10000)")
     }
 

--- a/src/data/src/db/repo_stat.rs
+++ b/src/data/src/db/repo_stat.rs
@@ -2,7 +2,9 @@ use sqlx::{FromRow, query_as};
 
 use super::repo_crud::APP_DUR;
 use super::*;
+use crate::db::infused::WithGroup;
 use crate::db::repo::Repository;
+use crate::table::Period;
 
 impl Repository {
     /// Gets the weighted average score of all apps in the given time range
@@ -35,5 +37,69 @@ impl Repository {
         .await?;
 
         Ok(score_result.total_score)
+    }
+
+    /// Gets the weighted average score of all apps per period in the given time range
+    pub async fn get_score_per_period(
+        &mut self,
+        start: Timestamp,
+        end: Timestamp,
+        period: Period,
+    ) -> Result<Vec<WithGroup<f64>>> {
+        let (period_start, period_end) =
+            Self::sql_period_start_end(&Self::sql_ticks_to_unix("u.start"), &period);
+
+        let period_next = Self::sql_period_next("period_end", &period);
+
+        let period_start_ticks = Self::sql_unix_to_ticks("period_start");
+        let period_end_ticks = Self::sql_unix_to_ticks("period_end");
+
+        let query = format!("WITH RECURSIVE
+            params(start, end) AS (SELECT ?, ?),
+            period_intervals AS (
+                SELECT s.app_id AS id,
+                    {period_start} AS period_start,
+                    {period_end} AS period_end,
+                    u.start AS usage_start,
+                    u.end AS usage_end
+                FROM sessions s, params p
+                INNER JOIN usages u ON s.id = u.session_id
+                WHERE u.end > p.start AND u.start <= p.end
+
+                UNION ALL
+
+                SELECT id,
+                    period_end AS period_start,
+                    {period_next} AS period_end,
+                    usage_start,
+                    usage_end
+                FROM period_intervals, params p
+                WHERE {period_end_ticks} < MIN(usage_end, p.end)
+            ),
+            appscore AS (
+                SELECT a.*, COALESCE(t.score, 0) AS score
+                FROM apps a
+                LEFT JOIN tags t ON a.tag_id = t.id
+            )
+
+            SELECT 
+                {period_start_ticks} AS `group`,
+                COALESCE(
+                    SUM(CAST(MIN({period_end_ticks}, usage_end, p.end) - MAX({period_start_ticks}, usage_start, p.start) AS REAL) * COALESCE(a.score, 0)) / 
+                    COALESCE(SUM(MIN({period_end_ticks}, usage_end, p.end) - MAX({period_start_ticks}, usage_start, p.start)), 1.0)
+                , 0.0) AS value
+            FROM period_intervals, params p
+            INNER JOIN appscore a ON period_intervals.id = a.id
+            WHERE {period_start_ticks} BETWEEN p.start AND p.end
+            GROUP BY period_start
+           ");
+
+        let score_results: Vec<WithGroup<f64>> = query_as(&query)
+            .bind(start)
+            .bind(end)
+            .fetch_all(self.db.executor())
+            .await?;
+
+        Ok(score_results)
     }
 }

--- a/src/data/src/db/repo_stat.rs
+++ b/src/data/src/db/repo_stat.rs
@@ -4,14 +4,14 @@ use super::repo_crud::APP_DUR;
 use super::*;
 use crate::db::infused::WithGroup;
 use crate::db::repo::Repository;
-use crate::table::Period;
+use crate::table::{Period, Score};
 
 impl Repository {
     /// Gets the weighted average score of all apps in the given time range
-    pub async fn get_score(&mut self, start: Timestamp, end: Timestamp) -> Result<f64> {
+    pub async fn get_score(&mut self, start: Timestamp, end: Timestamp) -> Result<Score> {
         #[derive(FromRow)]
         struct ScoreResult {
-            total_score: f64,
+            total_score: Score,
         }
 
         // Get app durations and their tag scores in the given time range
@@ -45,7 +45,7 @@ impl Repository {
         start: Timestamp,
         end: Timestamp,
         period: Period,
-    ) -> Result<Vec<WithGroup<f64>>> {
+    ) -> Result<Vec<WithGroup<Score>>> {
         let (period_start, period_end) =
             Self::sql_period_start_end(&Self::sql_ticks_to_unix("u.start"), &period);
 
@@ -94,7 +94,7 @@ impl Repository {
             GROUP BY period_start
            ");
 
-        let score_results: Vec<WithGroup<f64>> = query_as(&query)
+        let score_results: Vec<WithGroup<Score>> = query_as(&query)
             .bind(start)
             .bind(end)
             .fetch_all(self.db.executor())

--- a/src/data/src/db/repo_stat.rs
+++ b/src/data/src/db/repo_stat.rs
@@ -1,0 +1,39 @@
+use sqlx::{FromRow, query_as};
+
+use super::repo_crud::APP_DUR;
+use super::*;
+use crate::db::repo::Repository;
+
+impl Repository {
+    /// Gets the weighted average score of all apps in the given time range
+    pub async fn get_score(&mut self, start: Timestamp, end: Timestamp) -> Result<f64> {
+        #[derive(FromRow)]
+        struct ScoreResult {
+            total_score: f64,
+        }
+
+        // Get app durations and their tag scores in the given time range
+        // For apps without a tag, use score 0
+        // Normalize by dividing by total duration to get weighted average score
+        let score_result: ScoreResult = query_as(&format!(
+            "WITH
+                appscore AS (
+                    SELECT a.*, COALESCE(t.score, 0) AS score
+                    FROM apps a
+                    LEFT JOIN tags t ON a.tag_id = t.id
+                ),
+                appdur(id, dur) AS ({APP_DUR})
+            SELECT COALESCE(
+                SUM(CAST(d.dur AS REAL) * COALESCE(a.score, 0)) / COALESCE(SUM(d.dur), 1.0)
+            , 0.0) AS total_score
+            FROM appdur d
+            INNER JOIN appscore a ON d.id = a.id"
+        ))
+        .bind(start)
+        .bind(end)
+        .fetch_one(self.db.executor())
+        .await?;
+
+        Ok(score_result.total_score)
+    }
+}

--- a/src/data/src/db/repo_stat_tests.rs
+++ b/src/data/src/db/repo_stat_tests.rs
@@ -3,18 +3,23 @@ use util::future as tokio;
 
 use super::tests::*;
 use super::*;
+use crate::db::repo_tests::{LOCAL_TEST_DATE, ONE_HOUR};
 use crate::entities::AppIdentity;
+use crate::table::Period;
 
-const ONE_HOUR: i64 = 60 * 60 * 1000 * 10000; // 1 hour in ticks
-const TEST_START: i64 = 1000 * ONE_HOUR; // Start time
-const TEST_END: i64 = 2000 * ONE_HOUR; // End time
+fn test_start() -> i64 {
+    *LOCAL_TEST_DATE
+}
+fn test_end() -> i64 {
+    *LOCAL_TEST_DATE + 2000 * ONE_HOUR
+}
 
 #[tokio::test]
 async fn get_score_no_apps() -> Result<()> {
     let db = test_db().await?;
     let mut repo = Repository::new(db)?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     assert_eq!(score, 0.0);
 
     Ok(())
@@ -93,8 +98,8 @@ async fn get_score_apps_no_tags() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session1.id.clone(),
-            start: TEST_START + 100 * ONE_HOUR, // 100 hours after start
-            end: TEST_START + 200 * ONE_HOUR,   // 200 hours after start (100 hours duration)
+            start: test_start() + 100 * ONE_HOUR, // 100 hours after start
+            end: test_start() + 200 * ONE_HOUR,   // 200 hours after start (100 hours duration)
         },
     )
     .await?;
@@ -104,13 +109,13 @@ async fn get_score_apps_no_tags() -> Result<()> {
         Usage {
             id: Ref::new(2),
             session_id: session2.id.clone(),
-            start: TEST_START + 300 * ONE_HOUR, // 300 hours after start
-            end: TEST_START + 350 * ONE_HOUR,   // 350 hours after start (50 hours duration)
+            start: test_start() + 300 * ONE_HOUR, // 300 hours after start
+            end: test_start() + 350 * ONE_HOUR,   // 350 hours after start (50 hours duration)
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // Apps without tags should contribute 0 to the score
     assert_eq!(score, 0.0);
 
@@ -217,8 +222,8 @@ async fn get_score_apps_with_tags() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session1.id.clone(),
-            start: TEST_START + 100 * ONE_HOUR, // 100 hours after start
-            end: TEST_START + 200 * ONE_HOUR,   // 200 hours after start (100 hours duration)
+            start: test_start() + 100 * ONE_HOUR, // 100 hours after start
+            end: test_start() + 200 * ONE_HOUR,   // 200 hours after start (100 hours duration)
         },
     )
     .await?;
@@ -228,13 +233,13 @@ async fn get_score_apps_with_tags() -> Result<()> {
         Usage {
             id: Ref::new(2),
             session_id: session2.id.clone(),
-            start: TEST_START + 300 * ONE_HOUR, // 300 hours after start
-            end: TEST_START + 350 * ONE_HOUR,   // 350 hours after start (50 hours duration)
+            start: test_start() + 300 * ONE_HOUR, // 300 hours after start
+            end: test_start() + 350 * ONE_HOUR,   // 350 hours after start (50 hours duration)
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (100 hours * 10 score + 50 hours * 5 score) / (100 + 50) hours = 8.333...
     let expected = 25.0 / 3.0;
     let epsilon = 1e-9;
@@ -335,8 +340,8 @@ async fn get_score_mixed_apps() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session1.id.clone(),
-            start: TEST_START + 50 * ONE_HOUR,
-            end: TEST_START + 150 * ONE_HOUR, // 100 hours duration
+            start: test_start() + 50 * ONE_HOUR,
+            end: test_start() + 150 * ONE_HOUR, // 100 hours duration
         },
     )
     .await?;
@@ -346,13 +351,13 @@ async fn get_score_mixed_apps() -> Result<()> {
         Usage {
             id: Ref::new(2),
             session_id: session2.id.clone(),
-            start: TEST_START + 200 * ONE_HOUR,
-            end: TEST_START + 250 * ONE_HOUR, // 50 hours duration
+            start: test_start() + 200 * ONE_HOUR,
+            end: test_start() + 250 * ONE_HOUR, // 50 hours duration
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (100 hours * 8 score + 50 hours * 0 score) / (100 + 50) hours = 5.333...
     let expected = 16.0 / 3.0;
     let epsilon = 1e-9;
@@ -423,8 +428,8 @@ async fn get_score_usage_outside_range() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session.id.clone(),
-            start: TEST_START - 200 * ONE_HOUR,
-            end: TEST_START - 100 * ONE_HOUR, // 100 hours duration, but outside range
+            start: test_start() - 200 * ONE_HOUR,
+            end: test_start() - 100 * ONE_HOUR, // 100 hours duration, but outside range
         },
     )
     .await?;
@@ -435,13 +440,13 @@ async fn get_score_usage_outside_range() -> Result<()> {
         Usage {
             id: Ref::new(2),
             session_id: session.id.clone(),
-            start: TEST_END + 100 * ONE_HOUR,
-            end: TEST_END + 200 * ONE_HOUR, // 100 hours duration, but outside range
+            start: test_end() + 100 * ONE_HOUR,
+            end: test_end() + 200 * ONE_HOUR, // 100 hours duration, but outside range
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // No usage within the range, so score should be 0
     assert_eq!(score, 0.0);
 
@@ -505,8 +510,8 @@ async fn get_score_partial_usage_overlap() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session.id.clone(),
-            start: TEST_START - 50 * ONE_HOUR, // Starts 50 hours before range
-            end: TEST_START + 50 * ONE_HOUR,   // Ends 50 hours into range
+            start: test_start() - 50 * ONE_HOUR, // Starts 50 hours before range
+            end: test_start() + 50 * ONE_HOUR,   // Ends 50 hours into range
         },
     )
     .await?;
@@ -517,13 +522,13 @@ async fn get_score_partial_usage_overlap() -> Result<()> {
         Usage {
             id: Ref::new(2),
             session_id: session.id.clone(),
-            start: TEST_END - 30 * ONE_HOUR, // Starts 30 hours before end
-            end: TEST_END + 70 * ONE_HOUR,   // Ends 70 hours after range
+            start: test_end() - 30 * ONE_HOUR, // Starts 30 hours before end
+            end: test_end() + 70 * ONE_HOUR,   // Ends 70 hours after range
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (50 hours * 6 score + 30 hours * 6 score) / (50 + 30) hours = 6
     assert_eq!(score, 6.0);
 
@@ -609,8 +614,8 @@ async fn get_score_multiple_sessions_same_app() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session1.id.clone(),
-            start: TEST_START + 100 * ONE_HOUR,
-            end: TEST_START + 150 * ONE_HOUR, // 50 hours
+            start: test_start() + 100 * ONE_HOUR,
+            end: test_start() + 150 * ONE_HOUR, // 50 hours
         },
     )
     .await?;
@@ -620,8 +625,8 @@ async fn get_score_multiple_sessions_same_app() -> Result<()> {
         Usage {
             id: Ref::new(2),
             session_id: session2.id.clone(),
-            start: TEST_START + 200 * ONE_HOUR,
-            end: TEST_START + 250 * ONE_HOUR, // 50 hours
+            start: test_start() + 200 * ONE_HOUR,
+            end: test_start() + 250 * ONE_HOUR, // 50 hours
         },
     )
     .await?;
@@ -631,13 +636,13 @@ async fn get_score_multiple_sessions_same_app() -> Result<()> {
         Usage {
             id: Ref::new(3),
             session_id: session3.id.clone(),
-            start: TEST_START + 300 * ONE_HOUR,
-            end: TEST_START + 350 * ONE_HOUR, // 50 hours
+            start: test_start() + 300 * ONE_HOUR,
+            end: test_start() + 350 * ONE_HOUR, // 50 hours
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (50 + 50 + 50) hours * 7 score / (50 + 50 + 50) hours = 7
     assert_eq!(score, 7.0);
 
@@ -701,15 +706,1410 @@ async fn get_score_zero_tag_score() -> Result<()> {
         Usage {
             id: Ref::new(1),
             session_id: session.id.clone(),
-            start: TEST_START + 100 * ONE_HOUR,
-            end: TEST_START + 200 * ONE_HOUR, // 100 hours duration
+            start: test_start() + 100 * ONE_HOUR,
+            end: test_start() + 200 * ONE_HOUR, // 100 hours duration
         },
     )
     .await?;
 
-    let score = repo.get_score(TEST_START, TEST_END).await?;
+    let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: 100 hours * 0 score = 0
     assert_eq!(score, 0.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_usage_extends_beyond_end() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "BeyondEnd".to_string(),
+            color: "purple".to_string(),
+            score: 8,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "BeyondEndApp".to_string(),
+            description: "BeyondEnd Description".to_string(),
+            company: "BeyondEnd Company".to_string(),
+            color: "purple".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "beyondend.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "BeyondEnd Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage that starts within the range but extends beyond the end
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: test_end() - 50 * ONE_HOUR, // Starts 50 hours before end
+            end: test_end() + 100 * ONE_HOUR,  // Ends 100 hours after end
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(test_start(), test_end()).await?;
+    // Expected: only the portion within the range should count
+    // 50 hours * 8 score = 400 score-hours, but this should be normalized by total time
+    // The function should only consider the time within the range
+    let expected = 8.0; // The score should be the tag score since all usage is within range
+    assert_eq!(score, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_usage_starts_before_and_extends_beyond() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "BeforeAndAfter".to_string(),
+            color: "orange".to_string(),
+            score: 6,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "BeforeAndAfterApp".to_string(),
+            description: "BeforeAndAfter Description".to_string(),
+            company: "BeforeAndAfter Company".to_string(),
+            color: "orange".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "beforeandafter.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "BeforeAndAfter Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage that starts before the range and extends beyond the end
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: test_start() - 100 * ONE_HOUR, // Starts 100 hours before range
+            end: test_end() + 200 * ONE_HOUR,     // Ends 200 hours after range
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(test_start(), test_end()).await?;
+    // Expected: only the portion within the range should count
+    // Total range is 2000 hours, so the score should be 6.0 (the tag score)
+    // since the entire range is covered by this usage
+    let expected = 6.0;
+    assert_eq!(score, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_no_apps() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert!(scores.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_single_hour() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "blue".to_string(),
+            score: 10,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage within a single hour period
+    let hour_start = test_start() + 100 * ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: hour_start,
+            end: hour_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 1);
+    assert_eq!(scores[0].group, hour_start);
+    assert_eq!(scores[0].value, 10.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_multiple_hours() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "blue".to_string(),
+            score: 8,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage spanning multiple hours
+    let start_time = test_start() + 100 * ONE_HOUR;
+    let end_time = test_start() + 103 * ONE_HOUR; // 3 hours duration
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: start_time,
+            end: end_time,
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 3);
+
+    // Each hour should have the same score since usage is evenly distributed
+    for score in &scores {
+        assert_eq!(score.value, 8.0);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_different_scores() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create tags with different scores
+    let tag1 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "High".to_string(),
+            color: "green".to_string(),
+            score: 10,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let tag2 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(2),
+            name: "Low".to_string(),
+            color: "red".to_string(),
+            score: 2,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create apps with different tags
+    let app1 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "HighApp".to_string(),
+            description: "High Description".to_string(),
+            company: "High Company".to_string(),
+            color: "green".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "high.exe".to_string(),
+            },
+            tag_id: Some(tag1.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app2 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "LowApp".to_string(),
+            description: "Low Description".to_string(),
+            company: "Low Company".to_string(),
+            color: "red".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "low.exe".to_string(),
+            },
+            tag_id: Some(tag2.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app1.id.clone(),
+            title: "High Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app2.id.clone(),
+            title: "Low Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usages in different hours
+    let hour1_start = test_start() + 100 * ONE_HOUR;
+    let hour2_start = test_start() + 101 * ONE_HOUR;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: hour1_start,
+            end: hour1_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: hour2_start,
+            end: hour2_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 2);
+
+    // First hour should have score 10, second hour should have score 2
+    assert_eq!(scores[0].group, hour1_start);
+    assert_eq!(scores[0].value, 10.0);
+    assert_eq!(scores[1].group, hour2_start);
+    assert_eq!(scores[1].value, 2.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_mixed_hour() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create tags with different scores
+    let tag1 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "High".to_string(),
+            color: "green".to_string(),
+            score: 10,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let tag2 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(2),
+            name: "Low".to_string(),
+            color: "red".to_string(),
+            score: 2,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create apps with different tags
+    let app1 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "HighApp".to_string(),
+            description: "High Description".to_string(),
+            company: "High Company".to_string(),
+            color: "green".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "high.exe".to_string(),
+            },
+            tag_id: Some(tag1.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app2 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "LowApp".to_string(),
+            description: "Low Description".to_string(),
+            company: "Low Company".to_string(),
+            color: "red".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "low.exe".to_string(),
+            },
+            tag_id: Some(tag2.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app1.id.clone(),
+            title: "High Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app2.id.clone(),
+            title: "Low Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usages in the same hour
+    let hour_start = test_start() + 100 * ONE_HOUR;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: hour_start,
+            end: hour_start + 20 * 60 * 1000 * 10000, // 20 minutes
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: hour_start + 30 * 60 * 1000 * 10000, // 30 minutes into the hour
+            end: hour_start + 50 * 60 * 1000 * 10000, // 50 minutes into the hour (20 minutes duration)
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 1);
+
+    // Expected: weighted average = (20 min * 10 + 20 min * 2) / (20 + 20) min = 6.0
+    assert_eq!(scores[0].group, hour_start);
+    assert_eq!(scores[0].value, 6.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_day_period() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "blue".to_string(),
+            score: 5,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage spanning multiple days
+    let day_start = test_start() + 1 * ONE_HOUR;
+    let day_end = test_start() + 23 * ONE_HOUR; // 24 hours later
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: day_start,
+            end: day_end,
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Day)
+        .await?;
+    assert_eq!(scores.len(), 1);
+    assert_eq!(scores[0].value, 5.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_week_period() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "blue".to_string(),
+            score: 7,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage spanning multiple weeks
+    let week_start = test_start() + 100 * ONE_HOUR;
+    let week_end = test_start() + 6 * 24 * ONE_HOUR; // 7 days later (168 hours)
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: week_start,
+            end: week_end,
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Week)
+        .await?;
+    assert_eq!(scores.len(), 1);
+    assert_eq!(scores[0].value, 7.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_apps_without_tags() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create an app without a tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "UntaggedApp".to_string(),
+            description: "Untagged Description".to_string(),
+            company: "Untagged Company".to_string(),
+            color: "gray".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "untagged.exe".to_string(),
+            },
+            tag_id: None,
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Untagged Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage
+    let hour_start = test_start() + 100 * ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: hour_start,
+            end: hour_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 1);
+    assert_eq!(scores[0].value, 0.0); // Apps without tags should contribute 0 to the score
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_complex_multi_period() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create tags with different scores
+    let tag1 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Productivity".to_string(),
+            color: "green".to_string(),
+            score: 10,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let tag2 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(2),
+            name: "Gaming".to_string(),
+            color: "red".to_string(),
+            score: 2,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create apps with different tags
+    let app1 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "ProductivityApp".to_string(),
+            description: "Productivity Description".to_string(),
+            company: "Productivity Company".to_string(),
+            color: "green".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "productivity.exe".to_string(),
+            },
+            tag_id: Some(tag1.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app2 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "GamingApp".to_string(),
+            description: "Gaming Description".to_string(),
+            company: "Gaming Company".to_string(),
+            color: "red".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "gaming.exe".to_string(),
+            },
+            tag_id: Some(tag2.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app1.id.clone(),
+            title: "Productivity Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app2.id.clone(),
+            title: "Gaming Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create complex usage pattern spanning multiple hours
+    // Hour 1: 30 min productivity, 30 min gaming
+    let hour1_start = test_start() + 100 * ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: hour1_start,
+            end: hour1_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: hour1_start + 30 * 60 * 1000 * 10000, // 30 minutes into the hour
+            end: hour1_start + 60 * 60 * 1000 * 10000,   // End of hour (30 minutes duration)
+        },
+    )
+    .await?;
+
+    // Hour 2: 45 min productivity, 15 min gaming
+    let hour2_start = test_start() + 101 * ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(3),
+            session_id: session1.id.clone(),
+            start: hour2_start,
+            end: hour2_start + 45 * 60 * 1000 * 10000, // 45 minutes
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(4),
+            session_id: session2.id.clone(),
+            start: hour2_start + 45 * 60 * 1000 * 10000, // 45 minutes into the hour
+            end: hour2_start + 60 * 60 * 1000 * 10000,   // End of hour (15 minutes duration)
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 2);
+
+    // Hour 1: (30 min * 10 + 30 min * 2) / 60 min = 6.0
+    assert_eq!(scores[0].group, hour1_start);
+    assert_eq!(scores[0].value, 6.0);
+
+    // Hour 2: (45 min * 10 + 15 min * 2) / 60 min = 8.0
+    assert_eq!(scores[1].group, hour2_start);
+    assert_eq!(scores[1].value, 8.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_usage_split_across_periods() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "blue".to_string(),
+            score: 6,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage that starts in one hour and ends in the next
+    let hour1_start = test_start() + 100 * ONE_HOUR;
+    let hour2_start = test_start() + 101 * ONE_HOUR;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: hour1_start + 30 * 60 * 1000 * 10000, // 30 minutes into first hour
+            end: hour2_start + 30 * 60 * 1000 * 10000,   // 30 minutes into second hour
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 2);
+
+    // Both hours should have the same score since usage is split evenly
+    assert_eq!(scores[0].group, hour1_start);
+    assert_eq!(scores[0].value, 6.0);
+    assert_eq!(scores[1].group, hour2_start);
+    assert_eq!(scores[1].value, 6.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_empty_periods() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "blue".to_string(),
+            score: 5,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage only in the first hour, leave other hours empty
+    let hour1_start = test_start() + 100 * ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: hour1_start,
+            end: hour1_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+    assert_eq!(scores.len(), 1); // Only the hour with usage should be returned
+    assert_eq!(scores[0].group, hour1_start);
+    assert_eq!(scores[0].value, 5.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_usage_extends_beyond_end() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "BeyondEndPeriod".to_string(),
+            color: "cyan".to_string(),
+            score: 9,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "BeyondEndPeriodApp".to_string(),
+            description: "BeyondEndPeriod Description".to_string(),
+            company: "BeyondEndPeriod Company".to_string(),
+            color: "cyan".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "beyondendperiod.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "BeyondEndPeriod Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage that starts in the last hour and extends beyond the end
+    let last_hour_start = test_end() - ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: last_hour_start + 30 * 60 * 1000 * 10000, // 30 minutes into the last hour
+            end: test_end() + 50 * 60 * 1000 * 10000,        // 50 minutes beyond the end
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+
+    // Should only return the last hour since that's the only period with usage within the range
+    assert_eq!(scores.len(), 1);
+    assert_eq!(scores[0].group, last_hour_start);
+    // Expected: 30 minutes of usage in the last hour = 9.0 score
+    assert_eq!(scores[0].value, 9.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_usage_starts_before_and_extends_beyond() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "BeforeAndAfterPeriod".to_string(),
+            color: "magenta".to_string(),
+            score: 7,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "BeforeAndAfterPeriodApp".to_string(),
+            description: "BeforeAndAfterPeriod Description".to_string(),
+            company: "BeforeAndAfterPeriod Company".to_string(),
+            color: "magenta".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "beforeandafterperiod.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "BeforeAndAfterPeriod Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage that starts before the range and extends beyond the end
+    // This should cover the entire range
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: test_start() - 500 * ONE_HOUR, // Starts 500 hours before range
+            end: test_end() + 1000 * ONE_HOUR,    // Ends 1000 hours after range
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+
+    // Should return all hours in the range since the usage covers the entire period
+    // The range is 2000 hours, so we should get 2000 entries
+    assert_eq!(scores.len(), 2000);
+
+    // Each hour should have the same score since usage is evenly distributed
+    for score in &scores {
+        assert_eq!(score.value, 7.0);
+    }
+
+    // Verify the first and last entries have correct timestamps
+    assert_eq!(scores[0].group, test_start());
+    assert_eq!(scores[1999].group, test_end() - ONE_HOUR);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_per_period_mixed_usage_beyond_end() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create tags with different scores
+    let tag1 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "WithinRange".to_string(),
+            color: "green".to_string(),
+            score: 10,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let tag2 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(2),
+            name: "BeyondEnd".to_string(),
+            color: "red".to_string(),
+            score: 3,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create apps with different tags
+    let app1 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "WithinRangeApp".to_string(),
+            description: "WithinRange Description".to_string(),
+            company: "WithinRange Company".to_string(),
+            color: "green".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "withinrange.exe".to_string(),
+            },
+            tag_id: Some(tag1.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app2 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "BeyondEndApp".to_string(),
+            description: "BeyondEnd Description".to_string(),
+            company: "BeyondEnd Company".to_string(),
+            color: "red".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "beyondend.exe".to_string(),
+            },
+            tag_id: Some(tag2.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app1.id.clone(),
+            title: "WithinRange Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app2.id.clone(),
+            title: "BeyondEnd Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage within the range
+    let hour1_start = test_start() + 100 * ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: hour1_start,
+            end: hour1_start + 30 * 60 * 1000 * 10000, // 30 minutes
+        },
+    )
+    .await?;
+
+    // Create usage that extends beyond the end
+    let last_hour_start = test_end() - ONE_HOUR;
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: last_hour_start + 15 * 60 * 1000 * 10000, // 15 minutes into the last hour
+            end: test_end() + 45 * 60 * 1000 * 10000,        // 45 minutes beyond the end
+        },
+    )
+    .await?;
+
+    let scores = repo
+        .get_score_per_period(test_start(), test_end(), Period::Hour)
+        .await?;
+
+    // Should return 2 hours: one with within-range usage, one with beyond-end usage
+    assert_eq!(scores.len(), 2);
+
+    // First hour should have score 10 (within-range usage)
+    assert_eq!(scores[0].group, hour1_start);
+    assert_eq!(scores[0].value, 10.0);
+
+    // Last hour should have score 3 (beyond-end usage, but only the portion within range counts)
+    assert_eq!(scores[1].group, last_hour_start);
+    assert_eq!(scores[1].value, 3.0);
 
     Ok(())
 }

--- a/src/data/src/db/repo_stat_tests.rs
+++ b/src/data/src/db/repo_stat_tests.rs
@@ -1,0 +1,715 @@
+use repo::*;
+use util::future as tokio;
+
+use super::tests::*;
+use super::*;
+use crate::entities::AppIdentity;
+
+const ONE_HOUR: i64 = 60 * 60 * 1000 * 10000; // 1 hour in ticks
+const TEST_START: i64 = 1000 * ONE_HOUR; // Start time
+const TEST_END: i64 = 2000 * ONE_HOUR; // End time
+
+#[tokio::test]
+async fn get_score_no_apps() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    assert_eq!(score, 0.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_apps_no_tags() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create apps without tags
+    let app1 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "App1".to_string(),
+            description: "Description1".to_string(),
+            company: "Company1".to_string(),
+            color: "red".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "app1.exe".to_string(),
+            },
+            tag_id: None,
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app2 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "App2".to_string(),
+            description: "Description2".to_string(),
+            company: "Company2".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "app2.exe".to_string(),
+            },
+            tag_id: None,
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions and usages
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app1.id.clone(),
+            title: "Session1".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app2.id.clone(),
+            title: "Session2".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usages within the test range
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: TEST_START + 100 * ONE_HOUR, // 100 hours after start
+            end: TEST_START + 200 * ONE_HOUR,   // 200 hours after start (100 hours duration)
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: TEST_START + 300 * ONE_HOUR, // 300 hours after start
+            end: TEST_START + 350 * ONE_HOUR,   // 350 hours after start (50 hours duration)
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // Apps without tags should contribute 0 to the score
+    assert_eq!(score, 0.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_apps_with_tags() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create tags with different scores
+    let tag1 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Productivity".to_string(),
+            color: "green".to_string(),
+            score: 10, // High score for productivity
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let tag2 = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(2),
+            name: "Gaming".to_string(),
+            color: "red".to_string(),
+            score: 5, // Lower score for gaming
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create apps with tags
+    let app1 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "ProductivityApp".to_string(),
+            description: "Productivity Description".to_string(),
+            company: "Productivity Company".to_string(),
+            color: "green".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "productivity.exe".to_string(),
+            },
+            tag_id: Some(tag1.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app2 = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "GamingApp".to_string(),
+            description: "Gaming Description".to_string(),
+            company: "Gaming Company".to_string(),
+            color: "red".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "gaming.exe".to_string(),
+            },
+            tag_id: Some(tag2.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions and usages
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app1.id.clone(),
+            title: "Productivity Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app2.id.clone(),
+            title: "Gaming Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usages within the test range
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: TEST_START + 100 * ONE_HOUR, // 100 hours after start
+            end: TEST_START + 200 * ONE_HOUR,   // 200 hours after start (100 hours duration)
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: TEST_START + 300 * ONE_HOUR, // 300 hours after start
+            end: TEST_START + 350 * ONE_HOUR,   // 350 hours after start (50 hours duration)
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // Expected: weighted average = (100 hours * 10 score + 50 hours * 5 score) / (100 + 50) hours = 8.333...
+    let expected = 25.0 / 3.0;
+    let epsilon = 1e-9;
+    assert!(
+        (score - expected).abs() < epsilon,
+        "score: {}, expected: {}",
+        score,
+        expected
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_mixed_apps() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Work".to_string(),
+            color: "blue".to_string(),
+            score: 8,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create apps: one with tag, one without
+    let app_with_tag = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "WorkApp".to_string(),
+            description: "Work Description".to_string(),
+            company: "Work Company".to_string(),
+            color: "blue".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "work.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    let app_without_tag = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(2),
+            name: "UntaggedApp".to_string(),
+            description: "Untagged Description".to_string(),
+            company: "Untagged Company".to_string(),
+            color: "gray".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "untagged.exe".to_string(),
+            },
+            tag_id: None,
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create sessions
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app_with_tag.id.clone(),
+            title: "Work Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app_without_tag.id.clone(),
+            title: "Untagged Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usages
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: TEST_START + 50 * ONE_HOUR,
+            end: TEST_START + 150 * ONE_HOUR, // 100 hours duration
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: TEST_START + 200 * ONE_HOUR,
+            end: TEST_START + 250 * ONE_HOUR, // 50 hours duration
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // Expected: weighted average = (100 hours * 8 score + 50 hours * 0 score) / (100 + 50) hours = 5.333...
+    let expected = 16.0 / 3.0;
+    let epsilon = 1e-9;
+    assert!(
+        (score - expected).abs() < epsilon,
+        "score: {}, expected: {}",
+        score,
+        expected
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_usage_outside_range() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Test".to_string(),
+            color: "purple".to_string(),
+            score: 10,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "TestApp".to_string(),
+            description: "Test Description".to_string(),
+            company: "Test Company".to_string(),
+            color: "purple".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "test.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Test Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage outside the test range (before start)
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: TEST_START - 200 * ONE_HOUR,
+            end: TEST_START - 100 * ONE_HOUR, // 100 hours duration, but outside range
+        },
+    )
+    .await?;
+
+    // Create usage outside the test range (after end)
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session.id.clone(),
+            start: TEST_END + 100 * ONE_HOUR,
+            end: TEST_END + 200 * ONE_HOUR, // 100 hours duration, but outside range
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // No usage within the range, so score should be 0
+    assert_eq!(score, 0.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_partial_usage_overlap() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "Overlap".to_string(),
+            color: "orange".to_string(),
+            score: 6,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "OverlapApp".to_string(),
+            description: "Overlap Description".to_string(),
+            company: "Overlap Company".to_string(),
+            color: "orange".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "overlap.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Overlap Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage that starts before the range but ends within it
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: TEST_START - 50 * ONE_HOUR, // Starts 50 hours before range
+            end: TEST_START + 50 * ONE_HOUR,   // Ends 50 hours into range
+        },
+    )
+    .await?;
+
+    // Create usage that starts within the range but ends after it
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session.id.clone(),
+            start: TEST_END - 30 * ONE_HOUR, // Starts 30 hours before end
+            end: TEST_END + 70 * ONE_HOUR,   // Ends 70 hours after range
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // Expected: weighted average = (50 hours * 6 score + 30 hours * 6 score) / (50 + 30) hours = 6
+    assert_eq!(score, 6.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_multiple_sessions_same_app() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "MultiSession".to_string(),
+            color: "cyan".to_string(),
+            score: 7,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "MultiSessionApp".to_string(),
+            description: "MultiSession Description".to_string(),
+            company: "MultiSession Company".to_string(),
+            color: "cyan".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "multisession.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create multiple sessions for the same app
+    let session1 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "Session 1".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session2 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(2),
+            app_id: app.id.clone(),
+            title: "Session 2".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    let session3 = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(3),
+            app_id: app.id.clone(),
+            title: "Session 3".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usages for each session
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session1.id.clone(),
+            start: TEST_START + 100 * ONE_HOUR,
+            end: TEST_START + 150 * ONE_HOUR, // 50 hours
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(2),
+            session_id: session2.id.clone(),
+            start: TEST_START + 200 * ONE_HOUR,
+            end: TEST_START + 250 * ONE_HOUR, // 50 hours
+        },
+    )
+    .await?;
+
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(3),
+            session_id: session3.id.clone(),
+            start: TEST_START + 300 * ONE_HOUR,
+            end: TEST_START + 350 * ONE_HOUR, // 50 hours
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // Expected: weighted average = (50 + 50 + 50) hours * 7 score / (50 + 50 + 50) hours = 7
+    assert_eq!(score, 7.0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_score_zero_tag_score() -> Result<()> {
+    let db = test_db().await?;
+    let mut repo = Repository::new(db)?;
+
+    // Create a tag with zero score
+    let tag = arrange::tag(
+        &mut repo.db,
+        Tag {
+            id: Ref::new(1),
+            name: "ZeroScore".to_string(),
+            color: "black".to_string(),
+            score: 0, // Zero score
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create an app with the zero-score tag
+    let app = arrange::app(
+        &mut repo.db,
+        App {
+            id: Ref::new(1),
+            name: "ZeroScoreApp".to_string(),
+            description: "ZeroScore Description".to_string(),
+            company: "ZeroScore Company".to_string(),
+            color: "black".to_string(),
+            identity: AppIdentity::Win32 {
+                path: "zeroscore.exe".to_string(),
+            },
+            tag_id: Some(tag.id.clone()),
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+        },
+    )
+    .await?;
+
+    // Create a session
+    let session = arrange::session(
+        &mut repo.db,
+        Session {
+            id: Ref::new(1),
+            app_id: app.id.clone(),
+            title: "ZeroScore Session".to_string(),
+            url: None,
+        },
+    )
+    .await?;
+
+    // Create usage
+    arrange::usage(
+        &mut repo.db,
+        Usage {
+            id: Ref::new(1),
+            session_id: session.id.clone(),
+            start: TEST_START + 100 * ONE_HOUR,
+            end: TEST_START + 200 * ONE_HOUR, // 100 hours duration
+        },
+    )
+    .await?;
+
+    let score = repo.get_score(TEST_START, TEST_END).await?;
+    // Expected: 100 hours * 0 score = 0
+    assert_eq!(score, 0.0);
+
+    Ok(())
+}

--- a/src/data/src/db/repo_stat_tests.rs
+++ b/src/data/src/db/repo_stat_tests.rs
@@ -20,7 +20,7 @@ async fn get_score_no_apps() -> Result<()> {
     let mut repo = Repository::new(db)?;
 
     let score = repo.get_score(test_start(), test_end()).await?;
-    assert_eq!(score, 0.0);
+    assert_eq!(score, 0.0.into());
 
     Ok(())
 }
@@ -117,7 +117,7 @@ async fn get_score_apps_no_tags() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // Apps without tags should contribute 0 to the score
-    assert_eq!(score, 0.0);
+    assert_eq!(score, 0.0.into());
 
     Ok(())
 }
@@ -134,7 +134,7 @@ async fn get_score_apps_with_tags() -> Result<()> {
             id: Ref::new(1),
             name: "Productivity".to_string(),
             color: "green".to_string(),
-            score: 10, // High score for productivity
+            score: 10.0.into(), // High score for productivity
             created_at: 0,
             updated_at: 0,
         },
@@ -147,7 +147,7 @@ async fn get_score_apps_with_tags() -> Result<()> {
             id: Ref::new(2),
             name: "Gaming".to_string(),
             color: "red".to_string(),
-            score: 5, // Lower score for gaming
+            score: 5.0.into(), // Lower score for gaming
             created_at: 0,
             updated_at: 0,
         },
@@ -241,10 +241,10 @@ async fn get_score_apps_with_tags() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (100 hours * 10 score + 50 hours * 5 score) / (100 + 50) hours = 8.333...
-    let expected = 25.0 / 3.0;
+    let expected = (25.0 / 3.0).into();
     let epsilon = 1e-9;
     assert!(
-        (score - expected).abs() < epsilon,
+        f64::from(score - expected).abs() < epsilon,
         "score: {}, expected: {}",
         score,
         expected
@@ -265,7 +265,7 @@ async fn get_score_mixed_apps() -> Result<()> {
             id: Ref::new(1),
             name: "Work".to_string(),
             color: "blue".to_string(),
-            score: 8,
+            score: 8.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -359,10 +359,10 @@ async fn get_score_mixed_apps() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (100 hours * 8 score + 50 hours * 0 score) / (100 + 50) hours = 5.333...
-    let expected = 16.0 / 3.0;
+    let expected = (16.0 / 3.0).into();
     let epsilon = 1e-9;
     assert!(
-        (score - expected).abs() < epsilon,
+        f64::from(score - expected).abs() < epsilon,
         "score: {}, expected: {}",
         score,
         expected
@@ -383,7 +383,7 @@ async fn get_score_usage_outside_range() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "purple".to_string(),
-            score: 10,
+            score: 10.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -448,7 +448,7 @@ async fn get_score_usage_outside_range() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // No usage within the range, so score should be 0
-    assert_eq!(score, 0.0);
+    assert_eq!(score, 0.0.into());
 
     Ok(())
 }
@@ -465,7 +465,7 @@ async fn get_score_partial_usage_overlap() -> Result<()> {
             id: Ref::new(1),
             name: "Overlap".to_string(),
             color: "orange".to_string(),
-            score: 6,
+            score: 6.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -530,7 +530,7 @@ async fn get_score_partial_usage_overlap() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (50 hours * 6 score + 30 hours * 6 score) / (50 + 30) hours = 6
-    assert_eq!(score, 6.0);
+    assert_eq!(score, 6.0.into());
 
     Ok(())
 }
@@ -547,7 +547,7 @@ async fn get_score_multiple_sessions_same_app() -> Result<()> {
             id: Ref::new(1),
             name: "MultiSession".to_string(),
             color: "cyan".to_string(),
-            score: 7,
+            score: 7.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -644,7 +644,7 @@ async fn get_score_multiple_sessions_same_app() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: weighted average = (50 + 50 + 50) hours * 7 score / (50 + 50 + 50) hours = 7
-    assert_eq!(score, 7.0);
+    assert_eq!(score, 7.0.into());
 
     Ok(())
 }
@@ -661,7 +661,7 @@ async fn get_score_zero_tag_score() -> Result<()> {
             id: Ref::new(1),
             name: "ZeroScore".to_string(),
             color: "black".to_string(),
-            score: 0, // Zero score
+            score: 0.0.into(), // Zero score
             created_at: 0,
             updated_at: 0,
         },
@@ -714,7 +714,7 @@ async fn get_score_zero_tag_score() -> Result<()> {
 
     let score = repo.get_score(test_start(), test_end()).await?;
     // Expected: 100 hours * 0 score = 0
-    assert_eq!(score, 0.0);
+    assert_eq!(score, 0.0.into());
 
     Ok(())
 }
@@ -731,7 +731,7 @@ async fn get_score_usage_extends_beyond_end() -> Result<()> {
             id: Ref::new(1),
             name: "BeyondEnd".to_string(),
             color: "purple".to_string(),
-            score: 8,
+            score: 8.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -786,7 +786,7 @@ async fn get_score_usage_extends_beyond_end() -> Result<()> {
     // Expected: only the portion within the range should count
     // 50 hours * 8 score = 400 score-hours, but this should be normalized by total time
     // The function should only consider the time within the range
-    let expected = 8.0; // The score should be the tag score since all usage is within range
+    let expected = 8.0.into(); // The score should be the tag score since all usage is within range
     assert_eq!(score, expected);
 
     Ok(())
@@ -804,7 +804,7 @@ async fn get_score_usage_starts_before_and_extends_beyond() -> Result<()> {
             id: Ref::new(1),
             name: "BeforeAndAfter".to_string(),
             color: "orange".to_string(),
-            score: 6,
+            score: 6.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -859,7 +859,7 @@ async fn get_score_usage_starts_before_and_extends_beyond() -> Result<()> {
     // Expected: only the portion within the range should count
     // Total range is 2000 hours, so the score should be 6.0 (the tag score)
     // since the entire range is covered by this usage
-    let expected = 6.0;
+    let expected = 6.0.into();
     assert_eq!(score, expected);
 
     Ok(())
@@ -890,7 +890,7 @@ async fn get_score_per_period_single_hour() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "blue".to_string(),
-            score: 10,
+            score: 10.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -947,7 +947,7 @@ async fn get_score_per_period_single_hour() -> Result<()> {
         .await?;
     assert_eq!(scores.len(), 1);
     assert_eq!(scores[0].group, hour_start);
-    assert_eq!(scores[0].value, 10.0);
+    assert_eq!(scores[0].value, 10.0.into());
 
     Ok(())
 }
@@ -964,7 +964,7 @@ async fn get_score_per_period_multiple_hours() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "blue".to_string(),
-            score: 8,
+            score: 8.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1024,7 +1024,7 @@ async fn get_score_per_period_multiple_hours() -> Result<()> {
 
     // Each hour should have the same score since usage is evenly distributed
     for score in &scores {
-        assert_eq!(score.value, 8.0);
+        assert_eq!(score.value, 8.0.into());
     }
 
     Ok(())
@@ -1042,7 +1042,7 @@ async fn get_score_per_period_different_scores() -> Result<()> {
             id: Ref::new(1),
             name: "High".to_string(),
             color: "green".to_string(),
-            score: 10,
+            score: 10.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1055,7 +1055,7 @@ async fn get_score_per_period_different_scores() -> Result<()> {
             id: Ref::new(2),
             name: "Low".to_string(),
             color: "red".to_string(),
-            score: 2,
+            score: 2.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1157,9 +1157,9 @@ async fn get_score_per_period_different_scores() -> Result<()> {
 
     // First hour should have score 10, second hour should have score 2
     assert_eq!(scores[0].group, hour1_start);
-    assert_eq!(scores[0].value, 10.0);
+    assert_eq!(scores[0].value, 10.0.into());
     assert_eq!(scores[1].group, hour2_start);
-    assert_eq!(scores[1].value, 2.0);
+    assert_eq!(scores[1].value, 2.0.into());
 
     Ok(())
 }
@@ -1176,7 +1176,7 @@ async fn get_score_per_period_mixed_hour() -> Result<()> {
             id: Ref::new(1),
             name: "High".to_string(),
             color: "green".to_string(),
-            score: 10,
+            score: 10.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1189,7 +1189,7 @@ async fn get_score_per_period_mixed_hour() -> Result<()> {
             id: Ref::new(2),
             name: "Low".to_string(),
             color: "red".to_string(),
-            score: 2,
+            score: 2.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1290,7 +1290,7 @@ async fn get_score_per_period_mixed_hour() -> Result<()> {
 
     // Expected: weighted average = (20 min * 10 + 20 min * 2) / (20 + 20) min = 6.0
     assert_eq!(scores[0].group, hour_start);
-    assert_eq!(scores[0].value, 6.0);
+    assert_eq!(scores[0].value, 6.0.into());
 
     Ok(())
 }
@@ -1307,7 +1307,7 @@ async fn get_score_per_period_day_period() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "blue".to_string(),
-            score: 5,
+            score: 5.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1364,7 +1364,7 @@ async fn get_score_per_period_day_period() -> Result<()> {
         .get_score_per_period(test_start(), test_end(), Period::Day)
         .await?;
     assert_eq!(scores.len(), 1);
-    assert_eq!(scores[0].value, 5.0);
+    assert_eq!(scores[0].value, 5.0.into());
 
     Ok(())
 }
@@ -1381,7 +1381,7 @@ async fn get_score_per_period_week_period() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "blue".to_string(),
-            score: 7,
+            score: 7.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1438,7 +1438,7 @@ async fn get_score_per_period_week_period() -> Result<()> {
         .get_score_per_period(test_start(), test_end(), Period::Week)
         .await?;
     assert_eq!(scores.len(), 1);
-    assert_eq!(scores[0].value, 7.0);
+    assert_eq!(scores[0].value, 7.0.into());
 
     Ok(())
 }
@@ -1497,7 +1497,7 @@ async fn get_score_per_period_apps_without_tags() -> Result<()> {
         .get_score_per_period(test_start(), test_end(), Period::Hour)
         .await?;
     assert_eq!(scores.len(), 1);
-    assert_eq!(scores[0].value, 0.0); // Apps without tags should contribute 0 to the score
+    assert_eq!(scores[0].value, 0.0.into()); // Apps without tags should contribute 0 to the score
 
     Ok(())
 }
@@ -1514,7 +1514,7 @@ async fn get_score_per_period_complex_multi_period() -> Result<()> {
             id: Ref::new(1),
             name: "Productivity".to_string(),
             color: "green".to_string(),
-            score: 10,
+            score: 10.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1527,7 +1527,7 @@ async fn get_score_per_period_complex_multi_period() -> Result<()> {
             id: Ref::new(2),
             name: "Gaming".to_string(),
             color: "red".to_string(),
-            score: 2,
+            score: 2.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1652,11 +1652,11 @@ async fn get_score_per_period_complex_multi_period() -> Result<()> {
 
     // Hour 1: (30 min * 10 + 30 min * 2) / 60 min = 6.0
     assert_eq!(scores[0].group, hour1_start);
-    assert_eq!(scores[0].value, 6.0);
+    assert_eq!(scores[0].value, 6.0.into());
 
     // Hour 2: (45 min * 10 + 15 min * 2) / 60 min = 8.0
     assert_eq!(scores[1].group, hour2_start);
-    assert_eq!(scores[1].value, 8.0);
+    assert_eq!(scores[1].value, 8.0.into());
 
     Ok(())
 }
@@ -1673,7 +1673,7 @@ async fn get_score_per_period_usage_split_across_periods() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "blue".to_string(),
-            score: 6,
+            score: 6.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1734,9 +1734,9 @@ async fn get_score_per_period_usage_split_across_periods() -> Result<()> {
 
     // Both hours should have the same score since usage is split evenly
     assert_eq!(scores[0].group, hour1_start);
-    assert_eq!(scores[0].value, 6.0);
+    assert_eq!(scores[0].value, 6.0.into());
     assert_eq!(scores[1].group, hour2_start);
-    assert_eq!(scores[1].value, 6.0);
+    assert_eq!(scores[1].value, 6.0.into());
 
     Ok(())
 }
@@ -1753,7 +1753,7 @@ async fn get_score_per_period_empty_periods() -> Result<()> {
             id: Ref::new(1),
             name: "Test".to_string(),
             color: "blue".to_string(),
-            score: 5,
+            score: 5.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1810,7 +1810,7 @@ async fn get_score_per_period_empty_periods() -> Result<()> {
         .await?;
     assert_eq!(scores.len(), 1); // Only the hour with usage should be returned
     assert_eq!(scores[0].group, hour1_start);
-    assert_eq!(scores[0].value, 5.0);
+    assert_eq!(scores[0].value, 5.0.into());
 
     Ok(())
 }
@@ -1827,7 +1827,7 @@ async fn get_score_per_period_usage_extends_beyond_end() -> Result<()> {
             id: Ref::new(1),
             name: "BeyondEndPeriod".to_string(),
             color: "cyan".to_string(),
-            score: 9,
+            score: 9.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1887,7 +1887,7 @@ async fn get_score_per_period_usage_extends_beyond_end() -> Result<()> {
     assert_eq!(scores.len(), 1);
     assert_eq!(scores[0].group, last_hour_start);
     // Expected: 30 minutes of usage in the last hour = 9.0 score
-    assert_eq!(scores[0].value, 9.0);
+    assert_eq!(scores[0].value, 9.0.into());
 
     Ok(())
 }
@@ -1904,7 +1904,7 @@ async fn get_score_per_period_usage_starts_before_and_extends_beyond() -> Result
             id: Ref::new(1),
             name: "BeforeAndAfterPeriod".to_string(),
             color: "magenta".to_string(),
-            score: 7,
+            score: 7.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -1966,7 +1966,7 @@ async fn get_score_per_period_usage_starts_before_and_extends_beyond() -> Result
 
     // Each hour should have the same score since usage is evenly distributed
     for score in &scores {
-        assert_eq!(score.value, 7.0);
+        assert_eq!(score.value, 7.0.into());
     }
 
     // Verify the first and last entries have correct timestamps
@@ -1988,7 +1988,7 @@ async fn get_score_per_period_mixed_usage_beyond_end() -> Result<()> {
             id: Ref::new(1),
             name: "WithinRange".to_string(),
             color: "green".to_string(),
-            score: 10,
+            score: 10.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -2001,7 +2001,7 @@ async fn get_score_per_period_mixed_usage_beyond_end() -> Result<()> {
             id: Ref::new(2),
             name: "BeyondEnd".to_string(),
             color: "red".to_string(),
-            score: 3,
+            score: 3.0.into(),
             created_at: 0,
             updated_at: 0,
         },
@@ -2105,11 +2105,11 @@ async fn get_score_per_period_mixed_usage_beyond_end() -> Result<()> {
 
     // First hour should have score 10 (within-range usage)
     assert_eq!(scores[0].group, hour1_start);
-    assert_eq!(scores[0].value, 10.0);
+    assert_eq!(scores[0].value, 10.0.into());
 
     // Last hour should have score 3 (beyond-end usage, but only the portion within range counts)
     assert_eq!(scores[1].group, last_hour_start);
-    assert_eq!(scores[1].value, 3.0);
+    assert_eq!(scores[1].value, 3.0.into());
 
     Ok(())
 }

--- a/src/data/src/db/repo_tests.rs
+++ b/src/data/src/db/repo_tests.rs
@@ -14,9 +14,9 @@ use crate::db::tests::arrange::*;
 use crate::entities::{Reason, TimeFrame, TriggerAction};
 use crate::table::Period;
 
-const ONE_HOUR: i64 = 60 * 60 * 1000 * 10000;
-const TEST_DATE: i64 = (1735776000 * 1000 + 62_135_596_800_000) * 10000;
-static LOCAL_TEST_DATE: LazyLock<i64> = LazyLock::new(|| add_tz_shift(TEST_DATE));
+pub const ONE_HOUR: i64 = 60 * 60 * 1000 * 10000;
+pub const TEST_DATE: i64 = (1735776000 * 1000 + 62_135_596_800_000) * 10000;
+pub static LOCAL_TEST_DATE: LazyLock<i64> = LazyLock::new(|| add_tz_shift(TEST_DATE));
 
 fn add_tz_shift(ts: i64) -> i64 {
     // Get the current timezone offset in seconds

--- a/src/data/src/db/tests.rs
+++ b/src/data/src/db/tests.rs
@@ -724,7 +724,7 @@ pub mod arrange {
             &app.description,
             &app.company,
             &app.color,
-            app.tag_id.as_ref().map(|id| id.0).clone(),
+            app.tag_id.as_ref().map(|id| id.0),
             if let AppIdentity::Win32 { .. } = app.identity {
                 1
             } else {
@@ -752,7 +752,7 @@ pub mod arrange {
             &app.description,
             &app.company,
             &app.color,
-            app.tag_id.as_ref().map(|id| id.0).clone(),
+            app.tag_id.as_ref().map(|id| id.0),
             if let AppIdentity::Win32 { .. } = app.identity {
                 1
             } else {
@@ -1381,7 +1381,7 @@ mod triggered_alerts {
             &mut db,
             AlertEvent {
                 id: Ref::default(),
-                alert_id: alert.id.clone().into(),
+                alert_id: alert.id.clone(),
                 timestamp: 75,
                 reason: Reason::Hit,
             },

--- a/src/ui/app/components/tag/score-slider.tsx
+++ b/src/ui/app/components/tag/score-slider.tsx
@@ -1,4 +1,5 @@
 import { Colors } from "@/components/tag/score";
+import type { Score } from "@/lib/entities";
 import { cn } from "@/lib/utils";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import * as React from "react";
@@ -16,9 +17,9 @@ function ScoreSlider({
   React.ComponentProps<typeof SliderPrimitive.Root>,
   "defaultValue" | "value" | "onValueChange"
 > & {
-  defaultValue?: number;
-  value?: number;
-  onValueChange?: (value: number) => void;
+  defaultValue?: Score;
+  value?: Score;
+  onValueChange?: (value: Score) => void;
 }) {
   const _values = React.useMemo(
     () =>
@@ -31,7 +32,7 @@ function ScoreSlider({
   );
 
   const handleValueChange = React.useCallback(
-    (values: number[]) => {
+    (values: Score[]) => {
       if (onValueChange) {
         onValueChange(values[0]);
       }

--- a/src/ui/app/components/tag/score.tsx
+++ b/src/ui/app/components/tag/score.tsx
@@ -13,6 +13,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { Score } from "@/lib/entities";
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
 
@@ -27,7 +28,7 @@ export const Colors = {
  * @param score A number between -100 and 100
  * @returns A string describing the focus level
  */
-export function getScoreDescription(score: number): string {
+export function getScoreDescription(score: Score): string {
   if (score < -80) return "Highly Distractive";
   if (score < -40) return "Distractive";
   if (score < 0) return "Slightly Distractive";
@@ -42,7 +43,7 @@ export function ScoreCircle({
   className,
   hoverTooltip = true,
 }: {
-  score: number;
+  score: Score;
   className?: ClassValue;
   hoverTooltip?: boolean;
 }) {
@@ -72,7 +73,7 @@ export function ScoreBadge({
   className,
   circleClassName,
 }: {
-  score: number;
+  score: Score;
   className?: ClassValue;
   circleClassName?: ClassValue;
 }) {
@@ -102,13 +103,13 @@ export function ScoreWrapper({
   className,
   children,
 }: {
-  score: number;
+  score: Score;
   className?: ClassValue;
   children?: React.ReactNode;
 }) {
   const { theme } = useTheme();
 
-  const getOpacity = (value: number) => {
+  const getOpacity = (value: Score) => {
     return Math.max(0, value / 100);
   };
 
@@ -145,8 +146,8 @@ export function ScoreEdit({
   className,
   children,
 }: {
-  score: number;
-  onScoreChange: (score: number) => void;
+  score: Score;
+  onScoreChange: (score: Score) => void;
   className?: ClassValue;
   children?: React.ReactNode;
 }) {

--- a/src/ui/app/hooks/use-repo.tsx
+++ b/src/ui/app/hooks/use-repo.tsx
@@ -9,6 +9,7 @@ import {
   getTagDurationsPerPeriod,
 } from "@/lib/repo";
 import type { EntityMap } from "@/lib/state";
+import { getScore, SCORE_SENTINEL } from "@/lib/stats";
 import _ from "lodash";
 import type { DateTime } from "luxon";
 import { useMemo } from "react";
@@ -74,6 +75,7 @@ export const useTagDurationsPerPeriod = makeUseRepo(
   getTagDurationsPerPeriod,
   {},
 );
+export const useScore = makeUseRepo(getScore, SCORE_SENTINEL);
 
 export function useTotalUsageFromPerPeriod<T>(
   durationsPerPeriod: EntityMap<T, WithGroupedDuration<T>[]>,

--- a/src/ui/app/hooks/use-repo.tsx
+++ b/src/ui/app/hooks/use-repo.tsx
@@ -9,7 +9,7 @@ import {
   getTagDurationsPerPeriod,
 } from "@/lib/repo";
 import type { EntityMap } from "@/lib/state";
-import { getScore, SCORE_SENTINEL } from "@/lib/stats";
+import { getScore } from "@/lib/stats";
 import _ from "lodash";
 import type { DateTime } from "luxon";
 import { useMemo } from "react";
@@ -75,7 +75,7 @@ export const useTagDurationsPerPeriod = makeUseRepo(
   getTagDurationsPerPeriod,
   {},
 );
-export const useScore = makeUseRepo(getScore, SCORE_SENTINEL);
+export const useScore = makeUseRepo(getScore, 0);
 
 export function useTotalUsageFromPerPeriod<T>(
   durationsPerPeriod: EntityMap<T, WithGroupedDuration<T>[]>,

--- a/src/ui/app/hooks/use-repo.tsx
+++ b/src/ui/app/hooks/use-repo.tsx
@@ -9,7 +9,7 @@ import {
   getTagDurationsPerPeriod,
 } from "@/lib/repo";
 import type { EntityMap } from "@/lib/state";
-import { getScore } from "@/lib/stats";
+import { getScore, getScorePerPeriod } from "@/lib/stats";
 import _ from "lodash";
 import type { DateTime } from "luxon";
 import { useMemo } from "react";
@@ -76,6 +76,7 @@ export const useTagDurationsPerPeriod = makeUseRepo(
   {},
 );
 export const useScore = makeUseRepo(getScore, 0);
+export const useScorePerPeriod = makeUseRepo(getScorePerPeriod, []);
 
 export function useTotalUsageFromPerPeriod<T>(
   durationsPerPeriod: EntityMap<T, WithGroupedDuration<T>[]>,

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -20,6 +20,11 @@ export interface WithGroupedDuration<T> {
   group: Timestamp;
 }
 
+export interface WithGroup<T> {
+  value: T;
+  group: Timestamp;
+}
+
 export type AppIdentity =
   | { tag: "uwp"; aumid: string }
   | { tag: "win32"; path: string }

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -5,6 +5,7 @@ export function newRef<T>(id: number): Ref<T> {
 export type Color = string;
 export type Timestamp = number;
 export type Duration = number;
+export type Score = number;
 type Period = "hour" | "day" | "week" | "month" | "year";
 // change the exported type so that users use the time.ts Period type instead
 export type EntityPeriod = Period;
@@ -67,7 +68,7 @@ export interface Tag {
   id: Ref<Tag>;
   name: string;
   color: string;
-  score: number;
+  score: Score;
   apps: Ref<App>[];
   usages: ValuePerPeriod<Duration>;
 }

--- a/src/ui/app/lib/repo.ts
+++ b/src/ui/app/lib/repo.ts
@@ -5,6 +5,7 @@ import type {
   InteractionPeriod,
   Ref,
   Reminder,
+  Score,
   Session,
   SystemEvent,
   Tag,
@@ -23,7 +24,7 @@ import { DateTime } from "luxon";
 export interface CreateTag {
   name: string;
   color: string;
-  score: number;
+  score: Score;
   apps: Ref<App>[];
 }
 

--- a/src/ui/app/lib/stats.ts
+++ b/src/ui/app/lib/stats.ts
@@ -1,5 +1,6 @@
+import type { WithGroup } from "@/lib/entities";
 import { getQueryOptions, type QueryOptions } from "@/lib/repo";
-import { dateTimeToTicks } from "@/lib/time";
+import { dateTimeToTicks, type Period } from "@/lib/time";
 import { invoke } from "@tauri-apps/api/core";
 import { DateTime } from "luxon";
 
@@ -17,5 +18,25 @@ export async function getScore({
     queryOptions,
     start: dateTimeToTicks(start),
     end: dateTimeToTicks(end),
+  });
+}
+
+export async function getScorePerPeriod({
+  options,
+  start,
+  end,
+  period,
+}: {
+  options?: QueryOptions;
+  start: DateTime;
+  end: DateTime;
+  period: Period;
+}): Promise<WithGroup<number>[]> {
+  const queryOptions = getQueryOptions(options);
+  return await invoke("get_score_per_period", {
+    queryOptions,
+    start: dateTimeToTicks(start),
+    end: dateTimeToTicks(end),
+    period,
   });
 }

--- a/src/ui/app/lib/stats.ts
+++ b/src/ui/app/lib/stats.ts
@@ -3,8 +3,6 @@ import { dateTimeToTicks } from "@/lib/time";
 import { invoke } from "@tauri-apps/api/core";
 import { DateTime } from "luxon";
 
-export const SCORE_SENTINEL = null as unknown as number;
-
 export async function getScore({
   options,
   start,

--- a/src/ui/app/lib/stats.ts
+++ b/src/ui/app/lib/stats.ts
@@ -1,4 +1,4 @@
-import type { WithGroup } from "@/lib/entities";
+import type { Score, WithGroup } from "@/lib/entities";
 import { getQueryOptions, type QueryOptions } from "@/lib/repo";
 import { dateTimeToTicks, type Period } from "@/lib/time";
 import { invoke } from "@tauri-apps/api/core";
@@ -12,7 +12,7 @@ export async function getScore({
   options?: QueryOptions;
   start: DateTime;
   end: DateTime;
-}): Promise<number> {
+}): Promise<Score> {
   const queryOptions = getQueryOptions(options);
   return await invoke("get_score", {
     queryOptions,
@@ -31,7 +31,7 @@ export async function getScorePerPeriod({
   start: DateTime;
   end: DateTime;
   period: Period;
-}): Promise<WithGroup<number>[]> {
+}): Promise<WithGroup<Score>[]> {
   const queryOptions = getQueryOptions(options);
   return await invoke("get_score_per_period", {
     queryOptions,

--- a/src/ui/app/lib/stats.ts
+++ b/src/ui/app/lib/stats.ts
@@ -1,0 +1,23 @@
+import { getQueryOptions, type QueryOptions } from "@/lib/repo";
+import { dateTimeToTicks } from "@/lib/time";
+import { invoke } from "@tauri-apps/api/core";
+import { DateTime } from "luxon";
+
+export const SCORE_SENTINEL = null as unknown as number;
+
+export async function getScore({
+  options,
+  start,
+  end,
+}: {
+  options?: QueryOptions;
+  start: DateTime;
+  end: DateTime;
+}): Promise<number> {
+  const queryOptions = getQueryOptions(options);
+  return await invoke("get_score", {
+    queryOptions,
+    start: dateTimeToTicks(start),
+    end: dateTimeToTicks(end),
+  });
+}

--- a/src/ui/src-tauri/src/lib.rs
+++ b/src/ui/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod config;
 mod error;
 mod repo;
 mod state;
+mod stats;
 mod tracing;
 
 /// Tauri run entry point
@@ -58,6 +59,7 @@ pub fn run() {
             repo::get_app_session_usages,
             repo::get_interaction_periods,
             repo::get_system_events,
+            stats::get_score,
             tracing::log,
             config::read_config,
             config::config_set_track_incognito,

--- a/src/ui/src-tauri/src/lib.rs
+++ b/src/ui/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run() {
             repo::get_interaction_periods,
             repo::get_system_events,
             stats::get_score,
+            stats::get_score_per_period,
             tracing::log,
             config::read_config,
             config::config_set_track_incognito,

--- a/src/ui/src-tauri/src/stats.rs
+++ b/src/ui/src-tauri/src/stats.rs
@@ -1,5 +1,5 @@
 use data::db::infused::WithGroup;
-use data::entities::{Period, Timestamp};
+use data::entities::{Period, Score, Timestamp};
 use tauri::State;
 use util::tracing;
 
@@ -13,7 +13,7 @@ pub async fn get_score(
     _query_options: QueryOptions,
     start: Timestamp,
     end: Timestamp,
-) -> AppResult<f64> {
+) -> AppResult<Score> {
     let mut repo = {
         let state = state.read().await;
         state.assume_init().get_repo().await?
@@ -30,7 +30,7 @@ pub async fn get_score_per_period(
     start: Timestamp,
     end: Timestamp,
     period: Period,
-) -> AppResult<Vec<WithGroup<f64>>> {
+) -> AppResult<Vec<WithGroup<Score>>> {
     let mut repo = {
         let state = state.read().await;
         state.assume_init().get_repo().await?

--- a/src/ui/src-tauri/src/stats.rs
+++ b/src/ui/src-tauri/src/stats.rs
@@ -1,0 +1,22 @@
+use data::entities::Timestamp;
+use tauri::State;
+use util::tracing;
+
+use crate::error::AppResult;
+use crate::state::{AppState, QueryOptions};
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
+pub async fn get_score(
+    state: State<'_, AppState>,
+    _query_options: QueryOptions,
+    start: Timestamp,
+    end: Timestamp,
+) -> AppResult<f64> {
+    let mut repo = {
+        let state = state.read().await;
+        state.assume_init().get_repo().await?
+    };
+    let res = repo.get_score(start, end).await?;
+    Ok(res)
+}

--- a/src/ui/src-tauri/src/stats.rs
+++ b/src/ui/src-tauri/src/stats.rs
@@ -1,4 +1,5 @@
-use data::entities::Timestamp;
+use data::db::infused::WithGroup;
+use data::entities::{Period, Timestamp};
 use tauri::State;
 use util::tracing;
 
@@ -18,5 +19,22 @@ pub async fn get_score(
         state.assume_init().get_repo().await?
     };
     let res = repo.get_score(start, end).await?;
+    Ok(res)
+}
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
+pub async fn get_score_per_period(
+    state: State<'_, AppState>,
+    _query_options: QueryOptions,
+    start: Timestamp,
+    end: Timestamp,
+    period: Period,
+) -> AppResult<Vec<WithGroup<f64>>> {
+    let mut repo = {
+        let state = state.read().await;
+        state.assume_init().get_repo().await?
+    };
+    let res = repo.get_score_per_period(start, end, period).await?;
     Ok(res)
 }


### PR DESCRIPTION
e### TL;DR

Added functionality to calculate productivity scores based on app usage and tags.

### What changed?

- Added a new `repo_stat.rs` module with methods to calculate productivity scores
- Implemented `get_score()` to calculate weighted average scores based on app usage durations and tag scores
- Implemented `get_score_per_period()` to calculate scores grouped by time periods (hour, day, week)
- Added a new `WithGroup<T>` struct to represent values grouped by time periods
- Created comprehensive tests for the new functionality
- Added corresponding Tauri commands and React hooks to expose the functionality to the UI