### PR TITLE
Debounced State Hook

### DIFF
--- a/src/ui/app/hooks/use-debounced-state.tsx
+++ b/src/ui/app/hooks/use-debounced-state.tsx
@@ -1,0 +1,20 @@
+import { error } from "@/lib/log";
+import { useEffect, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
+
+export function useDebouncedState<T>(
+  initialState: T,
+  updateFn: (state: T) => Promise<void>,
+  debounceMs: number,
+) {
+  const [state, setStateInner] = useState(initialState);
+  const debouncedUpdate = useDebouncedCallback(updateFn, debounceMs);
+  useEffect(() => {
+    debouncedUpdate(state)?.catch((err) => {
+      console.error(err);
+      error("Failed to update debounced state", err);
+    });
+  }, [state, debouncedUpdate]);
+
+  return [state, setStateInner] as const;
+}

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -29,6 +29,7 @@ import {
   VizCardTitle,
 } from "@/components/viz/viz-card";
 import { useClipboard } from "@/hooks/use-clipboard";
+import { useDebouncedState } from "@/hooks/use-debounced-state";
 import { useApp, useTag } from "@/hooks/use-refresh";
 import {
   useAppDurationsPerPeriod,
@@ -52,9 +53,8 @@ import type { ClassValue } from "clsx";
 import _ from "lodash";
 import { Check, ChevronsUpDown, Copy } from "lucide-react";
 import { DateTime } from "luxon";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { NavLink } from "react-router";
-import { useDebouncedCallback } from "use-debounce";
 import type { Route } from "../apps/+types/[id]";
 
 export default function Page({ params }: Route.ComponentProps) {
@@ -66,19 +66,11 @@ export default function Page({ params }: Route.ComponentProps) {
 
 function AppPage({ app }: { app: App }) {
   const updateApp = useAppState((state) => state.updateApp);
-  const [color, setColorInner] = useState(app.color);
-  const debouncedUpdateColor = useDebouncedCallback(async (color: string) => {
-    await updateApp({ ...app, color });
-  }, 500);
-
-  const setColor = useCallback(
-    async (color: string) => {
-      setColorInner(color);
-      await debouncedUpdateColor(color);
-    },
-    [setColorInner, debouncedUpdateColor],
+  const [color, setColor] = useDebouncedState(
+    app.color,
+    async (color) => await updateApp({ ...app, color }),
+    500,
   );
-
   const { copy, hasCopied } = useClipboard();
 
   return (

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -37,6 +37,7 @@ import {
   VizCardHeader,
   VizCardTitle,
 } from "@/components/viz/viz-card";
+import { useDebouncedState } from "@/hooks/use-debounced-state";
 import { useAlerts, useTag } from "@/hooks/use-refresh";
 import {
   useAppDurationsPerPeriod,
@@ -59,9 +60,8 @@ import {
 import _ from "lodash";
 import { TagIcon, TrashIcon } from "lucide-react";
 import { DateTime } from "luxon";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { NavLink, useNavigate } from "react-router";
-import { useDebouncedCallback } from "use-debounce";
 import type { Route } from "../tags/+types/[id]";
 
 export default function Page({ params }: Route.ComponentProps) {
@@ -76,30 +76,15 @@ function TagPage({ tag }: { tag: Tag }) {
   const removeTag = useAppState((state) => state.removeTag);
   const updateTagApps = useAppState((state) => state.updateTagApps);
 
-  const [color, setColorInner] = useState(tag.color);
-  const [score, setScoreInner] = useState(tag.score);
-  const debouncedUpdateColor = useDebouncedCallback(async (color: string) => {
-    await updateTag({ ...tag, color });
-  }, 500);
-
-  const debouncedUpdateScore = useDebouncedCallback(async (score: number) => {
-    await updateTag({ ...tag, score });
-  }, 500);
-
-  const setColor = useCallback(
-    async (color: string) => {
-      setColorInner(color);
-      await debouncedUpdateColor(color);
-    },
-    [setColorInner, debouncedUpdateColor],
+  const [color, setColor] = useDebouncedState(
+    tag.color,
+    async (color) => await updateTag({ ...tag, color }),
+    500,
   );
-
-  const setScore = useCallback(
-    async (score: number) => {
-      setScoreInner(score);
-      await debouncedUpdateScore(score);
-    },
-    [setScoreInner, debouncedUpdateScore],
+  const [score, setScore] = useDebouncedState(
+    tag.score,
+    async (score) => await updateTag({ ...tag, score }),
+    500,
   );
 
   const navigate = useNavigate();


### PR DESCRIPTION
### TL;DR

Added a new `useDebouncedState` hook to simplify debounced state management and refactored existing implementations to use it.

### What changed?

- Created a new custom hook `useDebouncedState` that combines React's `useState` with debounced updates
- Refactored the color state management in the App page to use this new hook
- Refactored both color and score state management in the Tag page to use this new hook
- The hook handles error logging if the update function fails.