### PR TITLE
Visualize Streaks in Gantt2

### DIFF
--- a/dev/appsettings.Debug.json
+++ b/dev/appsettings.Debug.json
@@ -2,7 +2,18 @@
   "engineLogFilter": "Debug,selectors=info,html5ever=info",
   "uiLogFilter": "Debug,selectors=info,html5ever=info",
 
-  "maxIdleDuration": { "secs": 5,  "nanos": 0 },
-  "pollDuration": { "secs": 1,  "nanos": 0 },
-  "alertDuration": { "secs": 1,  "nanos": 0 }
+  "defaultFocusStreakSettings": {
+    "minFocusScore": 0.0,
+    "minFocusUsageDur": { "secs": 60, "nanos": 0 },
+    "maxFocusGap": { "secs": 10, "nanos": 0 }
+  },
+  "defaultDistractiveStreakSettings": {
+    "maxDistractiveScore": 0.0,
+    "minDistractiveUsageDur": { "secs": 10, "nanos": 0 },
+    "maxDistractiveGap": { "secs": 60, "nanos": 0 }
+  },
+
+  "maxIdleDuration": { "secs": 5, "nanos": 0 },
+  "pollDuration": { "secs": 1, "nanos": 0 },
+  "alertDuration": { "secs": 1, "nanos": 0 }
 }

--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -402,6 +402,26 @@ pub struct FocusStreakSettings {
     pub max_focus_gap: Duration,
 }
 
+impl From<util::config::FocusStreakSettings> for FocusStreakSettings {
+    fn from(settings: util::config::FocusStreakSettings) -> Self {
+        Self {
+            min_focus_score: settings.min_focus_score.into(),
+            min_focus_usage_dur: to_ticks(settings.min_focus_usage_dur),
+            max_focus_gap: to_ticks(settings.max_focus_gap),
+        }
+    }
+}
+
+impl From<FocusStreakSettings> for util::config::FocusStreakSettings {
+    fn from(settings: FocusStreakSettings) -> Self {
+        Self {
+            min_focus_score: settings.min_focus_score.into(),
+            min_focus_usage_dur: from_ticks(settings.min_focus_usage_dur),
+            max_focus_gap: from_ticks(settings.max_focus_gap),
+        }
+    }
+}
+
 /// Settings for distractive streaks.
 #[derive(FromRow, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -412,4 +432,32 @@ pub struct DistractiveStreakSettings {
     pub min_distractive_usage_dur: Duration,
     /// The maximum gap between two distractive streaks.
     pub max_distractive_gap: Duration,
+}
+
+impl From<util::config::DistractiveStreakSettings> for DistractiveStreakSettings {
+    fn from(settings: util::config::DistractiveStreakSettings) -> Self {
+        Self {
+            max_distractive_score: settings.max_distractive_score.into(),
+            min_distractive_usage_dur: to_ticks(settings.min_distractive_usage_dur),
+            max_distractive_gap: to_ticks(settings.max_distractive_gap),
+        }
+    }
+}
+
+impl From<DistractiveStreakSettings> for util::config::DistractiveStreakSettings {
+    fn from(settings: DistractiveStreakSettings) -> Self {
+        Self {
+            max_distractive_score: settings.max_distractive_score.into(),
+            min_distractive_usage_dur: from_ticks(settings.min_distractive_usage_dur),
+            max_distractive_gap: from_ticks(settings.max_distractive_gap),
+        }
+    }
+}
+
+fn to_ticks(duration: std::time::Duration) -> i64 {
+    (duration.as_nanos() / 100) as i64
+}
+
+fn from_ticks(ticks: i64) -> std::time::Duration {
+    std::time::Duration::from_nanos((ticks * 100) as u64)
 }

--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -454,10 +454,12 @@ impl From<DistractiveStreakSettings> for util::config::DistractiveStreakSettings
     }
 }
 
+const TICKS_PER_NANOSECOND: i64 = 100;
+
 fn to_ticks(duration: std::time::Duration) -> i64 {
-    (duration.as_nanos() / 100) as i64
+    duration.as_nanos() as i64 / TICKS_PER_NANOSECOND
 }
 
 fn from_ticks(ticks: i64) -> std::time::Duration {
-    std::time::Duration::from_nanos((ticks * 100) as u64)
+    std::time::Duration::from_nanos((ticks * TICKS_PER_NANOSECOND) as u64)
 }

--- a/src/ui/app/components/tag/score.tsx
+++ b/src/ui/app/components/tag/score.tsx
@@ -23,6 +23,9 @@ export const Colors = {
   worst: "bg-red-400 dark:bg-red-800",
 };
 
+export const FOCUS_STREAK_BACKGROUND = "rgba(0, 225, 0, 0.35)";
+export const DISTRACTIVE_STREAK_BACKGROUND = "rgba(200, 0, 0, 0.35)";
+
 /**
  * Converts a score value (-100 to 100) into a descriptive string
  * @param score A number between -100 and 100

--- a/src/ui/app/components/time/duration-text.tsx
+++ b/src/ui/app/components/time/duration-text.tsx
@@ -17,10 +17,12 @@ export function DurationText({
   ticks,
   duration,
   className,
+  description,
 }: {
   ticks?: number;
   duration?: Duration;
   className?: ClassValue;
+  description?: string;
 }) {
   return (
     <TooltipProvider>
@@ -36,6 +38,7 @@ export function DurationText({
           </div>
         </TooltipTrigger>
         <TooltipContent>
+          {description ? `${description}: ` : ""}
           {toHumanDurationFull(ticks ?? durationToTicks(duration!))}
         </TooltipContent>
       </Tooltip>

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -1,4 +1,8 @@
 import AppIcon from "@/components/app/app-icon";
+import {
+  DISTRACTIVE_STREAK_BACKGROUND,
+  FOCUS_STREAK_BACKGROUND,
+} from "@/components/tag/score";
 import { DurationText } from "@/components/time/duration-text";
 import { DateTimeText } from "@/components/time/time-text";
 import { Text } from "@/components/ui/text";
@@ -414,8 +418,8 @@ export function Gantt({
           // Individual color per streak
           itemStyle: {
             color: p.isFocused
-              ? "rgba(0, 225, 0, 0.35)" // green for focus
-              : "rgba(200, 0, 0, 0.35)", // red otherwise
+              ? FOCUS_STREAK_BACKGROUND
+              : DISTRACTIVE_STREAK_BACKGROUND,
           },
         },
         {

--- a/src/ui/app/hooks/use-repo.tsx
+++ b/src/ui/app/hooks/use-repo.tsx
@@ -1,4 +1,5 @@
 import { useRefresh } from "@/hooks/use-refresh";
+import { useConfig } from "@/lib/config";
 import type { Ref, WithGroupedDuration } from "@/lib/entities";
 import {
   getAppDurations,
@@ -78,6 +79,18 @@ export const useTagDurationsPerPeriod = makeUseRepo(
 export const useScore = makeUseRepo(getScore, 0);
 export const useScorePerPeriod = makeUseRepo(getScorePerPeriod, []);
 export const useStreaks = makeUseRepo(getStreaks, []);
+export const useDefaultStreaks = function (arg: {
+  start: DateTime;
+  end: DateTime;
+}) {
+  const { defaultFocusStreakSettings, defaultDistractiveStreakSettings } =
+    useConfig();
+  return useStreaks({
+    ...arg,
+    focusSettings: defaultFocusStreakSettings,
+    distractiveSettings: defaultDistractiveStreakSettings,
+  });
+};
 
 export function useTotalUsageFromPerPeriod<T>(
   durationsPerPeriod: EntityMap<T, WithGroupedDuration<T>[]>,

--- a/src/ui/app/lib/config.ts
+++ b/src/ui/app/lib/config.ts
@@ -1,6 +1,11 @@
+import type {
+  DistractiveStreakSettings,
+  FocusStreakSettings,
+} from "@/lib/entities";
 import { invoke } from "@tauri-apps/api/core";
 import { Duration } from "luxon";
 import { create } from "zustand";
+import { durationToTicks, ticksToDuration } from "./time";
 
 export interface ConfigDuration {
   secs: number;
@@ -12,6 +17,20 @@ export interface RawConfig {
   maxIdleDuration: ConfigDuration;
   pollDuration: ConfigDuration;
   alertDuration: ConfigDuration;
+  defaultFocusStreakSettings: RawFocusStreakSettings;
+  defaultDistractiveStreakSettings: RawDistractiveStreakSettings;
+}
+
+export interface RawFocusStreakSettings {
+  minFocusScore: number;
+  minFocusUsageDur: ConfigDuration;
+  maxFocusGap: ConfigDuration;
+}
+
+export interface RawDistractiveStreakSettings {
+  maxDistractiveScore: number;
+  minDistractiveUsageDur: ConfigDuration;
+  maxDistractiveGap: ConfigDuration;
 }
 
 export function toDuration(duration: ConfigDuration) {
@@ -21,8 +40,19 @@ export function toDuration(duration: ConfigDuration) {
   });
 }
 
+export function fromDuration(duration: Duration) {
+  const millis = duration.toMillis();
+  return {
+    secs: Math.floor(millis / 1000),
+    nanos: Math.floor((millis % 1000) * 1000000),
+  };
+}
+
 interface ConfigReadonly {
   trackIncognito: boolean;
+
+  defaultFocusStreakSettings: FocusStreakSettings;
+  defaultDistractiveStreakSettings: DistractiveStreakSettings;
 
   maxIdleDuration: Duration;
   pollDuration: Duration;
@@ -31,16 +61,81 @@ interface ConfigReadonly {
 
 interface Config extends ConfigReadonly {
   setTrackIncognito: (value: boolean) => Promise<void>;
+  setDefaultFocusStreakSettings: (
+    value: Partial<FocusStreakSettings>,
+  ) => Promise<void>;
+  setDefaultDistractiveStreakSettings: (
+    value: Partial<DistractiveStreakSettings>,
+  ) => Promise<void>;
+  resetDefaultFocusStreakSettings: () => Promise<void>;
+  resetDefaultDistractiveStreakSettings: () => Promise<void>;
 }
 
 export const useConfig = create<Config>((set) => {
   return {
     trackIncognito: false,
+
+    defaultFocusStreakSettings: {
+      minFocusScore: 0,
+      minFocusUsageDur: durationToTicks(toDuration({ secs: 0, nanos: 0 })),
+      maxFocusGap: durationToTicks(toDuration({ secs: 0, nanos: 0 })),
+    },
+    defaultDistractiveStreakSettings: {
+      maxDistractiveScore: 0,
+      minDistractiveUsageDur: durationToTicks(
+        toDuration({ secs: 0, nanos: 0 }),
+      ),
+      maxDistractiveGap: durationToTicks(toDuration({ secs: 0, nanos: 0 })),
+    },
+
     maxIdleDuration: Duration.fromObject({ seconds: 0 }),
     pollDuration: Duration.fromObject({ seconds: 0 }),
     alertDuration: Duration.fromObject({ seconds: 0 }),
+
     setTrackIncognito: async (value) => {
       await setTrackIncognito(value);
+      set(await readConfigReadonly());
+    },
+    setDefaultFocusStreakSettings: async (value) => {
+      // Assumes FocusStreakSettings is shallow-cloneable
+      const newValue = Object.assign(
+        {},
+        useConfig.getState().defaultFocusStreakSettings,
+        value,
+      );
+      await setDefaultFocusStreakSettings({
+        minFocusScore: newValue.minFocusScore,
+        minFocusUsageDur: fromDuration(
+          ticksToDuration(newValue.minFocusUsageDur),
+        ),
+        maxFocusGap: fromDuration(ticksToDuration(newValue.maxFocusGap)),
+      });
+      set(await readConfigReadonly());
+    },
+    setDefaultDistractiveStreakSettings: async (value) => {
+      // Assumes DistractiveStreakSettings is shallow-cloneable
+      const newValue = Object.assign(
+        {},
+        useConfig.getState().defaultDistractiveStreakSettings,
+        value,
+      );
+      await setDefaultDistractiveStreakSettings({
+        maxDistractiveScore: newValue.maxDistractiveScore,
+        minDistractiveUsageDur: fromDuration(
+          ticksToDuration(newValue.minDistractiveUsageDur),
+        ),
+        maxDistractiveGap: fromDuration(
+          ticksToDuration(newValue.maxDistractiveGap),
+        ),
+      });
+      set(await readConfigReadonly());
+    },
+    resetDefaultFocusStreakSettings: async () => {
+      await resetDefaultFocusStreakSettings();
+      set(await readConfigReadonly());
+    },
+    resetDefaultDistractiveStreakSettings: async () => {
+      await resetDefaultDistractiveStreakSettings();
       set(await readConfigReadonly());
     },
   };
@@ -55,6 +150,27 @@ export async function readConfigReadonly() {
   const raw = await invoke<RawConfig>("read_config");
   return {
     trackIncognito: raw.trackIncognito ?? false,
+
+    defaultFocusStreakSettings: {
+      minFocusScore: raw.defaultFocusStreakSettings.minFocusScore,
+      minFocusUsageDur: durationToTicks(
+        toDuration(raw.defaultFocusStreakSettings.minFocusUsageDur),
+      ),
+      maxFocusGap: durationToTicks(
+        toDuration(raw.defaultFocusStreakSettings.maxFocusGap),
+      ),
+    },
+    defaultDistractiveStreakSettings: {
+      maxDistractiveScore:
+        raw.defaultDistractiveStreakSettings.maxDistractiveScore,
+      minDistractiveUsageDur: durationToTicks(
+        toDuration(raw.defaultDistractiveStreakSettings.minDistractiveUsageDur),
+      ),
+      maxDistractiveGap: durationToTicks(
+        toDuration(raw.defaultDistractiveStreakSettings.maxDistractiveGap),
+      ),
+    },
+
     maxIdleDuration: toDuration(raw.maxIdleDuration),
     pollDuration: toDuration(raw.pollDuration),
     alertDuration: toDuration(raw.alertDuration),
@@ -63,6 +179,26 @@ export async function readConfigReadonly() {
 
 async function setTrackIncognito(value: boolean) {
   return await invoke("config_set_track_incognito", { value });
+}
+
+async function setDefaultFocusStreakSettings(value: RawFocusStreakSettings) {
+  return await invoke("config_set_default_focus_streak_settings", { value });
+}
+
+async function setDefaultDistractiveStreakSettings(
+  value: RawDistractiveStreakSettings,
+) {
+  return await invoke("config_set_default_distractive_streak_settings", {
+    value,
+  });
+}
+
+async function resetDefaultFocusStreakSettings() {
+  return await invoke("config_reset_default_focus_streak_settings");
+}
+
+async function resetDefaultDistractiveStreakSettings() {
+  return await invoke("config_reset_default_distractive_streak_settings");
 }
 
 export async function getIconsDir(): Promise<string> {

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -423,7 +423,7 @@ function AppSessionsCard({ app }: { app: App }) {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
           Sessions
         </VizCardTitle>

--- a/src/ui/app/routes/history.tsx
+++ b/src/ui/app/routes/history.tsx
@@ -26,6 +26,7 @@ import { VerticalLegend } from "@/components/viz/vertical-legend";
 import {
   useAppDurationsPerPeriod,
   useAppSessionUsages,
+  useDefaultStreaks,
   useInteractionPeriods,
   useSystemEvents,
   useTotalUsageFromPerPeriod,
@@ -231,12 +232,16 @@ function SessionHistory() {
     useInteractionPeriods(interval);
   const { ret: systemEvents, isLoading: systemEventsLoading } =
     useSystemEvents(interval);
+  const { ret: streaks, isLoading: streaksLoading } =
+    useDefaultStreaks(interval);
 
   return (
     <div className="sticky rounded-lg bg-card shadow-xs border border-border overflow-clip">
       <Gantt
         usages={usages}
         usagesLoading={usagesLoading}
+        streaks={streaks}
+        streaksLoading={streaksLoading}
         interactionPeriods={interactions}
         interactionPeriodsLoading={interactionPeriodsLoading}
         systemEvents={systemEvents}

--- a/src/ui/app/routes/history.tsx
+++ b/src/ui/app/routes/history.tsx
@@ -247,6 +247,7 @@ function SessionHistory() {
         systemEvents={systemEvents}
         systemEventsLoading={systemEventsLoading}
         interval={interval}
+        durationSummariesClassName="mt-4"
       />
     </div>
   );

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -160,7 +160,7 @@ function SessionsCard() {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
           Sessions
         </VizCardTitle>

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -20,6 +20,7 @@ import {
 import {
   useAppDurationsPerPeriod,
   useAppSessionUsages,
+  useDefaultStreaks,
   useInteractionPeriods,
   useSystemEvents,
   useTotalUsageFromPerPeriod,
@@ -148,9 +149,14 @@ function SessionsCard() {
     useInteractionPeriods(interval);
   const { ret: systemEvents, isLoading: systemEventsLoading } =
     useSystemEvents(interval);
+  const { ret: streaks, isLoading: streaksLoading } =
+    useDefaultStreaks(interval);
 
   const isLoading =
-    usagesLoading || interactionPeriodsLoading || systemEventsLoading;
+    usagesLoading ||
+    interactionPeriodsLoading ||
+    systemEventsLoading ||
+    streaksLoading;
 
   return (
     <VizCard>
@@ -186,6 +192,8 @@ function SessionsCard() {
         <Gantt
           usages={usages}
           usagesLoading={usagesLoading}
+          streaks={streaks}
+          streaksLoading={streaksLoading}
           interactionPeriods={interactions}
           interactionPeriodsLoading={interactionPeriodsLoading}
           systemEvents={systemEvents}

--- a/src/ui/app/routes/settings.tsx
+++ b/src/ui/app/routes/settings.tsx
@@ -1,16 +1,28 @@
+import { ScoreSlider } from "@/components/tag/score-slider";
 import { useTheme } from "@/components/theme-provider";
 import { ThemeSwitch } from "@/components/theme-switch";
+import { DurationPicker } from "@/components/time/duration-picker";
 import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
   BreadcrumbPage,
 } from "@/components/ui/breadcrumb";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Switch } from "@/components/ui/switch";
 import { useConfig } from "@/lib/config";
+import type { Score } from "@/lib/entities";
+import { durationToTicks, ticksToDuration } from "@/lib/time";
+import { RefreshCcwIcon } from "lucide-react";
 import { type ReactNode } from "react";
 
 export function Setting({
@@ -23,7 +35,7 @@ export function Setting({
   action: ReactNode;
 }) {
   return (
-    <div className="flex items-center">
+    <div className="flex items-center gap-2">
       <div>
         <h3 className="text-lg font-semibold text-card-foreground/80">
           {title}
@@ -40,7 +52,21 @@ export function Setting({
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
-  const { trackIncognito, setTrackIncognito } = useConfig();
+  const {
+    trackIncognito,
+    defaultFocusStreakSettings,
+    defaultDistractiveStreakSettings,
+    setTrackIncognito,
+    setDefaultFocusStreakSettings,
+    setDefaultDistractiveStreakSettings,
+    resetDefaultFocusStreakSettings,
+    resetDefaultDistractiveStreakSettings,
+  } = useConfig();
+
+  const resetStreakSettings = async () => {
+    await resetDefaultFocusStreakSettings();
+    await resetDefaultDistractiveStreakSettings();
+  };
 
   return (
     <>
@@ -86,8 +112,166 @@ export default function Settings() {
               />
             </CardContent>
           </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                <div className="flex items-center">
+                  <div>Streaks</div>
+                  <Button
+                    variant="outline"
+                    onClick={resetStreakSettings}
+                    className="ml-auto"
+                  >
+                    <RefreshCcwIcon className="w-4 h-4 text-muted-foreground" />
+                    <div className="text-muted-foreground">Reset</div>
+                  </Button>
+                </div>
+              </CardTitle>
+              <CardDescription>Settings for streak detection.</CardDescription>
+            </CardHeader>
+            <CardContent className="gap-4 flex flex-col">
+              <Setting
+                title="Focus: Minimum Score"
+                description="The minimum score of an app's tag for the app to be considered a focus app."
+                action={
+                  <ScoreSettingAction
+                    score={defaultFocusStreakSettings.minFocusScore}
+                    onScoreChange={(v) =>
+                      setDefaultFocusStreakSettings({ minFocusScore: v })
+                    }
+                  />
+                }
+              />
+
+              <Setting
+                title="Focus: Minimum Usage Duration"
+                description="The minimum duration of contiguous usages from focus apps to be considered a focus streak."
+                action={
+                  <DurationPicker
+                    className="w-40"
+                    value={ticksToDuration(
+                      defaultFocusStreakSettings.minFocusUsageDur,
+                    )}
+                    onValueChange={(v) =>
+                      v !== null &&
+                      setDefaultFocusStreakSettings({
+                        minFocusUsageDur: durationToTicks(v),
+                      })
+                    }
+                  />
+                }
+              />
+
+              <Setting
+                title="Focus: Maximum Gap"
+                description="The maximum gap between focus streaks before adjacent focus streaks are combined into a longer streak."
+                action={
+                  <DurationPicker
+                    className="w-40"
+                    value={ticksToDuration(
+                      defaultFocusStreakSettings.maxFocusGap,
+                    )}
+                    onValueChange={(v) =>
+                      v !== null &&
+                      setDefaultFocusStreakSettings({
+                        maxFocusGap: durationToTicks(v),
+                      })
+                    }
+                  />
+                }
+              />
+
+              <Setting
+                title="Distractive: Maximum Score"
+                description="The maximum score of an app's tag for the app to be considered a distractive app."
+                action={
+                  <ScoreSettingAction
+                    score={defaultDistractiveStreakSettings.maxDistractiveScore}
+                    onScoreChange={(v) =>
+                      setDefaultDistractiveStreakSettings({
+                        maxDistractiveScore: v,
+                      })
+                    }
+                  />
+                }
+              />
+
+              <Setting
+                title="Distractive: Minimum Usage Duration"
+                description="The minimum duration of contiguous usages from distractive apps to be considered a distractive streak."
+                action={
+                  <DurationPicker
+                    className="w-40"
+                    value={ticksToDuration(
+                      defaultDistractiveStreakSettings.minDistractiveUsageDur,
+                    )}
+                    onValueChange={(v) =>
+                      v !== null &&
+                      setDefaultDistractiveStreakSettings({
+                        minDistractiveUsageDur: durationToTicks(v),
+                      })
+                    }
+                  />
+                }
+              />
+
+              <Setting
+                title="Distractive: Maximum Gap"
+                description="The maximum gap between distractive streaks before adjacent distractive streaks are combined into a longer streak."
+                action={
+                  <DurationPicker
+                    className="w-40"
+                    value={ticksToDuration(
+                      defaultDistractiveStreakSettings.maxDistractiveGap,
+                    )}
+                    onValueChange={(v) =>
+                      v !== null &&
+                      setDefaultDistractiveStreakSettings({
+                        maxDistractiveGap: durationToTicks(v),
+                      })
+                    }
+                  />
+                }
+              />
+            </CardContent>
+          </Card>
         </div>
       </div>
     </>
+  );
+}
+
+function ScoreSettingAction({
+  score,
+  onScoreChange,
+}: {
+  score: Score;
+  // TODO: we should add some debouncing here otherwise we get too much file io
+  onScoreChange: (score: Score) => void;
+}) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="h-8 mb-1 text-sm gap-2 flex items-center">
+        <span className="text-sm text-muted-foreground min-w-0 truncate">
+          {score}
+        </span>
+        {score !== 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="px-2 py-1 h-6 m-0 text-xs"
+            onClick={() => onScoreChange(0)}
+          >
+            Reset
+          </Button>
+        )}
+      </div>
+
+      <ScoreSlider
+        className="w-40"
+        value={score}
+        onValueChange={onScoreChange}
+      />
+    </div>
   );
 }

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -388,7 +388,7 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
           Sessions
         </VizCardTitle>

--- a/src/ui/src-tauri/src/config.rs
+++ b/src/ui/src-tauri/src/config.rs
@@ -1,5 +1,5 @@
 use tauri::State;
-use util::config::Config;
+use util::config::{Config, DistractiveStreakSettings, FocusStreakSettings};
 use util::error::Context;
 use util::tracing;
 
@@ -22,6 +22,64 @@ pub async fn config_set_track_incognito(state: State<'_, AppState>, value: bool)
         .config
         .set_track_incognito(value)
         .context("set track incognito")?;
+    Ok(())
+}
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
+pub async fn config_set_default_focus_streak_settings(
+    state: State<'_, AppState>,
+    value: FocusStreakSettings,
+) -> AppResult<()> {
+    let mut state = state.write().await;
+    state
+        .assume_init_mut()
+        .config
+        .set_default_focus_streak_settings(value)
+        .context("set default focus streak settings")?;
+    Ok(())
+}
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
+pub async fn config_set_default_distractive_streak_settings(
+    state: State<'_, AppState>,
+    value: DistractiveStreakSettings,
+) -> AppResult<()> {
+    let mut state = state.write().await;
+    state
+        .assume_init_mut()
+        .config
+        .set_default_distractive_streak_settings(value)
+        .context("set default distractive streak settings")?;
+    Ok(())
+}
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
+pub async fn config_reset_default_focus_streak_settings(
+    state: State<'_, AppState>,
+) -> AppResult<()> {
+    let mut state = state.write().await;
+    state
+        .assume_init_mut()
+        .config
+        .set_default_focus_streak_settings(Default::default())
+        .context("reset default focus streak settings")?;
+    Ok(())
+}
+
+#[tauri::command]
+#[tracing::instrument(err, skip(state))]
+pub async fn config_reset_default_distractive_streak_settings(
+    state: State<'_, AppState>,
+) -> AppResult<()> {
+    let mut state = state.write().await;
+    state
+        .assume_init_mut()
+        .config
+        .set_default_distractive_streak_settings(Default::default())
+        .context("reset default distractive streak settings")?;
     Ok(())
 }
 

--- a/src/ui/src-tauri/src/lib.rs
+++ b/src/ui/src-tauri/src/lib.rs
@@ -65,6 +65,10 @@ pub fn run() {
             tracing::log,
             config::read_config,
             config::config_set_track_incognito,
+            config::config_set_default_focus_streak_settings,
+            config::config_set_default_distractive_streak_settings,
+            config::config_reset_default_focus_streak_settings,
+            config::config_reset_default_distractive_streak_settings,
             config::get_icons_dir,
         ])
         .run(tauri::generate_context!())

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -231,6 +231,23 @@ impl Config {
         Ok(())
     }
 
+    /// Set default focus streak settings
+    pub fn set_default_focus_streak_settings(&mut self, value: FocusStreakSettings) -> Result<()> {
+        self.default_focus_streak_settings = value;
+        self.write()?;
+        Ok(())
+    }
+
+    /// Set default distractive streak settings
+    pub fn set_default_distractive_streak_settings(
+        &mut self,
+        value: DistractiveStreakSettings,
+    ) -> Result<()> {
+        self.default_distractive_streak_settings = value;
+        self.write()?;
+        Ok(())
+    }
+
     /// UI Log filter (tracing)
     pub fn ui_log_filter(&self) -> &str {
         &self.ui_log_filter

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -13,10 +13,58 @@ pub struct Config {
     ui_log_filter: String,
 
     track_incognito: Option<bool>,
+    default_focus_streak_settings: FocusStreakSettings,
+    default_distractive_streak_settings: DistractiveStreakSettings,
 
     max_idle_duration: Duration,
     poll_duration: Duration,
     alert_duration: Duration,
+}
+
+/// Settings for focus streaks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FocusStreakSettings {
+    /// The minimum score of a focused app.
+    pub min_focus_score: f64,
+    /// The minimum duration of a focused usage.
+    pub min_focus_usage_dur: Duration,
+    /// The maximum gap between two focused streaks.
+    pub max_focus_gap: Duration,
+}
+
+impl Default for FocusStreakSettings {
+    fn default() -> Self {
+        Self {
+            min_focus_score: 0.0,
+            // harder to be focused
+            min_focus_usage_dur: Duration::from_secs(60),
+            max_focus_gap: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Settings for distractive streaks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DistractiveStreakSettings {
+    /// The maximum score of a distractive app.
+    pub max_distractive_score: f64,
+    /// The minimum duration of a distractive usage.
+    pub min_distractive_usage_dur: Duration,
+    /// The maximum gap between two distractive streaks.
+    pub max_distractive_gap: Duration,
+}
+
+impl Default for DistractiveStreakSettings {
+    fn default() -> Self {
+        Self {
+            max_distractive_score: 0.0,
+            // easier to be distracted
+            min_distractive_usage_dur: Duration::from_secs(10),
+            max_distractive_gap: Duration::from_secs(60),
+        }
+    }
 }
 
 /// The name of the config file during tests
@@ -33,6 +81,8 @@ impl Default for Config {
             engine_log_filter: "Info".to_string(),
             ui_log_filter: "Info".to_string(),
             track_incognito: Some(false),
+            default_focus_streak_settings: FocusStreakSettings::default(),
+            default_distractive_streak_settings: DistractiveStreakSettings::default(),
             max_idle_duration: Duration::from_secs(5),
             poll_duration: Duration::from_secs(1),
             alert_duration: Duration::from_secs(1),
@@ -98,6 +148,32 @@ impl Config {
         if self.alert_duration >= Duration::from_secs(10) {
             replace = true;
         }
+
+        if self.default_focus_streak_settings.min_focus_score
+            < self
+                .default_distractive_streak_settings
+                .max_distractive_score
+        {
+            replace = true;
+        }
+        if self.default_focus_streak_settings.min_focus_score < -100.0
+            || self.default_focus_streak_settings.min_focus_score > 100.0
+        {
+            replace = true;
+        }
+        if self
+            .default_distractive_streak_settings
+            .max_distractive_score
+            < -100.0
+            || self
+                .default_distractive_streak_settings
+                .max_distractive_score
+                > 100.0
+        {
+            replace = true;
+        }
+
+        // Streak durations have no real limits since it doesn't affect the engine.
 
         if replace {
             Self::replace_with_default()?;
@@ -173,6 +249,16 @@ impl Config {
     /// How often the engine should check for alerts firing
     pub fn alert_duration(&self) -> Duration {
         self.alert_duration
+    }
+
+    /// Default focus streak settings
+    pub fn default_focus_streak_settings(&self) -> &FocusStreakSettings {
+        &self.default_focus_streak_settings
+    }
+
+    /// Default distractive streak settings
+    pub fn default_distractive_streak_settings(&self) -> &DistractiveStreakSettings {
+        &self.default_distractive_streak_settings
     }
 
     /// Write the config to the appsettings.json file


### PR DESCRIPTION
### TL;DR

Added focus and distractive streak detection with configurable settings.

### What changed?

- Added configurable settings for focus and distractive streak detection in the app settings
- Implemented streak visualization in the Gantt chart with green areas for focus streaks and red areas for distractive streaks
- Added conversion functions between different duration representations
- Created UI components for configuring streak settings in the Settings page
- Added default streak settings to the configuration file