### PR TITLE
Dashboard Page Overview

### DIFF
--- a/src/ui/app/components/app/app-icon.tsx
+++ b/src/ui/app/components/app/app-icon.tsx
@@ -13,15 +13,15 @@ import { useEffect, useState } from "react";
 export const DEFAULT_ICON_SVG_URL = "data:image/svg+xml," + CircleHelpStatic;
 export const TAG_ICON_URL = "data:image/svg+xml," + TagStatic;
 
-function appIconUrl(appIcon?: string) {
-  if (!appIcon) return null;
+export function appIconUrl(appIcon?: string) {
+  if (!appIcon) return DEFAULT_ICON_SVG_URL;
   const fileName = normalize(appIcon);
   return convertFileSrc(`${iconsDir}/${fileName}`);
 }
 
 export function appIconHtmlImgElement(appIcon?: string): HTMLImageElement {
   const img = new Image();
-  img.src = appIconUrl(appIcon) ?? DEFAULT_ICON_SVG_URL;
+  img.src = appIconUrl(appIcon);
   img.onerror = () => {
     img.src = DEFAULT_ICON_SVG_URL;
     img.onerror = null;
@@ -30,7 +30,7 @@ export function appIconHtmlImgElement(appIcon?: string): HTMLImageElement {
 }
 
 // A little hack to make the tag icon color dynamic - relies on Lucide Static using currentColor for the color
-export function tagIconUrlStatic(color?: string) {
+export function tagIconUrl(color?: string) {
   return TAG_ICON_URL.replaceAll(
     "currentColor",
     color ? encodeURIComponent(color) : "currentColor",

--- a/src/ui/app/components/viz/app-usage-pie.tsx
+++ b/src/ui/app/components/viz/app-usage-pie.tsx
@@ -1,4 +1,4 @@
-import { appIconHtmlImgElement } from "@/components/app/app-icon";
+import { appIconUrl } from "@/components/app/app-icon";
 import {
   fullKeyToString,
   stringToFullKey,
@@ -195,7 +195,7 @@ export function AppUsagePieChart({
                 rotate: 0,
                 position: "middle",
                 backgroundColor: {
-                  image: appIconHtmlImgElement(data.app.icon),
+                  image: appIconUrl(data.app.icon),
                 },
                 formatter: () => {
                   return `{empty|}`;

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -8,6 +8,7 @@ import { DateTimeText } from "@/components/time/time-text";
 import { Text } from "@/components/ui/text";
 import { VizTooltip } from "@/components/viz/viz-tooltip";
 import { useApps } from "@/hooks/use-refresh";
+import { useStreakDurations } from "@/hooks/use-repo";
 import { useWidth } from "@/hooks/use-width";
 import { getVarColorAsHex } from "@/lib/color-utils";
 import {
@@ -1204,19 +1205,8 @@ function DurationSummaries({
 
   className?: ClassValue;
 }) {
-  const [focusStreakUsage, distractiveStreakUsage] = useMemo(() => {
-    if (!streaks) {
-      return [0, 0];
-    }
-    return [
-      _(streaks)
-        .filter((streak) => streak.isFocused)
-        .sumBy((streak) => streak.end - streak.start),
-      _(streaks)
-        .filter((streak) => !streak.isFocused)
-        .sumBy((streak) => streak.end - streak.start),
-    ];
-  }, [streaks]);
+  const [focusStreakUsage, distractiveStreakUsage] =
+    useStreakDurations(streaks);
 
   const totalUsage = useMemo(() => {
     return _(usages)

--- a/src/ui/app/components/viz/usage-chart.tsx
+++ b/src/ui/app/components/viz/usage-chart.tsx
@@ -1,7 +1,4 @@
-import {
-  appIconHtmlImgElement,
-  tagIconUrlStatic,
-} from "@/components/app/app-icon";
+import { appIconUrl, tagIconUrl } from "@/components/app/app-icon";
 import {
   fullKeyToString,
   stringToFullKey,
@@ -265,10 +262,8 @@ export function UsageChart({
           backgroundColor: {
             image:
               kv.key === "app"
-                ? appIconHtmlImgElement(kv.app.icon)
-                : tagIconUrlStatic(
-                    `color-mix(in srgb, ${kv.tag.color} 65%, black)`,
-                  ),
+                ? appIconUrl(kv.app.icon)
+                : tagIconUrl(`color-mix(in srgb, ${kv.tag.color} 65%, black)`),
           },
           formatter: () => {
             return `{empty|}`;

--- a/src/ui/app/hooks/use-repo.tsx
+++ b/src/ui/app/hooks/use-repo.tsx
@@ -1,6 +1,6 @@
 import { useRefresh } from "@/hooks/use-refresh";
 import { useConfig } from "@/lib/config";
-import type { Ref, WithGroupedDuration } from "@/lib/entities";
+import type { Ref, Streak, WithGroupedDuration } from "@/lib/entities";
 import {
   getAppDurations,
   getAppDurationsPerPeriod,
@@ -107,4 +107,19 @@ export function useSingleEntityUsageFromPerPeriod<T>(
   return useMemo(() => {
     return _(durationsPerPeriod[id]).sumBy("duration");
   }, [durationsPerPeriod, id]);
+}
+
+export function useStreakDurations(streaks?: Streak[]) {
+  return useMemo(() => {
+    if (!streaks) {
+      return [0, 0];
+    }
+    const focusStreakUsage = _(streaks)
+      .filter((streak) => streak.isFocused)
+      .sumBy((streak) => streak.end - streak.start);
+    const distractiveStreakUsage = _(streaks)
+      .filter((streak) => !streak.isFocused)
+      .sumBy((streak) => streak.end - streak.start);
+    return [focusStreakUsage, distractiveStreakUsage];
+  }, [streaks]);
 }

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -50,14 +50,18 @@ import {
 } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import _ from "lodash";
-import { TagIcon } from "lucide-react";
+import { Loader2, TagIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
 export default function Home() {
   const interval = usePeriodInterval("day");
-  const { ret: streaks } = useDefaultStreaks(interval);
-  const { ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+  const { ret: streaks, isLoading: streaksLoading } =
+    useDefaultStreaks(interval);
+  const {
+    ret: appDurationsPerPeriod,
+    isLoading: appDurationsPerPeriodLoading,
+  } = useAppDurationsPerPeriod({
     ...interval,
     period: "hour",
   });
@@ -84,18 +88,21 @@ export default function Home() {
           <div className="grid auto-rows-min gap-4 grid-cols-4">
             <AlertEventItem />
             <UsageStatItem
+              isLoading={streaksLoading}
               label="Focus Streaks"
               usage={focusStreakUsage}
               color="text-green-600 dark:text-green-400"
               cardColor="bg-green-500/10 border-green-500/20"
             />
             <UsageStatItem
+              isLoading={streaksLoading}
               label="Distractive Streaks"
               usage={distractiveStreakUsage}
               color="text-red-600 dark:text-red-400"
               cardColor="bg-red-500/10 border-red-500/20"
             />
             <UsageStatItem
+              isLoading={appDurationsPerPeriodLoading}
               label="Total Usage"
               usage={totalUsage}
               color="text-foreground"
@@ -258,11 +265,13 @@ function SessionsCard() {
 
 // Component for displaying usage statistics
 function UsageStatItem({
+  isLoading,
   label,
   usage,
   color,
   cardColor,
 }: {
+  isLoading: boolean;
   label: string;
   usage: number;
   color?: string;
@@ -277,10 +286,16 @@ function UsageStatItem({
     >
       <div className="flex flex-col">
         <div className={cn("text-sm font-medium", color)}>{label}</div>
-        <DurationText
-          className={cn("text-xl font-bold self-end", color)}
-          ticks={usage}
-        />
+        {isLoading ? (
+          <Loader2
+            className={cn("h-6 w-6 mt-1 animate-spin self-end", color)}
+          />
+        ) : (
+          <DurationText
+            className={cn("text-xl font-bold self-end", color)}
+            ticks={usage}
+          />
+        )}
       </div>
     </div>
   );
@@ -300,6 +315,7 @@ function AlertEventItem() {
     <div className="rounded-lg p-4 shadow-sm border text-right bg-card border-border">
       <div className="flex flex-col">
         <div className="text-sm font-medium">Triggered Alerts</div>
+
         {triggeredAlerts.length > 0 ? (
           <TooltipProvider>
             <Tooltip>

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -19,28 +19,25 @@ import {
   VizCardTitle,
 } from "@/components/viz/viz-card";
 import {
-  useAppDurations,
   useAppDurationsPerPeriod,
   useAppSessionUsages,
   useDefaultStreaks,
   useInteractionPeriods,
+  useStreakDurations,
   useSystemEvents,
   useTotalUsageFromPerPeriod,
 } from "@/hooks/use-repo";
 import {
   useIntervalControlsWithDefault,
   usePeriodInterval,
-  useToday,
 } from "@/hooks/use-time";
 import {
   hour24Formatter,
   monthDayFormatter,
   weekDayFormatter,
-  type Interval,
   type Period,
 } from "@/lib/time";
 import { cn } from "@/lib/utils";
-import _ from "lodash";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
@@ -51,19 +48,10 @@ export default function Home() {
     ...interval,
     period: "hour",
   });
+
+  const [focusStreakUsage, distractiveStreakUsage] =
+    useStreakDurations(streaks);
   const totalUsage = useTotalUsageFromPerPeriod(appDurationsPerPeriod);
-
-  const focusStreakUsage = useMemo(() => {
-    return _(streaks)
-      .filter((streak) => streak.isFocused)
-      .sumBy((streak) => streak.end - streak.start);
-  }, [streaks]);
-
-  const distractiveStreakUsage = useMemo(() => {
-    return _(streaks)
-      .filter((streak) => !streak.isFocused)
-      .sumBy((streak) => streak.end - streak.start);
-  }, [streaks]);
 
   return (
     <>
@@ -80,37 +68,25 @@ export default function Home() {
       </header>
       <div className="h-0 flex-auto overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]">
         <div className="flex flex-col gap-4 p-4">
-          <VizCard>
-            <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
-              <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
-                Overview
-              </VizCardTitle>
-            </VizCardHeader>
-
-            <VizCardContent className="aspect-video flex-1 mx-1 max-w-full max-h-80 flex flex-row">
-              <div className="flex-2/3">{/* TODO: Add a chart here */}</div>
-              <div className="p-4 flex flex-col gap-2 justify-between max-w-72 flex-1/3">
-                <UsageStatItem
-                  label="Focus Streaks"
-                  usage={focusStreakUsage}
-                  color="text-green-600 dark:text-green-400"
-                  cardColor="bg-green-500/10 border-green-500/20"
-                />
-                <UsageStatItem
-                  label="Distractive Streaks"
-                  usage={distractiveStreakUsage}
-                  color="text-red-600 dark:text-red-400"
-                  cardColor="bg-red-500/10 border-red-500/20"
-                />
-                <UsageStatItem
-                  label="Total Usage"
-                  usage={totalUsage}
-                  color="text-foreground"
-                  cardColor="bg-foreground/5 border-foreground/10"
-                />
-              </div>
-            </VizCardContent>
-          </VizCard>
+          <div className="grid auto-rows-min gap-4 grid-cols-3">
+            <UsageStatItem
+              label="Focus Streaks"
+              usage={focusStreakUsage}
+              color="text-green-600 dark:text-green-400"
+              cardColor="bg-green-500/10 border-green-500/20"
+            />
+            <UsageStatItem
+              label="Distractive Streaks"
+              usage={distractiveStreakUsage}
+              color="text-red-600 dark:text-red-400"
+              cardColor="bg-red-500/10 border-red-500/20"
+            />
+            <UsageStatItem
+              label="Total Usage"
+              usage={totalUsage}
+              color="text-foreground"
+            />
+          </div>
 
           <div className="grid auto-rows-min gap-4 grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
             <AppUsageBarChartCard
@@ -282,7 +258,7 @@ function UsageStatItem({
     <div
       className={cn(
         "rounded-lg p-4 shadow-sm border text-right",
-        cardColor || "bg-card border-border",
+        cardColor ?? "bg-card border-border",
       )}
     >
       <div className="flex flex-col">

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -1,3 +1,5 @@
+import AppIcon from "@/components/app/app-icon";
+import { ScoreCircle } from "@/components/tag/score";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { DurationText } from "@/components/time/duration-text";
 import {
@@ -8,6 +10,13 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Text } from "@/components/ui/text";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { NextButton, PrevButton, UsageCard } from "@/components/usage-card";
 import { Gantt } from "@/components/viz/gantt2";
 import { UsageChart } from "@/components/viz/usage-chart";
@@ -18,6 +27,7 @@ import {
   VizCardHeader,
   VizCardTitle,
 } from "@/components/viz/viz-card";
+import { useAlerts, useApp, useTag } from "@/hooks/use-refresh";
 import {
   useAppDurationsPerPeriod,
   useAppSessionUsages,
@@ -31,6 +41,7 @@ import {
   useIntervalControlsWithDefault,
   usePeriodInterval,
 } from "@/hooks/use-time";
+import type { Alert, TimeFrame } from "@/lib/entities";
 import {
   hour24Formatter,
   monthDayFormatter,
@@ -38,6 +49,8 @@ import {
   type Period,
 } from "@/lib/time";
 import { cn } from "@/lib/utils";
+import _ from "lodash";
+import { TagIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
@@ -68,7 +81,8 @@ export default function Home() {
       </header>
       <div className="h-0 flex-auto overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]">
         <div className="flex flex-col gap-4 p-4">
-          <div className="grid auto-rows-min gap-4 grid-cols-3">
+          <div className="grid auto-rows-min gap-4 grid-cols-4">
+            <AlertEventItem />
             <UsageStatItem
               label="Focus Streaks"
               usage={focusStreakUsage}
@@ -264,10 +278,114 @@ function UsageStatItem({
       <div className="flex flex-col">
         <div className={cn("text-sm font-medium", color)}>{label}</div>
         <DurationText
-          className={cn("text-xl font-bold", color)}
+          className={cn("text-xl font-bold self-end", color)}
           ticks={usage}
         />
       </div>
+    </div>
+  );
+}
+
+function AlertEventItem() {
+  const alerts = useAlerts();
+  const triggeredAlerts = useMemo(
+    () =>
+      _(alerts)
+        .filter((alert) => alert.events.today > 0)
+        .value(),
+    [alerts],
+  );
+
+  return (
+    <div className="rounded-lg p-4 shadow-sm border text-right bg-card border-border">
+      <div className="flex flex-col">
+        <div className="text-sm font-medium">Triggered Alerts</div>
+        {triggeredAlerts.length > 0 ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger className="self-end">
+                <div className="text-xl font-bold">
+                  {triggeredAlerts.length}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent className="gap-2">
+                {triggeredAlerts.map((alert) => (
+                  <MiniAlertItem key={alert.id} alert={alert} />
+                ))}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <div className="text-xl font-bold">None</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MiniAlertItem({ alert }: { alert: Alert }) {
+  return (
+    <div className="shadow-lg p-1 rounded-md bg-card border border-border flex flex-row gap-2 items-center">
+      <MiniTargetItem alert={alert} />
+      <div className="flex flex-row gap-1 items-center text-xs text-muted-foreground">
+        <DurationText ticks={alert.usageLimit} />
+        <div className="">{" / " + timeFrameToString(alert.timeFrame)}</div>
+      </div>
+      <MiniAlertTriggerAction alert={alert} />
+    </div>
+  );
+}
+
+function timeFrameToString(timeFrame: TimeFrame) {
+  return timeFrame === "daily"
+    ? "day"
+    : timeFrame === "weekly"
+      ? "week"
+      : "month";
+}
+
+function MiniTargetItem({ alert }: { alert: Alert }) {
+  const app = useApp(alert.target.tag === "app" ? alert.target.id : null);
+  const tag = useTag(alert.target.tag === "tag" ? alert.target.id : null);
+
+  return alert.target.tag === "app" && app ? (
+    <div className="flex gap-1 items-center">
+      <AppIcon className="h-4 w-4 shrink-0" appIcon={app.icon} />
+      <div>{app.name}</div>
+    </div>
+  ) : alert.target.tag === "tag" && tag ? (
+    <div className="flex gap-1 items-center">
+      <TagIcon className="h-4 w-4 shrink-0" style={{ color: tag.color }} />
+      <div>{tag.name}</div>
+      <ScoreCircle score={tag.score} />
+    </div>
+  ) : null;
+}
+
+function MiniAlertTriggerAction({ alert }: { alert: Alert }) {
+  return (
+    <div className="flex gap-1 items-center text-xs text-muted-foreground">
+      <span>
+        {alert.triggerAction.tag === "dim"
+          ? "Dim"
+          : alert.triggerAction.tag === "message"
+            ? "Message"
+            : "Kill"}
+      </span>
+      {alert.triggerAction.tag === "dim" && (
+        <div className="flex items-center">
+          <span>(</span>
+          <DurationText ticks={alert.triggerAction.duration} />
+          <span>)</span>
+        </div>
+      )}
+      {alert.triggerAction.tag === "message" && (
+        <div className="flex items-center">
+          <span>(</span>
+          <Text className="max-w-24">{alert.triggerAction.content}</Text>
+          <span>)</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -1,4 +1,5 @@
 import { DateRangePicker } from "@/components/time/date-range-picker";
+import { DurationText } from "@/components/time/duration-text";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -18,6 +19,7 @@ import {
   VizCardTitle,
 } from "@/components/viz/viz-card";
 import {
+  useAppDurations,
   useAppDurationsPerPeriod,
   useAppSessionUsages,
   useDefaultStreaks,
@@ -25,17 +27,44 @@ import {
   useSystemEvents,
   useTotalUsageFromPerPeriod,
 } from "@/hooks/use-repo";
-import { useIntervalControlsWithDefault } from "@/hooks/use-time";
+import {
+  useIntervalControlsWithDefault,
+  usePeriodInterval,
+  useToday,
+} from "@/hooks/use-time";
 import {
   hour24Formatter,
   monthDayFormatter,
   weekDayFormatter,
+  type Interval,
   type Period,
 } from "@/lib/time";
+import { cn } from "@/lib/utils";
+import _ from "lodash";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
 export default function Home() {
+  const interval = usePeriodInterval("day");
+  const { ret: streaks } = useDefaultStreaks(interval);
+  const { ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+    ...interval,
+    period: "hour",
+  });
+  const totalUsage = useTotalUsageFromPerPeriod(appDurationsPerPeriod);
+
+  const focusStreakUsage = useMemo(() => {
+    return _(streaks)
+      .filter((streak) => streak.isFocused)
+      .sumBy((streak) => streak.end - streak.start);
+  }, [streaks]);
+
+  const distractiveStreakUsage = useMemo(() => {
+    return _(streaks)
+      .filter((streak) => !streak.isFocused)
+      .sumBy((streak) => streak.end - streak.start);
+  }, [streaks]);
+
   return (
     <>
       <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
@@ -51,6 +80,38 @@ export default function Home() {
       </header>
       <div className="h-0 flex-auto overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]">
         <div className="flex flex-col gap-4 p-4">
+          <VizCard>
+            <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+              <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
+                Overview
+              </VizCardTitle>
+            </VizCardHeader>
+
+            <VizCardContent className="aspect-video flex-1 mx-1 max-w-full max-h-80 flex flex-row">
+              <div className="flex-2/3">{/* TODO: Add a chart here */}</div>
+              <div className="p-4 flex flex-col gap-2 justify-between max-w-72 flex-1/3">
+                <UsageStatItem
+                  label="Focus Streaks"
+                  usage={focusStreakUsage}
+                  color="text-green-600 dark:text-green-400"
+                  cardColor="bg-green-500/10 border-green-500/20"
+                />
+                <UsageStatItem
+                  label="Distractive Streaks"
+                  usage={distractiveStreakUsage}
+                  color="text-red-600 dark:text-red-400"
+                  cardColor="bg-red-500/10 border-red-500/20"
+                />
+                <UsageStatItem
+                  label="Total Usage"
+                  usage={totalUsage}
+                  color="text-foreground"
+                  cardColor="bg-foreground/5 border-foreground/10"
+                />
+              </div>
+            </VizCardContent>
+          </VizCard>
+
           <div className="grid auto-rows-min gap-4 grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
             <AppUsageBarChartCard
               timePeriod="day"
@@ -202,5 +263,35 @@ function SessionsCard() {
         />
       </VizCardContent>
     </VizCard>
+  );
+}
+
+// Component for displaying usage statistics
+function UsageStatItem({
+  label,
+  usage,
+  color,
+  cardColor,
+}: {
+  label: string;
+  usage: number;
+  color?: string;
+  cardColor?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg p-4 shadow-sm border text-right",
+        cardColor || "bg-card border-border",
+      )}
+    >
+      <div className="flex flex-col">
+        <div className={cn("text-sm font-medium", color)}>{label}</div>
+        <DurationText
+          className={cn("text-xl font-bold", color)}
+          ticks={usage}
+        />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
### TL;DR

Added a dashboard overview section to the home page with usage statistics and alert information, and extracted streak duration calculation logic into a reusable hook.

### What changed?

- Created a new `useStreakDurations` hook in `use-repo.tsx` to calculate focus and distractive streak durations
- Refactored the `DurationSummaries` component in `gantt2.tsx` to use the new hook
- Added a dashboard overview section to the home page with four cards:
  - Triggered Alerts - shows count of alerts triggered today with detailed tooltip
  - Focus Streaks - displays total focus streak duration
  - Distractive Streaks - displays total distractive streak duration
  - Total Usage - shows overall app usage time
- Implemented supporting components:
  - `UsageStatItem` - for displaying usage statistics
  - `AlertEventItem` - for displaying triggered alerts
  - `MiniAlertItem`, `MiniTargetItem`, and `MiniAlertTriggerAction` - for alert details in tooltips