### PR TITLE
SQLite Perf

### DIFF
--- a/src/data/src/db/infused.rs
+++ b/src/data/src/db/infused.rs
@@ -372,9 +372,23 @@ pub struct Session {
     /// Maximum Usage of Usages
     pub end: Timestamp,
     /// Usages
-    pub usages: Vec<super::Usage>,
+    pub usages: Vec<Usage>,
 }
 
+/// [super::Usage] with additional information
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Usage {
+    // Remove id - we don't care about it
+    // /// Identifier
+    // pub id: Ref<super::Usage>,
+    /// Session Identifier
+    pub session_id: Ref<super::Session>,
+    /// Start time
+    pub start: Timestamp,
+    /// End time
+    pub end: Timestamp,
+}
 /// [Session]s with [Usage]s, partitioned by [App]s
 pub type AppSessionUsages = HashMap<Ref<super::App>, HashMap<Ref<super::Session>, Session>>;
 

--- a/src/data/src/db/repo.rs
+++ b/src/data/src/db/repo.rs
@@ -252,7 +252,6 @@ impl Repository {
         struct AppSessionUsage {
             app_id: Ref<App>,
             session_id: Ref<Session>,
-            usage_id: Ref<Usage>,
             session_title: String,
             session_url: Option<String>,
             start: Timestamp,
@@ -263,7 +262,6 @@ impl Repository {
             "SELECT
                 s.app_id AS app_id,
                 u.session_id AS session_id,
-                u.id AS usage_id,
                 s.title AS session_title,
                 s.url AS session_url,
                 MAX(u.start, p.start) AS start,
@@ -294,8 +292,7 @@ impl Repository {
                 });
             session.start = session.start.min(usage.start);
             session.end = session.end.max(usage.end);
-            session.usages.push(Usage {
-                id: usage.usage_id,
+            session.usages.push(infused::Usage {
                 session_id: usage.session_id,
                 start: usage.start,
                 end: usage.end,

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -16,7 +16,6 @@ import {
   type Ref,
   type Session,
   type SystemEventEnum,
-  type Usage,
 } from "@/lib/entities";
 import type { InteractionPeriod, Streak, SystemEvent } from "@/lib/entities";
 import type { AppSessionUsages } from "@/lib/repo";
@@ -81,7 +80,6 @@ interface CombinedUsage {
 interface AppSessionUsage {
   start: number;
   end: number;
-  usageId: Ref<Usage>;
   sessionId: Ref<Session>;
   appId: Ref<App>;
 }
@@ -218,7 +216,6 @@ export function Gantt({
                   session.usages.map((usage) => ({
                     start: usage.start,
                     end: usage.end,
-                    usageId: usage.id,
                     sessionId: session.id,
                     appId: app.id,
                   })),
@@ -303,7 +300,7 @@ export function Gantt({
             key.id,
             false,
             (usage as CombinedUsage).count,
-            (usage as AppSessionUsage).usageId,
+            undefined,
             (usage as AppSessionUsage).sessionId,
             (usage as AppSessionUsage).appId,
           ]),
@@ -313,7 +310,6 @@ export function Gantt({
           usagesPerAppSession[key.appId][key.id].usages.map((usage) => ({
             start: usage.start,
             end: usage.end,
-            usageId: usage.id,
             sessionId: key.id,
             appId: key.appId,
           })),
@@ -335,7 +331,7 @@ export function Gantt({
             key.id,
             usagesPerAppSession[key.appId][key.id].url,
             (usage as CombinedUsage).count,
-            (usage as AppSessionUsage).usageId,
+            undefined,
             (usage as AppSessionUsage).sessionId,
             (usage as AppSessionUsage).appId,
           ]),
@@ -699,7 +695,7 @@ export function Gantt({
         ,
         boolI,
         count,
-        usageId,
+        entityId,
         sessionId,
         appId,
       ] = params.data as number[];
@@ -720,7 +716,6 @@ export function Gantt({
           usage = {
             start,
             end,
-            usageId: +usageId as Ref<Usage>,
             sessionId: +sessionId as Ref<Session>,
             appId: +appId as Ref<App>,
           };
@@ -733,7 +728,7 @@ export function Gantt({
         const isSystemEvent = boolI;
         if (isSystemEvent) {
           setHoverSystemEvent({
-            id: +usageId as Ref<SystemEvent>,
+            id: +entityId as Ref<SystemEvent>,
             timestamp: start,
             event: sessionId as unknown as SystemEventEnum,
           });
@@ -756,7 +751,7 @@ export function Gantt({
             interaction = {
               start,
               end,
-              id: +usageId as Ref<InteractionPeriod>,
+              id: +entityId as Ref<InteractionPeriod>,
               mouseClicks,
               keyStrokes,
             };

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -57,7 +57,6 @@ export interface Session {
 }
 
 export interface Usage {
-  id: Ref<Usage>;
   start: Timestamp;
   end: Timestamp;
 }

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -15,9 +15,7 @@ export interface WithDuration<T> {
   duration: Duration;
 }
 
-export interface WithGroupedDuration<T> {
-  id: Ref<T>;
-  duration: Duration;
+export interface WithGroupedDuration<T> extends WithDuration<T> {
   group: Timestamp;
 }
 


### PR DESCRIPTION
This PR refactors the Usage data structure and related components, improves the get_streaks algorithm to improve performance and simplify the codebase:

- Removed unnecessary `id` field from the `Usage` struct as it's not needed for our use cases
- Created a dedicated `infused::Usage` struct with only the essential fields
- Updated SQL query in `Repository::get_app_session_usages` to no longer fetch usage IDs
- Modified the streak calculation SQL to filter out focus sessions that intersect with distraction sessions earlier in the query
- Updated the Gantt chart component to work with the simplified Usage structure
- Fixed type definitions in entities.ts to better represent the data model

These changes reduce data transfer overhead and simplify the data model while maintaining all functionality.