### PR TITLE
Better Streak Durations

### DIFF
--- a/src/ui/app/components/alert/alert-form.tsx
+++ b/src/ui/app/components/alert/alert-form.tsx
@@ -247,9 +247,13 @@ function LimitStepContent({ form }: { form: UseFormReturn<FormValues> }) {
                 showIcon={false}
                 className="w-full text-muted-foreground"
                 {...field}
-                value={value === undefined ? null : ticksToDuration(value)}
+                value={
+                  value === undefined || value === null
+                    ? null
+                    : ticksToDuration(value)
+                }
                 onValueChange={(dur) =>
-                  onChange(dur === null ? undefined : durationToTicks(dur))
+                  onChange(!dur ? null : durationToTicks(dur))
                 }
               />
             </FormControl>
@@ -310,10 +314,10 @@ function ActionStepContent({ form }: { form: UseFormReturn<FormValues> }) {
                 <FormControl>
                   <DurationPicker
                     showIcon={false}
-                    className="w-full text-foreground"
+                    className="w-full text-muted-foreground"
                     {...field}
                     value={
-                      value?.duration === undefined
+                      value?.duration === undefined || value?.duration === null
                         ? null
                         : ticksToDuration(value.duration)
                     }

--- a/src/ui/app/components/time/duration-picker.tsx
+++ b/src/ui/app/components/time/duration-picker.tsx
@@ -19,6 +19,7 @@ interface DurationPickerProps {
   value: Duration | null;
   onValueChange: (dur: Duration | null) => void;
   showIcon?: boolean;
+  showClear?: boolean;
 }
 
 const QUICK_DURATIONS = [
@@ -30,57 +31,52 @@ const QUICK_DURATIONS = [
   { label: "7 days", duration: Duration.fromObject({ days: 7 }) },
 ];
 
+// Helper function to break down duration into components
+const breakdownDuration = (duration: Duration | null) => {
+  if (!duration) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+  }
+
+  return {
+    days: Math.floor(duration.as("days")),
+    hours: Math.floor(duration.as("hours") % 24),
+    minutes: Math.floor(duration.as("minutes") % 60),
+    seconds: Math.floor(duration.as("seconds") % 60),
+  };
+};
+
 export function DurationPicker({
   className,
   value: duration,
   onValueChange: setDuration,
   showIcon = true,
+  showClear = true,
 }: DurationPickerProps) {
   const [open, setOpen] = React.useState(false);
-  const [days, setDays] = React.useState(
-    Math.floor(duration?.as("days") ?? 0).toString(),
-  );
-  const [hours, setHours] = React.useState(
-    Math.floor((duration?.as("hours") ?? 0) % 24).toString(),
-  );
-  const [minutes, setMinutes] = React.useState(
-    Math.floor((duration?.as("minutes") ?? 0) % 60).toString(),
-  );
-  const [seconds, setSeconds] = React.useState(
-    Math.floor((duration?.as("seconds") ?? 0) % 60).toString(),
-  );
 
-  const handleDurationChange = (
-    days: string,
-    hours: string,
-    minutes: string,
-    seconds: string,
+  // Derive the breakdown from the current duration
+  const { days, hours, minutes, seconds } = breakdownDuration(duration);
+
+  const handleInputChange = (
+    field: "days" | "hours" | "minutes" | "seconds",
+    value: string,
   ) => {
-    const d = parseInt(days) || 0;
-    const h = parseInt(hours) || 0;
-    const m = parseInt(minutes) || 0;
-    const s = parseInt(seconds) || 0;
+    const numValue = parseInt(value) || 0;
 
-    if (d === 0 && h === 0 && m === 0 && s === 0) {
-      setDuration(null);
-    } else {
-      setDuration(
-        Duration.fromObject({
-          days: d,
-          hours: h,
-          minutes: m,
-          seconds: s,
-        }),
-      );
-    }
+    // Create new duration with updated field
+    const newValues = { days, hours, minutes, seconds, [field]: numValue };
+    const newDuration = Duration.fromObject(newValues);
+
+    setDuration(newDuration);
   };
 
   const handleQuickDuration = (quickDuration: Duration) => {
     setDuration(quickDuration);
-    setDays(Math.floor(quickDuration.as("days")).toString());
-    setHours(Math.floor(quickDuration.as("hours") % 24).toString());
-    setMinutes(Math.floor(quickDuration.as("minutes") % 60).toString());
-    setSeconds(Math.floor(quickDuration.as("seconds") % 60).toString());
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    setDuration(null);
     setOpen(false);
   };
 
@@ -127,11 +123,8 @@ export function DurationPicker({
               <Label className="text-xs">Days</Label>
               <Input
                 type="number"
-                value={days}
-                onChange={(e) => {
-                  setDays(e.target.value);
-                  handleDurationChange(e.target.value, hours, minutes, seconds);
-                }}
+                value={days.toString()}
+                onChange={(e) => handleInputChange("days", e.target.value)}
                 min={0}
                 className="h-8"
               />
@@ -140,11 +133,8 @@ export function DurationPicker({
               <Label className="text-xs">Hours</Label>
               <Input
                 type="number"
-                value={hours}
-                onChange={(e) => {
-                  setHours(e.target.value);
-                  handleDurationChange(days, e.target.value, minutes, seconds);
-                }}
+                value={hours.toString()}
+                onChange={(e) => handleInputChange("hours", e.target.value)}
                 min={0}
                 max={23}
                 className="h-8"
@@ -154,11 +144,8 @@ export function DurationPicker({
               <Label className="text-xs">Mins</Label>
               <Input
                 type="number"
-                value={minutes}
-                onChange={(e) => {
-                  setMinutes(e.target.value);
-                  handleDurationChange(days, hours, e.target.value, seconds);
-                }}
+                value={minutes.toString()}
+                onChange={(e) => handleInputChange("minutes", e.target.value)}
                 min={0}
                 max={59}
                 className="h-8"
@@ -168,11 +155,8 @@ export function DurationPicker({
               <Label className="text-xs">Secs</Label>
               <Input
                 type="number"
-                value={seconds}
-                onChange={(e) => {
-                  setSeconds(e.target.value);
-                  handleDurationChange(days, hours, minutes, e.target.value);
-                }}
+                value={seconds.toString()}
+                onChange={(e) => handleInputChange("seconds", e.target.value)}
                 min={0}
                 max={59}
                 className="h-8"
@@ -180,21 +164,16 @@ export function DurationPicker({
             </div>
           </div>
 
-          <Button
-            variant="destructive"
-            size="sm"
-            className="w-full h-8"
-            onClick={() => {
-              setDuration(null);
-              setDays("0");
-              setHours("0");
-              setMinutes("0");
-              setSeconds("0");
-              setOpen(false);
-            }}
-          >
-            Clear
-          </Button>
+          {showClear && (
+            <Button
+              variant="destructive"
+              size="sm"
+              className="w-full h-8"
+              onClick={handleClear}
+            >
+              Clear
+            </Button>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/ui/app/components/usage-card.tsx
+++ b/src/ui/app/components/usage-card.tsx
@@ -36,7 +36,7 @@ export function UsageCard({
 }: UsageCardProps) {
   return (
     <VizCard>
-      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4">
           <UsageCardTitle
             usage={usage}

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -525,6 +525,7 @@ export function Gantt({
     const common = {
       animation: false,
       grid: {
+        height: Math.min(innerHeight, seriesHeight),
         right: scrollbarWidth,
         containLabel: true,
       },
@@ -537,6 +538,8 @@ export function Gantt({
         show: false,
         type: "value",
         inverse: true,
+        min: 0,
+        max: seriesHeight,
         splitLine: { show: false },
         axisLabel: {
           show: false,

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -133,7 +133,7 @@ interface GanttProps {
   systemEvents?: SystemEvent[];
   systemEventsLoading?: boolean;
 
-  durationSummariesClassName?: ClassValue;
+  summary?: React.ReactNode;
   defaultExpanded?: Record<Ref<App>, boolean>;
   interval: Interval;
   interactionInfoBarHeight?: number;
@@ -154,7 +154,7 @@ export function Gantt({
   interactionPeriodsLoading,
   systemEvents,
   systemEventsLoading,
-  durationSummariesClassName,
+  summary,
   defaultExpanded,
   interval,
   infoGap = 300,
@@ -895,15 +895,7 @@ export function Gantt({
           className="absolute top-0 left-0 bottom-0"
           style={{ width: infoGap }}
         >
-          <div className="w-full h-full py-0 px-4">
-            <DurationSummaries
-              className={durationSummariesClassName}
-              usages={usagesPerAppSession}
-              usagesLoading={usagesLoading}
-              streaks={streaks}
-              streaksLoading={streaksLoading}
-            />
-          </div>
+          {summary}
         </div>
       </div>
 
@@ -1188,7 +1180,7 @@ function InteractionTooltip({
   );
 }
 
-function DurationSummaries({
+export function DurationSummaries({
   usages,
   usagesLoading,
 

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -525,7 +525,7 @@ export function Gantt({
     const common = {
       animation: false,
       grid: {
-        height: Math.min(innerHeight, seriesHeight),
+        height: innerHeight,
         right: scrollbarWidth,
         containLabel: true,
       },
@@ -539,7 +539,7 @@ export function Gantt({
         type: "value",
         inverse: true,
         min: 0,
-        max: seriesHeight,
+        max: innerHeight,
         splitLine: { show: false },
         axisLabel: {
           show: false,

--- a/src/ui/app/components/viz/viz-card.tsx
+++ b/src/ui/app/components/viz/viz-card.tsx
@@ -13,7 +13,9 @@ export function VizCard({
   className,
   ...props
 }: React.ComponentProps<typeof Card>) {
-  return <Card className={cn("gap-0 p-0", className)} {...props} />;
+  return (
+    <Card className={cn("gap-0 p-0 overflow-clip", className)} {...props} />
+  );
 }
 
 export function VizCardHeader({

--- a/src/ui/app/hooks/use-debounced-state.tsx
+++ b/src/ui/app/hooks/use-debounced-state.tsx
@@ -18,5 +18,5 @@ export function useDebouncedState<T>(
     [setStateInner, debouncedUpdate],
   );
 
-  return [state, setState] as const;
+  return [state, setState, setStateInner] as const;
 }

--- a/src/ui/app/lib/config.ts
+++ b/src/ui/app/lib/config.ts
@@ -67,8 +67,8 @@ interface Config extends ConfigReadonly {
   setDefaultDistractiveStreakSettings: (
     value: Partial<DistractiveStreakSettings>,
   ) => Promise<void>;
-  resetDefaultFocusStreakSettings: () => Promise<void>;
-  resetDefaultDistractiveStreakSettings: () => Promise<void>;
+  resetDefaultFocusStreakSettings: () => Promise<ConfigReadonly>;
+  resetDefaultDistractiveStreakSettings: () => Promise<ConfigReadonly>;
 }
 
 export const useConfig = create<Config>((set) => {
@@ -132,11 +132,15 @@ export const useConfig = create<Config>((set) => {
     },
     resetDefaultFocusStreakSettings: async () => {
       await resetDefaultFocusStreakSettings();
-      set(await readConfigReadonly());
+      const config = await readConfigReadonly();
+      set(config);
+      return config;
     },
     resetDefaultDistractiveStreakSettings: async () => {
       await resetDefaultDistractiveStreakSettings();
-      set(await readConfigReadonly());
+      const config = await readConfigReadonly();
+      set(config);
+      return config;
     },
   };
 });

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -423,7 +423,7 @@ function AppSessionsCard({ app }: { app: App }) {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
           Sessions
         </VizCardTitle>

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -21,13 +21,7 @@ import { NextButton, PrevButton, UsageCard } from "@/components/usage-card";
 import { Gantt } from "@/components/viz/gantt2";
 import Heatmap from "@/components/viz/heatmap";
 import { UsageChart } from "@/components/viz/usage-chart";
-import {
-  VizCard,
-  VizCardAction,
-  VizCardContent,
-  VizCardHeader,
-  VizCardTitle,
-} from "@/components/viz/viz-card";
+import { VizCard, VizCardContent } from "@/components/viz/viz-card";
 import { useClipboard } from "@/hooks/use-clipboard";
 import { useDebouncedState } from "@/hooks/use-debounced-state";
 import { useApp, useTag } from "@/hooks/use-refresh";
@@ -51,7 +45,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
 import _ from "lodash";
-import { Check, ChevronsUpDown, Copy } from "lucide-react";
+import { Check, ChevronsUpDown, Copy, Loader2 } from "lucide-react";
 import { DateTime } from "luxon";
 import { useCallback, useMemo } from "react";
 import { NavLink } from "react-router";
@@ -423,36 +417,33 @@ function AppSessionsCard({ app }: { app: App }) {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
-        <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
-          Sessions
-        </VizCardTitle>
-
-        <VizCardAction className="flex mt-3 mr-1.5">
-          {
-            <>
-              <PrevButton
-                canGoPrev={canGoPrev}
-                isLoading={isLoading}
-                goPrev={goPrev}
-              />
-              <DateRangePicker
-                className="min-w-32"
-                value={interval}
-                onChange={setInterval}
-              />
-              <NextButton
-                canGoNext={canGoNext}
-                isLoading={isLoading}
-                goNext={goNext}
-              />
-            </>
-          }
-        </VizCardAction>
-      </VizCardHeader>
-
       <VizCardContent>
         <Gantt
+          summary={
+            <div className="flex flex-col gap-2 my-2 mx-4">
+              <div className="text-lg font-bold flex items-center gap-2">
+                Sessions
+                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+              </div>
+              <div className="flex items-center -ml-2">
+                <PrevButton
+                  canGoPrev={canGoPrev}
+                  isLoading={isLoading}
+                  goPrev={goPrev}
+                />
+                <DateRangePicker
+                  className="min-w-32"
+                  value={interval}
+                  onChange={setInterval}
+                />
+                <NextButton
+                  canGoNext={canGoNext}
+                  isLoading={isLoading}
+                  goNext={goNext}
+                />
+              </div>
+            </div>
+          }
           usages={onlyAppSessionUsages}
           usagesLoading={usagesLoading}
           defaultExpanded={{ [app.id]: true }}

--- a/src/ui/app/routes/experiments.tsx
+++ b/src/ui/app/routes/experiments.tsx
@@ -5,11 +5,16 @@ import {
   BreadcrumbPage,
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { refresh } from "@/lib/state";
-import { Setting } from "@/routes/settings";
+import {
+  Setting,
+  SettingContent,
+  SettingHeader,
+  SettingItem,
+  SettingTitle,
+} from "@/routes/settings";
 import { invoke } from "@tauri-apps/api/core";
 import { LoaderIcon } from "lucide-react";
 import { useTransition, type ComponentProps } from "react";
@@ -64,12 +69,12 @@ export default function Experiments() {
       </header>
       <div className="h-0 flex-auto overflow-auto [scrollbar-gutter:stable]">
         <div className="flex flex-col gap-4 p-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Database</CardTitle>
-            </CardHeader>
-            <CardContent className="gap-2 flex flex-col">
-              <Setting
+          <Setting>
+            <SettingHeader>
+              <SettingTitle>Database</SettingTitle>
+            </SettingHeader>
+            <SettingContent className="gap-2 flex flex-col">
+              <SettingItem
                 title={
                   <>
                     Copy <p className="font-mono inline">seed.db</p>
@@ -83,7 +88,7 @@ export default function Experiments() {
                 }
               />
 
-              <Setting
+              <SettingItem
                 title={<>Copy install db</>}
                 description="Replace the current database with the installed database"
                 action={
@@ -93,7 +98,7 @@ export default function Experiments() {
                 }
               />
 
-              <Setting
+              <SettingItem
                 title="Update Last Usage to Now"
                 description="Update last usage in database to Now"
                 action={
@@ -102,15 +107,15 @@ export default function Experiments() {
                   </AsyncButton>
                 }
               />
-            </CardContent>
-          </Card>
+            </SettingContent>
+          </Setting>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Refresh</CardTitle>
-            </CardHeader>
-            <CardContent className="gap-2 flex flex-col">
-              <Setting
+          <Setting>
+            <SettingHeader>
+              <SettingTitle>Refresh</SettingTitle>
+            </SettingHeader>
+            <SettingContent className="gap-2 flex flex-col">
+              <SettingItem
                 title="Refresh Now"
                 description="Refresh all app data"
                 action={
@@ -119,8 +124,8 @@ export default function Experiments() {
                   </AsyncButton>
                 }
               />
-            </CardContent>
-          </Card>
+            </SettingContent>
+          </Setting>
         </div>
       </div>
     </>

--- a/src/ui/app/routes/history.tsx
+++ b/src/ui/app/routes/history.tsx
@@ -247,7 +247,6 @@ function SessionHistory() {
         systemEvents={systemEvents}
         systemEventsLoading={systemEventsLoading}
         interval={interval}
-        durationSummariesClassName="mt-4"
       />
     </div>
   );

--- a/src/ui/app/routes/history.tsx
+++ b/src/ui/app/routes/history.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import { Gantt } from "@/components/viz/gantt2";
+import { DurationSummaries, Gantt } from "@/components/viz/gantt2";
 import { GroupByPicker } from "@/components/viz/groupby-picker";
 import { UsageChart, type GroupBy } from "@/components/viz/usage-chart";
 import { VerticalLegend } from "@/components/viz/vertical-legend";
@@ -235,19 +235,49 @@ function SessionHistory() {
   const { ret: streaks, isLoading: streaksLoading } =
     useDefaultStreaks(interval);
 
+  const isLoading =
+    usagesLoading ||
+    interactionPeriodsLoading ||
+    systemEventsLoading ||
+    streaksLoading;
+
   return (
-    <div className="sticky rounded-lg bg-card shadow-xs border border-border overflow-clip">
-      <Gantt
-        usages={usages}
-        usagesLoading={usagesLoading}
-        streaks={streaks}
-        streaksLoading={streaksLoading}
-        interactionPeriods={interactions}
-        interactionPeriodsLoading={interactionPeriodsLoading}
-        systemEvents={systemEvents}
-        systemEventsLoading={systemEventsLoading}
-        interval={interval}
-      />
+    <div className="flex flex-col flex-1 gap-6">
+      <div className="flex flex-wrap gap-2 font-bold items-center rounded-lg bg-card border border-border p-4 shadow-xs">
+        <FormItem>
+          <Label className="font-medium text-muted-foreground place-self-start">
+            Streaks
+          </Label>
+          <DurationSummaries
+            usages={usages}
+            usagesLoading={usagesLoading}
+            streaks={streaks}
+            streaksLoading={streaksLoading}
+          />
+        </FormItem>
+      </div>
+
+      <div className="sticky rounded-lg bg-card shadow-xs border border-border overflow-clip">
+        <Gantt
+          summary={
+            <div className="flex flex-col gap-2 my-2 mx-4">
+              <div className="text-lg font-bold flex items-center gap-2">
+                Sessions
+                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+              </div>
+            </div>
+          }
+          usages={usages}
+          usagesLoading={usagesLoading}
+          streaks={streaks}
+          streaksLoading={streaksLoading}
+          interactionPeriods={interactions}
+          interactionPeriodsLoading={interactionPeriodsLoading}
+          systemEvents={systemEvents}
+          systemEventsLoading={systemEventsLoading}
+          interval={interval}
+        />
+      </div>
     </div>
   );
 }

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -20,13 +20,7 @@ import {
 import { NextButton, PrevButton, UsageCard } from "@/components/usage-card";
 import { Gantt } from "@/components/viz/gantt2";
 import { UsageChart } from "@/components/viz/usage-chart";
-import {
-  VizCard,
-  VizCardAction,
-  VizCardContent,
-  VizCardHeader,
-  VizCardTitle,
-} from "@/components/viz/viz-card";
+import { VizCard, VizCardContent } from "@/components/viz/viz-card";
 import { useAlerts, useApp, useTag } from "@/hooks/use-refresh";
 import {
   useAppDurationsPerPeriod,
@@ -218,36 +212,33 @@ function SessionsCard() {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
-        <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
-          Sessions
-        </VizCardTitle>
-
-        <VizCardAction className="flex mt-3 mr-1.5">
-          {
-            <>
-              <PrevButton
-                canGoPrev={canGoPrev}
-                isLoading={isLoading}
-                goPrev={goPrev}
-              />
-              <DateRangePicker
-                className="min-w-32"
-                value={interval}
-                onChange={setInterval}
-              />
-              <NextButton
-                canGoNext={canGoNext}
-                isLoading={isLoading}
-                goNext={goNext}
-              />
-            </>
-          }
-        </VizCardAction>
-      </VizCardHeader>
-
       <VizCardContent>
         <Gantt
+          summary={
+            <div className="flex flex-col gap-2 my-2 mx-4">
+              <div className="text-lg font-bold flex items-center gap-2">
+                Sessions
+                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+              </div>
+              <div className="flex items-center -ml-2">
+                <PrevButton
+                  canGoPrev={canGoPrev}
+                  isLoading={isLoading}
+                  goPrev={goPrev}
+                />
+                <DateRangePicker
+                  className="min-w-32"
+                  value={interval}
+                  onChange={setInterval}
+                />
+                <NextButton
+                  canGoNext={canGoNext}
+                  isLoading={isLoading}
+                  goNext={goNext}
+                />
+              </div>
+            </div>
+          }
           usages={usages}
           usagesLoading={usagesLoading}
           streaks={streaks}

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -218,7 +218,7 @@ function SessionsCard() {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
           Sessions
         </VizCardTitle>

--- a/src/ui/app/routes/settings.tsx
+++ b/src/ui/app/routes/settings.tsx
@@ -140,6 +140,7 @@ function FocusStreakSetting() {
           description="The minimum duration of contiguous usages from focus apps to be considered a focus streak."
           action={
             <DurationPicker
+              showClear={false}
               className="w-40"
               value={ticksToDuration(
                 defaultFocusStreakSettings.minFocusUsageDur,
@@ -159,6 +160,7 @@ function FocusStreakSetting() {
           description="The maximum gap between focus streaks before adjacent focus streaks are combined into a longer streak."
           action={
             <DurationPicker
+              showClear={false}
               className="w-40"
               value={ticksToDuration(defaultFocusStreakSettings.maxFocusGap)}
               onValueChange={(v) =>
@@ -235,6 +237,7 @@ function DistractiveStreakSetting() {
           description="The minimum duration of contiguous usages from distractive apps to be considered a distractive streak."
           action={
             <DurationPicker
+              showClear={false}
               className="w-40"
               value={ticksToDuration(
                 defaultDistractiveStreakSettings.minDistractiveUsageDur,
@@ -254,6 +257,7 @@ function DistractiveStreakSetting() {
           description="The maximum gap between distractive streaks before adjacent distractive streaks are combined into a longer streak."
           action={
             <DurationPicker
+              showClear={false}
               className="w-40"
               value={ticksToDuration(
                 defaultDistractiveStreakSettings.maxDistractiveGap,

--- a/src/ui/app/routes/settings.tsx
+++ b/src/ui/app/routes/settings.tsx
@@ -102,14 +102,10 @@ function FocusStreakSetting() {
     );
 
   const reset = useCallback(async () => {
-    await resetDefaultFocusStreakSettings();
+    const config = await resetDefaultFocusStreakSettings();
     // Reset the min focus score to the default value
-    setMinFocusScoreInner(defaultFocusStreakSettings.minFocusScore);
-  }, [
-    resetDefaultFocusStreakSettings,
-    setMinFocusScoreInner,
-    defaultFocusStreakSettings,
-  ]);
+    setMinFocusScoreInner(config.defaultFocusStreakSettings.minFocusScore);
+  }, [resetDefaultFocusStreakSettings, setMinFocusScoreInner]);
 
   return (
     <Setting>
@@ -199,16 +195,12 @@ function DistractiveStreakSetting() {
   );
 
   const reset = useCallback(async () => {
-    await resetDefaultDistractiveStreakSettings();
+    const config = await resetDefaultDistractiveStreakSettings();
     // Reset the max distractive score to the default value
     setMaxDistractiveScoreInner(
-      defaultDistractiveStreakSettings.maxDistractiveScore,
+      config.defaultDistractiveStreakSettings.maxDistractiveScore,
     );
-  }, [
-    resetDefaultDistractiveStreakSettings,
-    setMaxDistractiveScoreInner,
-    defaultDistractiveStreakSettings,
-  ]);
+  }, [resetDefaultDistractiveStreakSettings, setMaxDistractiveScoreInner]);
 
   return (
     <Setting>

--- a/src/ui/app/routes/settings.tsx
+++ b/src/ui/app/routes/settings.tsx
@@ -23,33 +23,9 @@ import { useDebouncedState } from "@/hooks/use-debounced-state";
 import { useConfig } from "@/lib/config";
 import type { Score } from "@/lib/entities";
 import { durationToTicks, ticksToDuration } from "@/lib/time";
+import { cn } from "@/lib/utils";
 import { RefreshCcwIcon } from "lucide-react";
-import { useCallback, type ReactNode } from "react";
-
-export function Setting({
-  title,
-  description,
-  action,
-}: {
-  title: ReactNode;
-  description: ReactNode;
-  action: ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-2">
-      <div>
-        <h3 className="text-lg font-semibold text-card-foreground/80">
-          {title}
-        </h3>
-        <p className="text-sm text-card-foreground/50">{description}</p>
-      </div>
-
-      <div className="flex-1"></div>
-
-      {action}
-    </div>
-  );
-}
+import { type ReactNode } from "react";
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
@@ -63,11 +39,6 @@ export default function Settings() {
     resetDefaultFocusStreakSettings,
     resetDefaultDistractiveStreakSettings,
   } = useConfig();
-
-  const resetStreakSettings = useCallback(async () => {
-    await resetDefaultFocusStreakSettings();
-    await resetDefaultDistractiveStreakSettings();
-  }, [resetDefaultFocusStreakSettings, resetDefaultDistractiveStreakSettings]);
 
   const [minFocusScore, setMinFocusScore] = useDebouncedState(
     defaultFocusStreakSettings.minFocusScore,
@@ -99,24 +70,24 @@ export default function Settings() {
       </header>
       <div className="h-0 flex-auto overflow-auto [scrollbar-gutter:stable]">
         <div className="flex flex-col gap-4 p-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Appearance</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Setting
+          <Setting>
+            <SettingHeader>
+              <SettingTitle>Appearance</SettingTitle>
+            </SettingHeader>
+            <SettingContent>
+              <SettingItem
                 title="Theme"
                 description="Choose a theme for the app"
                 action={<ThemeSwitch value={theme} onValueChange={setTheme} />}
               />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardTitle>Privacy</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Setting
+            </SettingContent>
+          </Setting>
+          <Setting>
+            <SettingHeader>
+              <SettingTitle>Privacy</SettingTitle>
+            </SettingHeader>
+            <SettingContent>
+              <SettingItem
                 title="Track Incognito"
                 description="Track incognito windows (title, url) in browsers. If disabled, incognito windows will be tracked as '<Incognito>'."
                 action={
@@ -126,28 +97,30 @@ export default function Settings() {
                   />
                 }
               />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardTitle>
+            </SettingContent>
+          </Setting>
+          <Setting>
+            <SettingHeader>
+              <SettingTitle>
                 <div className="flex items-center">
-                  <div>Streaks</div>
+                  <div>Focus Streaks</div>
                   <Button
                     variant="outline"
-                    onClick={resetStreakSettings}
+                    onClick={resetDefaultFocusStreakSettings}
                     className="ml-auto"
                   >
                     <RefreshCcwIcon className="w-4 h-4 text-muted-foreground" />
                     <div className="text-muted-foreground">Reset</div>
                   </Button>
                 </div>
-              </CardTitle>
-              <CardDescription>Settings for streak detection.</CardDescription>
-            </CardHeader>
-            <CardContent className="gap-4 flex flex-col">
-              <Setting
-                title="Focus: Minimum Score"
+              </SettingTitle>
+              <SettingDescription>
+                Settings for focus streak detection.
+              </SettingDescription>
+            </SettingHeader>
+            <SettingContent className="gap-4 flex flex-col">
+              <SettingItem
+                title="Minimum Score"
                 description="The minimum score of an app's tag for the app to be considered a focus app."
                 action={
                   <ScoreSettingAction
@@ -157,8 +130,8 @@ export default function Settings() {
                 }
               />
 
-              <Setting
-                title="Focus: Minimum Usage Duration"
+              <SettingItem
+                title="Minimum Usage Duration"
                 description="The minimum duration of contiguous usages from focus apps to be considered a focus streak."
                 action={
                   <DurationPicker
@@ -176,8 +149,8 @@ export default function Settings() {
                 }
               />
 
-              <Setting
-                title="Focus: Maximum Gap"
+              <SettingItem
+                title="Maximum Gap"
                 description="The maximum gap between focus streaks before adjacent focus streaks are combined into a longer streak."
                 action={
                   <DurationPicker
@@ -194,9 +167,31 @@ export default function Settings() {
                   />
                 }
               />
+            </SettingContent>
+          </Setting>
 
-              <Setting
-                title="Distractive: Maximum Score"
+          <Setting>
+            <SettingHeader>
+              <SettingTitle>
+                <div className="flex items-center">
+                  <div>Distractive Streaks</div>
+                  <Button
+                    variant="outline"
+                    onClick={resetDefaultDistractiveStreakSettings}
+                    className="ml-auto"
+                  >
+                    <RefreshCcwIcon className="w-4 h-4 text-muted-foreground" />
+                    <div className="text-muted-foreground">Reset</div>
+                  </Button>
+                </div>
+              </SettingTitle>
+              <SettingDescription>
+                Settings for distractive streak detection.
+              </SettingDescription>
+            </SettingHeader>
+            <SettingContent className="gap-4 flex flex-col">
+              <SettingItem
+                title="Maximum Score"
                 description="The maximum score of an app's tag for the app to be considered a distractive app."
                 action={
                   <ScoreSettingAction
@@ -206,8 +201,8 @@ export default function Settings() {
                 }
               />
 
-              <Setting
-                title="Distractive: Minimum Usage Duration"
+              <SettingItem
+                title="Minimum Usage Duration"
                 description="The minimum duration of contiguous usages from distractive apps to be considered a distractive streak."
                 action={
                   <DurationPicker
@@ -225,8 +220,8 @@ export default function Settings() {
                 }
               />
 
-              <Setting
-                title="Distractive: Maximum Gap"
+              <SettingItem
+                title="Maximum Gap"
                 description="The maximum gap between distractive streaks before adjacent distractive streaks are combined into a longer streak."
                 action={
                   <DurationPicker
@@ -243,8 +238,8 @@ export default function Settings() {
                   />
                 }
               />
-            </CardContent>
-          </Card>
+            </SettingContent>
+          </Setting>
         </div>
       </div>
     </>
@@ -281,6 +276,59 @@ function ScoreSettingAction({
         value={score}
         onValueChange={onScoreChange}
       />
+    </div>
+  );
+}
+
+export function Setting(props: React.ComponentProps<typeof Card>) {
+  return <Card {...props} />;
+}
+
+export function SettingHeader({
+  className,
+  ...props
+}: React.ComponentProps<typeof CardHeader>) {
+  return <CardHeader className={cn("gap-0", className)} {...props} />;
+}
+
+export function SettingDescription(
+  props: React.ComponentProps<typeof CardDescription>,
+) {
+  return <CardDescription {...props} />;
+}
+
+export function SettingContent(
+  props: React.ComponentProps<typeof CardContent>,
+) {
+  return <CardContent {...props} />;
+}
+
+export function SettingTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof CardTitle>) {
+  return <CardTitle className={cn("text-lg", className)} {...props} />;
+}
+
+export function SettingItem({
+  title,
+  description,
+  action,
+}: {
+  title: ReactNode;
+  description: ReactNode;
+  action: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <div>
+        <h3 className="font-semibold text-card-foreground/80">{title}</h3>
+        <p className="text-card-foreground/50">{description}</p>
+      </div>
+
+      <div className="flex-1"></div>
+
+      {action}
     </div>
   );
 }

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -30,13 +30,7 @@ import { NextButton, PrevButton, UsageCard } from "@/components/usage-card";
 import { Gantt } from "@/components/viz/gantt2";
 import Heatmap from "@/components/viz/heatmap";
 import { UsageChart } from "@/components/viz/usage-chart";
-import {
-  VizCard,
-  VizCardAction,
-  VizCardContent,
-  VizCardHeader,
-  VizCardTitle,
-} from "@/components/viz/viz-card";
+import { VizCard, VizCardContent } from "@/components/viz/viz-card";
 import { useDebouncedState } from "@/hooks/use-debounced-state";
 import { useAlerts, useTag } from "@/hooks/use-refresh";
 import {
@@ -58,7 +52,7 @@ import {
   type Period,
 } from "@/lib/time";
 import _ from "lodash";
-import { TagIcon, TrashIcon } from "lucide-react";
+import { Loader2, TagIcon, TrashIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import { useCallback, useMemo } from "react";
 import { NavLink, useNavigate } from "react-router";
@@ -388,36 +382,33 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
-        <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
-          Sessions
-        </VizCardTitle>
-
-        <VizCardAction className="flex mt-3 mr-1.5">
-          {
-            <>
-              <PrevButton
-                canGoPrev={canGoPrev}
-                isLoading={isLoading}
-                goPrev={goPrev}
-              />
-              <DateRangePicker
-                className="min-w-32"
-                value={interval}
-                onChange={setInterval}
-              />
-              <NextButton
-                canGoNext={canGoNext}
-                isLoading={isLoading}
-                goNext={goNext}
-              />
-            </>
-          }
-        </VizCardAction>
-      </VizCardHeader>
-
       <VizCardContent>
         <Gantt
+          summary={
+            <div className="flex flex-col gap-2 my-2 mx-4">
+              <div className="text-lg font-bold flex items-center gap-2">
+                Sessions
+                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+              </div>
+              <div className="flex items-center -ml-2">
+                <PrevButton
+                  canGoPrev={canGoPrev}
+                  isLoading={isLoading}
+                  goPrev={goPrev}
+                />
+                <DateRangePicker
+                  className="min-w-32"
+                  value={interval}
+                  onChange={setInterval}
+                />
+                <NextButton
+                  canGoNext={canGoNext}
+                  isLoading={isLoading}
+                  goNext={goNext}
+                />
+              </div>
+            </div>
+          }
           usages={tagAppSessionUsages}
           usagesLoading={usagesLoading}
           interval={interval}

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -388,7 +388,7 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
 
   return (
     <VizCard>
-      <VizCardHeader className="pb-1 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
+      <VizCardHeader className="pb-4 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto]">
         <VizCardTitle className="pl-4 pt-4 text-lg font-bold">
           Sessions
         </VizCardTitle>


### PR DESCRIPTION
### TL;DR

Redesigned the UI for sessions visualization and improved the settings page structure.

### What changed?

- Refactored the Gantt component to use a more flexible `summary` prop instead of `durationSummariesClassName`
- Moved session headers and controls into the Gantt summary section for a more integrated look
- Restructured the settings page by creating dedicated components for focus and distractive streak settings
- Added a third return value to `useDebouncedState` hook to allow direct state updates
- Improved the history page layout by separating streaks summary from the sessions timeline
- Created reusable setting components (`Setting`, `SettingHeader`, `SettingTitle`, etc.) for consistent UI
- Updated padding in the UsageCard component for better spacing
- Applied the new setting components to the experiments page