### PR TITLE
Database Management Tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2420,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror 1.0.61",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2823,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -2872,6 +2925,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nix"
@@ -4553,6 +4615,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5543,7 +5626,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -5680,11 +5763,14 @@ name = "tools"
 version = "0.5.0"
 dependencies = [
  "clap",
+ "data",
  "dialoguer",
  "engine",
+ "inquire",
  "platform",
  "serde",
  "serde_json",
+ "sqlx",
  "util",
  "windows 0.59.0",
  "windows-core 0.59.0",

--- a/dev/tools/Cargo.toml
+++ b/dev/tools/Cargo.toml
@@ -10,12 +10,15 @@ workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
+data = { path = "../../src/data" }
 util = { path = "../../src/util" }
 platform = { path = "../../src/platform" }
 engine = { path = "../../src/engine" }
 dialoguer = "0.11.0"
+inquire = "0.6"
 serde = "1.0.219"
 serde_json = "1.0.140"
+sqlx = { version = "0.8", features = [ "runtime-tokio", "sqlite", "derive", "macros" ] }
 
 [dependencies.windows-core]
 version = "0.59"
@@ -46,4 +49,8 @@ path = "src/bin/kill.rs"
 
 [[bin]]
 name = "tab_switch"
-path = "src/bin/tab_switch.rs" 
+path = "src/bin/tab_switch.rs"
+
+[[bin]]
+name = "merge_apps"
+path = "src/bin/merge_apps.rs" 

--- a/dev/tools/src/bin/copy_db.rs
+++ b/dev/tools/src/bin/copy_db.rs
@@ -1,0 +1,201 @@
+//! Copy database from source to target
+
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use clap::Parser;
+use util::error::{Context, ContextCompat, Result, bail};
+use util::tracing::{debug, warn};
+use util::{Target, config, future as tokio};
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Database source ('seed', 'install', or custom path)
+    #[arg(short, long)]
+    source: String,
+    /// Database target ('seed', 'install', or custom path)
+    #[arg(short, long)]
+    target: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// Source of the database
+pub enum Source {
+    // /// Seed database
+    // Seed,
+    /// Install location
+    Install,
+    /// Current directory
+    Current,
+    /// Custom path
+    Custom(String),
+}
+
+impl FromStr for Source {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            // "seed" => Ok(Source::Seed),
+            "install" => Ok(Source::Install),
+            "." => Ok(Source::Current),
+            _ => Ok(Source::Custom(s.to_string())),
+        }
+    }
+}
+
+impl Source {
+    /// Convert the source to a PathBuf
+    pub fn to_path(&self) -> Result<PathBuf> {
+        let path = match self {
+            // Source::Seed => Ok(PathBuf::from("./dev/seed.db")),
+            Source::Install => util::config::data_local_dir()
+                .context("data local dir")?
+                .join("me.enigmatrix.cobalt"),
+            Source::Current => PathBuf::from("."),
+            Source::Custom(path) => PathBuf::from(path),
+        };
+        if !path.is_dir() {
+            bail!("{} is not a directory", path.display());
+        }
+        Ok(path)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    util::set_target(Target::Tool {
+        name: "copy_db".to_string(),
+    });
+    let config = config::get_config()?;
+    util::setup(&config)?;
+    platform::setup()?;
+
+    let args = Args::parse();
+    let source: Source = args.source.parse().context("failed to parse source")?;
+    let target: Source = args.target.parse().context("failed to parse target")?;
+
+    let source_path = source
+        .to_path()
+        .context("failed to resolve source path")?
+        .canonicalize()?;
+    let target_path = target
+        .to_path()
+        .context("failed to resolve target path")?
+        .canonicalize()?;
+
+    if source_path == target_path {
+        bail!("source and target are the same");
+    }
+
+    debug!(
+        "Copying from {} to {}",
+        source_path.display(),
+        target_path.display()
+    );
+
+    remove_icon_files(&target_path)?;
+    remove_db_files(&target_path)?;
+
+    check_and_copy_dir(&source_path, &target_path, "icons")?;
+    check_and_copy_file(&source_path, &target_path, "main.db")?;
+    check_and_copy_file(&source_path, &target_path, "main.db-journal")?;
+    check_and_copy_file(&source_path, &target_path, "main.db-shm")?;
+    check_and_copy_file(&source_path, &target_path, "main.db-wal")?;
+
+    Ok(())
+}
+
+fn check_and_remove_file(source_dir: &Path, file: &str) -> util::error::Result<()> {
+    let file = source_dir.join(file);
+    if std::fs::metadata(&file)
+        .map(|f| f.is_file())
+        .unwrap_or(false)
+    {
+        std::fs::remove_file(&file).context(format!("remove {:?}", &file))?;
+    } else {
+        warn!("file {:?} not found", file);
+    }
+    Ok(())
+}
+
+fn check_and_remove_dir(source_dir: &Path, dir: &str) -> util::error::Result<()> {
+    let dir = source_dir.join(dir);
+    if std::fs::metadata(&dir).map(|f| f.is_dir()).unwrap_or(false) {
+        std::fs::remove_dir_all(&dir).context(format!("remove {:?}", &dir))?;
+    } else {
+        warn!("dir {:?} not found", dir);
+    }
+    Ok(())
+}
+
+fn check_and_copy_file(
+    source_dir: &Path,
+    target_dir: &Path,
+    file: &str,
+) -> util::error::Result<()> {
+    let from_file = source_dir.join(file);
+    let to_file = target_dir.join(file);
+    if std::fs::metadata(&from_file)
+        .map(|f| f.is_file())
+        .unwrap_or(false)
+    {
+        std::fs::copy(from_file, to_file).context(format!("copy {file}"))?;
+    } else {
+        warn!("file {file} not found");
+    }
+    Ok(())
+}
+
+fn check_and_copy_dir(source_dir: &Path, target_dir: &Path, file: &str) -> util::error::Result<()> {
+    let from_dir = source_dir.join(file);
+    let to_dir = target_dir.join(file);
+    if std::fs::metadata(&from_dir)
+        .map(|f| f.is_dir())
+        .unwrap_or(false)
+    {
+        // Create destination directory if it doesn't exist
+        if !to_dir.exists() {
+            std::fs::create_dir_all(&to_dir).context(format!("create dir {}", to_dir.display()))?;
+        }
+
+        // Copy all files from source directory to destination directory
+        for entry in
+            std::fs::read_dir(&from_dir).context(format!("read dir {}", from_dir.display()))?
+        {
+            let entry = entry.context("read dir entry")?;
+            let entry_path = entry.path();
+            let file_name = entry_path.file_name().unwrap();
+            let dest_path = to_dir.join(file_name);
+
+            if entry_path.is_file() {
+                std::fs::copy(&entry_path, &dest_path).context(format!(
+                    "copy file {} to {}",
+                    entry_path.display(),
+                    dest_path.display()
+                ))?;
+            } else if entry_path.is_dir() {
+                // Recursively copy subdirectories
+                check_and_copy_dir(&from_dir, &to_dir, file_name.to_str().unwrap())?;
+            }
+        }
+    } else {
+        warn!("dir {} not found", file);
+    }
+    Ok(())
+}
+
+fn remove_db_files(source_dir: &Path) -> util::error::Result<()> {
+    // remove previous files (especially the non-main.db files)
+    check_and_remove_file(source_dir, "main.db")?;
+    check_and_remove_file(source_dir, "main.db-journal")?;
+    check_and_remove_file(source_dir, "main.db-shm")?;
+    check_and_remove_file(source_dir, "main.db-wal")?;
+    Ok(())
+}
+
+fn remove_icon_files(source_dir: &Path) -> util::error::Result<()> {
+    check_and_remove_dir(source_dir, "icons")?;
+    Ok(())
+}

--- a/dev/tools/src/bin/copy_db.rs
+++ b/dev/tools/src/bin/copy_db.rs
@@ -1,12 +1,9 @@
 //! Copy database from source to target
 
-use std::path::Path;
-
 use clap::Parser;
 use dialoguer::Confirm;
 use tools::db::Source;
 use util::error::{Context, Result, bail};
-use util::tracing::warn;
 use util::{Target, config, future as tokio};
 
 #[derive(Parser, Debug, Clone)]
@@ -54,107 +51,10 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    remove_icon_files(&target_path)?;
-    remove_db_files(&target_path)?;
+    util::fs::remove_icon_files(&target_path)?;
+    util::fs::remove_db_files(&target_path)?;
+    util::fs::copy_icon_files(&source_path, &target_path)?;
+    util::fs::copy_db_files(&source_path, &target_path)?;
 
-    check_and_copy_dir(&source_path, &target_path, "icons")?;
-    check_and_copy_file(&source_path, &target_path, "main.db")?;
-    check_and_copy_file(&source_path, &target_path, "main.db-journal")?;
-    check_and_copy_file(&source_path, &target_path, "main.db-shm")?;
-    check_and_copy_file(&source_path, &target_path, "main.db-wal")?;
-
-    Ok(())
-}
-
-fn check_and_remove_file(source_dir: &Path, file: &str) -> util::error::Result<()> {
-    let file = source_dir.join(file);
-    if std::fs::metadata(&file)
-        .map(|f| f.is_file())
-        .unwrap_or(false)
-    {
-        std::fs::remove_file(&file).context(format!("remove {:?}", &file))?;
-    } else {
-        warn!("file {:?} not found", file);
-    }
-    Ok(())
-}
-
-fn check_and_remove_dir(source_dir: &Path, dir: &str) -> util::error::Result<()> {
-    let dir = source_dir.join(dir);
-    if std::fs::metadata(&dir).map(|f| f.is_dir()).unwrap_or(false) {
-        std::fs::remove_dir_all(&dir).context(format!("remove {:?}", &dir))?;
-    } else {
-        warn!("dir {:?} not found", dir);
-    }
-    Ok(())
-}
-
-fn check_and_copy_file(
-    source_dir: &Path,
-    target_dir: &Path,
-    file: &str,
-) -> util::error::Result<()> {
-    let from_file = source_dir.join(file);
-    let to_file = target_dir.join(file);
-    if std::fs::metadata(&from_file)
-        .map(|f| f.is_file())
-        .unwrap_or(false)
-    {
-        std::fs::copy(from_file, to_file).context(format!("copy {file}"))?;
-    } else {
-        warn!("file {file} not found");
-    }
-    Ok(())
-}
-
-fn check_and_copy_dir(source_dir: &Path, target_dir: &Path, file: &str) -> util::error::Result<()> {
-    let from_dir = source_dir.join(file);
-    let to_dir = target_dir.join(file);
-    if std::fs::metadata(&from_dir)
-        .map(|f| f.is_dir())
-        .unwrap_or(false)
-    {
-        // Create destination directory if it doesn't exist
-        if !to_dir.exists() {
-            std::fs::create_dir_all(&to_dir).context(format!("create dir {}", to_dir.display()))?;
-        }
-
-        // Copy all files from source directory to destination directory
-        for entry in
-            std::fs::read_dir(&from_dir).context(format!("read dir {}", from_dir.display()))?
-        {
-            let entry = entry.context("read dir entry")?;
-            let entry_path = entry.path();
-            let file_name = entry_path.file_name().unwrap();
-            let dest_path = to_dir.join(file_name);
-
-            if entry_path.is_file() {
-                std::fs::copy(&entry_path, &dest_path).context(format!(
-                    "copy file {} to {}",
-                    entry_path.display(),
-                    dest_path.display()
-                ))?;
-            } else if entry_path.is_dir() {
-                // Recursively copy subdirectories
-                check_and_copy_dir(&from_dir, &to_dir, file_name.to_str().unwrap())?;
-            }
-        }
-    } else {
-        warn!("dir {} not found", file);
-    }
-    Ok(())
-}
-
-fn remove_db_files(source_dir: &Path) -> util::error::Result<()> {
-    // remove previous files (especially the non-main.db files)
-    check_and_remove_file(source_dir, "main.db")?;
-    check_and_remove_file(source_dir, "main.db-journal")?;
-    check_and_remove_file(source_dir, "main.db-shm")?;
-    check_and_remove_file(source_dir, "main.db-wal")?;
-    Ok(())
-}
-
-fn remove_icon_files(source_dir: &Path) -> util::error::Result<()> {
-    check_and_remove_dir(source_dir, "icons")?;
     Ok(())
 }

--- a/dev/tools/src/bin/merge_apps.rs
+++ b/dev/tools/src/bin/merge_apps.rs
@@ -153,6 +153,9 @@ fn select_apps(apps: Vec<infused::App>) -> Result<Vec<infused::App>> {
                 data::entities::AppIdentity::Website { base_url } => {
                     format!("Website: {}", base_url.trim())
                 }
+                data::entities::AppIdentity::Squirrel { identifier, file } => {
+                    format!("Squirrel: {} - {}", identifier.trim(), file.trim())
+                }
             };
 
             DisplayFirst {

--- a/dev/tools/src/bin/merge_apps.rs
+++ b/dev/tools/src/bin/merge_apps.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{self, Display};
 use std::path::PathBuf;
+use std::result::Result as StdResult;
 
 use clap::Parser;
 use data::db::repo::Repository;
@@ -19,18 +20,26 @@ struct Args {
     /// Database path
     #[arg()]
     db_path: Option<String>,
+
+    /// Target app ID to merge into
+    #[arg(long)]
+    target: Option<i64>,
+
+    /// App IDs to merge (comma-separated)
+    #[arg(long)]
+    apps: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = Args::parse();
+
     util::set_target(Target::Tool {
         name: "merge_apps".to_string(),
     });
     let config = config::get_config()?;
     util::setup(&config)?;
     platform::setup()?;
-
-    let args = Args::parse();
     let db_path = args
         .db_path
         .map(PathBuf::from)
@@ -46,28 +55,74 @@ async fn main() -> Result<()> {
     let apps_map = repo.get_apps(ts).await?;
     let apps: Vec<infused::App> = apps_map.into_values().collect();
 
-    let selected_apps = select_apps(apps.clone())?;
+    let selected_apps = if let Some(apps_str) = args.apps {
+        let app_ids = apps_str
+            .split(',')
+            .map(|s| s.trim().parse::<i64>())
+            .collect::<StdResult<Vec<i64>, _>>()
+            .context("Failed to parse app IDs")?;
 
-    if selected_apps.is_empty() {
-        error!("No apps selected for merging. Exiting.");
-        return Ok(());
-    }
+        // Find apps by ID
+        let selected_apps: Vec<infused::App> = apps
+            .iter()
+            .filter(|app| app_ids.contains(&app.inner.id.0))
+            .cloned()
+            .collect();
 
-    // Select the app with the lowest id as the target
-    let target_app = selected_apps
-        .iter()
-        .map(|app| app.inner.id.clone())
-        .min_by_key(|id| id.0)
-        .unwrap()
-        .clone();
+        if selected_apps.is_empty() {
+            error!("No apps found with the provided IDs: {:?}", app_ids);
+            return Ok(());
+        }
+
+        selected_apps
+    } else {
+        // Interactive mode (original behavior)
+        let selected_apps = select_apps(apps.clone())?;
+
+        if selected_apps.is_empty() {
+            error!("No apps selected for merging. Exiting.");
+            return Ok(());
+        }
+
+        selected_apps
+    };
+
+    let target_app = if let Some(target_id) = args.target {
+        // Find target app
+
+        selected_apps
+            .iter()
+            .find(|app| app.inner.id.0 == target_id)
+            .map(|app| app.inner.id.clone())
+            .context("Target app not found in the selected apps")?
+    } else {
+        // Select the app with the lowest id as the target
+
+        selected_apps
+            .iter()
+            .map(|app| app.inner.id.clone())
+            .min_by_key(|id| id.0)
+            .unwrap()
+            .clone()
+    };
 
     merge_apps(
         &mut db_pool.get_db().await?,
         db_path,
-        selected_apps,
-        target_app,
+        selected_apps.clone(),
+        target_app.clone(),
     )
     .await?;
+
+    let selected_app_ids = selected_apps
+        .iter()
+        .map(|app| app.inner.id.0.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    debug!(
+        "cargo run --bin merge_apps -- --apps {} --target {}",
+        selected_app_ids, target_app.0
+    );
 
     Ok(())
 }

--- a/dev/tools/src/bin/merge_apps.rs
+++ b/dev/tools/src/bin/merge_apps.rs
@@ -1,0 +1,175 @@
+//! Merge apps in database (user can select)
+
+use std::collections::HashSet;
+use std::fmt::{self, Display};
+use std::path::PathBuf;
+
+use clap::Parser;
+use data::db::repo::Repository;
+use data::db::{Database, DatabasePool, infused};
+use data::entities::{App, Ref};
+use inquire::MultiSelect as InquireMultiSelect;
+use platform::objects::Timestamp;
+use util::error::{ContextCompat, Result};
+use util::tracing::debug;
+use util::{Target, config, future as tokio};
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Database path
+    #[arg()]
+    db_path: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    util::set_target(Target::Tool {
+        name: "merge_apps".to_string(),
+    });
+    let config = config::get_config()?;
+    util::setup(&config)?;
+    platform::setup()?;
+
+    let args = Args::parse();
+    let db_path = args
+        .db_path
+        .map(PathBuf::from)
+        .context("db path not provided")
+        .or_else(|_| config.connection_string())?;
+    debug!("db path: {}", db_path.display());
+
+    let db_pool = DatabasePool::new(db_path).await?;
+    let ts = Timestamp::now();
+
+    let db = db_pool.get_db().await?;
+    let mut repo = Repository::new(db)?;
+    let apps_map = repo.get_apps(ts).await?;
+    let apps: Vec<infused::App> = apps_map.into_values().collect();
+
+    let selected_apps = select_apps(apps.clone())?;
+
+    if selected_apps.is_empty() {
+        println!("No apps selected for merging. Exiting.");
+        return Ok(());
+    }
+
+    // Select the app with the lowest id as the target
+    let target_app = selected_apps
+        .iter()
+        .min_by_key(|app| app.0)
+        .unwrap()
+        .clone();
+
+    merge_apps(&mut db_pool.get_db().await?, selected_apps, target_app).await?;
+
+    Ok(())
+}
+
+fn select_apps(apps: Vec<infused::App>) -> Result<HashSet<Ref<App>>> {
+    if apps.is_empty() {
+        println!("No apps found in the database.");
+        return Ok(HashSet::new());
+    }
+
+    // Create display strings for current apps
+    let app_display_strings: Vec<_> = apps
+        .iter()
+        .map(|app| {
+            let identity_str = match &app.inner.identity {
+                data::entities::AppIdentity::Uwp { aumid } => format!("UWP: {}", aumid.trim()),
+                data::entities::AppIdentity::Win32 { path } => {
+                    format!("Win32: {}", path.trim())
+                }
+                data::entities::AppIdentity::Website { base_url } => {
+                    format!("Website: {}", base_url.trim())
+                }
+            };
+
+            DisplayFirst {
+                first: format!(
+                    "{} - {} - {}",
+                    app.inner.name.trim(),
+                    app.inner.company.trim(),
+                    identity_str,
+                ),
+                second: app.clone(),
+            }
+        })
+        .collect();
+
+    let selected_indices =
+        InquireMultiSelect::new("Select apps to merge:", app_display_strings).prompt()?;
+
+    // Convert selected indices to HashSet of Ref<App>
+    let selected_apps: HashSet<Ref<App>> = selected_indices
+        .into_iter()
+        .map(|app| app.second.inner.id)
+        .collect();
+
+    println!("Selected {} apps for merging.", selected_apps.len());
+    return Ok(selected_apps);
+}
+
+struct DisplayFirst<T1, T2> {
+    pub first: T1,
+    pub second: T2,
+}
+
+impl<T1: Display, T2> Display for DisplayFirst<T1, T2> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.first.fmt(f)
+    }
+}
+
+async fn merge_apps(
+    db: &mut Database,
+    mut apps: HashSet<Ref<App>>,
+    target: Ref<App>,
+) -> Result<()> {
+    let mut tx = db.transaction().await?;
+
+    // Remove the target app from the set
+    apps.remove(&target);
+
+    let app_ids: Vec<i64> = apps.iter().map(|app| **app).collect();
+
+    if app_ids.is_empty() {
+        tx.commit().await?;
+        return Ok(());
+    }
+
+    // Build the placeholders for the IN clause
+    let placeholders = std::iter::repeat("?")
+        .take(app_ids.len())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    // Update all sessions' app_id where it's equal to any app in {apps} with {target}
+    let update_sessions_sql =
+        format!("UPDATE sessions SET app_id = ? WHERE app_id IN ({placeholders})");
+
+    let update_sessions_query = sqlx::query(&update_sessions_sql).bind(*target);
+    let update_sessions_query = app_ids
+        .iter()
+        .fold(update_sessions_query, |q, id| q.bind(id));
+    update_sessions_query.execute(&mut *tx).await?;
+
+    // Update all alerts' app_id where it's equal to any app in {apps} with {target}
+    let update_alerts_sql =
+        format!("UPDATE alerts SET app_id = ? WHERE app_id IN ({placeholders})");
+    let update_alerts_query = sqlx::query(&update_alerts_sql).bind(*target);
+    let update_alerts_query = app_ids.iter().fold(update_alerts_query, |q, id| q.bind(id));
+    update_alerts_query.execute(&mut *tx).await?;
+
+    // Delete all apps in {apps} except {target}
+    let delete_apps_sql = format!("DELETE FROM apps WHERE id IN ({placeholders})");
+    let delete_apps_query = sqlx::query(&delete_apps_sql);
+    let delete_apps_query = app_ids.iter().fold(delete_apps_query, |q, id| q.bind(id));
+    delete_apps_query.execute(&mut *tx).await?;
+
+    // Commit the transaction
+    tx.commit().await?;
+
+    Ok(())
+}

--- a/dev/tools/src/db.rs
+++ b/dev/tools/src/db.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use util::error::{ContextCompat, Result, bail};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// Source of the database
+pub enum Source {
+    // /// Seed database
+    // Seed,
+    /// Install location
+    Install,
+    /// Current directory
+    Current,
+    /// Custom path
+    Custom(PathBuf),
+}
+
+impl FromStr for Source {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            // "seed" => Ok(Source::Seed),
+            "install" => Ok(Source::Install),
+            "." => Ok(Source::Current),
+            _ => Ok(Source::Custom(PathBuf::from(s))),
+        }
+    }
+}
+
+impl Source {
+    /// Convert the source to a PathBuf
+    pub fn dir_path(&self) -> Result<PathBuf> {
+        let path = match self {
+            // Source::Seed => Ok(PathBuf::from("./dev/seed.db")),
+            Source::Install => util::config::data_local_dir()
+                .context("data local dir")?
+                .join("me.enigmatrix.cobalt"),
+            Source::Current => PathBuf::from("."),
+            Source::Custom(path) => PathBuf::from(path),
+        };
+        if !path.is_dir() {
+            bail!("{} is not a directory", path.display());
+        }
+        Ok(path)
+    }
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Source::Install => write!(f, "install"),
+            Source::Current => write!(f, "."),
+            Source::Custom(path) => write!(f, "{}", path.display()),
+        }
+    }
+}

--- a/dev/tools/src/db.rs
+++ b/dev/tools/src/db.rs
@@ -39,7 +39,7 @@ impl Source {
                 .context("data local dir")?
                 .join("me.enigmatrix.cobalt"),
             Source::Current => PathBuf::from("."),
-            Source::Custom(path) => PathBuf::from(path),
+            Source::Custom(path) => path.clone(),
         };
         if !path.is_dir() {
             bail!("{} is not a directory", path.display());

--- a/dev/tools/src/lib.rs
+++ b/dev/tools/src/lib.rs
@@ -1,4 +1,6 @@
 //! Tools utils
 
+/// Database helpers
+pub mod db;
 /// Filters for matching windows and processes
 pub mod filters;

--- a/src/data/src/db/mod.rs
+++ b/src/data/src/db/mod.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use sqlx::pool::PoolConnection;
@@ -55,8 +56,7 @@ pub struct DatabasePool {
 
 impl DatabasePool {
     /// Create a new [DatabasePool] from a [Config]
-    pub async fn new(config: &Config) -> Result<Self> {
-        let path = config.connection_string()?;
+    pub async fn new(path: impl AsRef<Path>) -> Result<Self> {
         let opts = SqliteConnectOptions::new()
             .filename(path)
             .create_if_missing(true)
@@ -95,12 +95,12 @@ impl Database {
     }
 
     /// Expose the inner [Executor]
-    pub(crate) fn executor(&mut self) -> impl Executor<'_, Database = Sqlite> {
+    pub fn executor(&mut self) -> impl Executor<'_, Database = Sqlite> {
         &mut *self.conn
     }
 
     /// Start a new [Transaction]
-    pub(crate) async fn transaction(&mut self) -> Result<Transaction<'_, Sqlite>> {
+    pub async fn transaction(&mut self) -> Result<Transaction<'_, Sqlite>> {
         self.conn.begin().await.context("begin transaction")
     }
 }

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -313,7 +313,7 @@ struct ProcessorArgs {
 
 /// Runs the [Engine] and [Sentry] loops in an asynchronous executor.
 async fn processor(args: ProcessorArgs) -> Result<()> {
-    let db_pool = DatabasePool::new(&args.config).await?;
+    let db_pool = DatabasePool::new(&args.config.connection_string()?).await?;
 
     // re-run failed app info updates
     let _db_pool = db_pool.clone();

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
 
 use data::db::infused;
 use data::entities::{
@@ -9,7 +8,6 @@ use tauri::State;
 use util::error::Context;
 use util::time::ToTicks;
 use util::tracing;
-use util::tracing::log::warn;
 
 use crate::error::AppResult;
 use crate::state::{AppState, Initable, QueryOptions, init_state};
@@ -113,96 +111,6 @@ pub async fn get_tag_durations_per_period(
     Ok(res)
 }
 
-fn check_and_remove_file(file: &str) -> util::error::Result<()> {
-    let file = util::config::Config::config_path(file)?;
-    if std::fs::metadata(&file)
-        .map(|f| f.is_file())
-        .unwrap_or(false)
-    {
-        std::fs::remove_file(&file).context(format!("remove {:?}", &file))?;
-    } else {
-        warn!("file {:?} not found", file);
-    }
-    Ok(())
-}
-
-fn check_and_remove_dir(dir: &str) -> util::error::Result<()> {
-    let dir = util::config::Config::config_path(dir)?;
-    if std::fs::metadata(&dir).map(|f| f.is_dir()).unwrap_or(false) {
-        std::fs::remove_dir_all(&dir).context(format!("remove {:?}", &dir))?;
-    } else {
-        warn!("dir {:?} not found", dir);
-    }
-    Ok(())
-}
-
-fn check_and_copy_file(dir: &Path, file: &str) -> util::error::Result<()> {
-    let from_file = dir.join(file);
-    let to_file = util::config::Config::config_path(file)?;
-    if std::fs::metadata(&from_file)
-        .map(|f| f.is_file())
-        .unwrap_or(false)
-    {
-        std::fs::copy(from_file, to_file).context(format!("copy {file}"))?;
-    } else {
-        warn!("file {file} not found");
-    }
-    Ok(())
-}
-
-fn check_and_copy_dir(dir: &Path, file: &str) -> util::error::Result<()> {
-    let from_dir = dir.join(file);
-    let to_dir = util::config::Config::config_path(file)?;
-    if std::fs::metadata(&from_dir)
-        .map(|f| f.is_dir())
-        .unwrap_or(false)
-    {
-        let to_dir = Path::new(&to_dir);
-        // Create destination directory if it doesn't exist
-        if !to_dir.exists() {
-            std::fs::create_dir_all(to_dir).context(format!("create dir {}", to_dir.display()))?;
-        }
-
-        // Copy all files from source directory to destination directory
-        for entry in
-            std::fs::read_dir(&from_dir).context(format!("read dir {}", from_dir.display()))?
-        {
-            let entry = entry.context("read dir entry")?;
-            let entry_path = entry.path();
-            let file_name = entry_path.file_name().unwrap();
-            let dest_path = to_dir.join(file_name);
-
-            if entry_path.is_file() {
-                std::fs::copy(&entry_path, &dest_path).context(format!(
-                    "copy file {} to {}",
-                    entry_path.display(),
-                    dest_path.display()
-                ))?;
-            } else if entry_path.is_dir() {
-                // Recursively copy subdirectories
-                check_and_copy_dir(&from_dir, file_name.to_str().unwrap())?;
-            }
-        }
-    } else {
-        warn!("dir {} not found", file);
-    }
-    Ok(())
-}
-
-fn remove_db_files() -> util::error::Result<()> {
-    // remove previous files (especially the non-main.db files)
-    check_and_remove_file("main.db")?;
-    check_and_remove_file("main.db-journal")?;
-    check_and_remove_file("main.db-shm")?;
-    check_and_remove_file("main.db-wal")?;
-    Ok(())
-}
-
-fn remove_icon_files() -> util::error::Result<()> {
-    check_and_remove_dir("icons")?;
-    Ok(())
-}
-
 #[tauri::command]
 #[tracing::instrument(err, skip(state))]
 pub async fn copy_from_seed_db(state: State<'_, AppState>) -> AppResult<()> {
@@ -213,8 +121,9 @@ pub async fn copy_from_seed_db(state: State<'_, AppState>) -> AppResult<()> {
         *state = Initable::Uninit;
     }
 
-    remove_icon_files()?;
-    remove_db_files()?;
+    let base_dir = util::config::Config::config_base_dir().context("config base dir")?;
+    util::fs::remove_icon_files(&base_dir)?;
+    util::fs::remove_db_files(&base_dir)?;
 
     let to_file = util::config::Config::config_path("main.db").context("config path")?;
     std::fs::copy("../../../dev/seed.db", to_file).context("copy seed.db")?;
@@ -252,18 +161,16 @@ pub async fn copy_from_install_db(state: State<'_, AppState>) -> AppResult<()> {
         *state = Initable::Uninit;
     }
 
-    remove_icon_files()?;
-    remove_db_files()?;
+    let base_dir = util::config::Config::config_base_dir().context("config base dir")?;
+    util::fs::remove_icon_files(&base_dir)?;
+    util::fs::remove_db_files(&base_dir)?;
 
     let install_dir = util::config::data_local_dir()
         .context("data local dir")?
         .join("me.enigmatrix.cobalt");
 
-    check_and_copy_dir(&install_dir, "icons")?;
-    check_and_copy_file(&install_dir, "main.db")?;
-    check_and_copy_file(&install_dir, "main.db-journal")?;
-    check_and_copy_file(&install_dir, "main.db-shm")?;
-    check_and_copy_file(&install_dir, "main.db-wal")?;
+    util::fs::copy_icon_files(&install_dir, &base_dir)?;
+    util::fs::copy_db_files(&install_dir, &base_dir)?;
 
     // reinit state (repo)
     init_state(state).await?;

--- a/src/ui/src-tauri/src/state.rs
+++ b/src/ui/src-tauri/src/state.rs
@@ -51,7 +51,7 @@ impl AppStateInner {
     pub async fn new() -> Result<Self> {
         let config = get_config()?;
         util::setup(&config)?;
-        let db_pool = DatabasePool::new(&config).await?;
+        let db_pool = DatabasePool::new(&config.connection_string()?).await?;
         Ok(Self { db_pool, config })
     }
 

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -323,7 +323,7 @@ fn combined_extract_fields() -> Result<()> {
     std::env::set_current_dir("../../")?;
     let config = get_config()?;
     assert_eq!(
-        "main.db",
+        ".\\main.db",
         config.connection_string()?.to_string_lossy().to_string()
     );
     std::fs::remove_file(Config::config_path(CONFIG_FILE)?).expect("failed to remove file");

--- a/src/util/src/config.rs
+++ b/src/util/src/config.rs
@@ -91,17 +91,17 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Get the config path from dir
-    pub fn config_path(segment: &str) -> Result<PathBuf> {
+    /// Get the config base path dir
+    pub fn config_base_dir() -> Result<PathBuf> {
         #[cfg(debug_assertions)]
         {
             use crate::{TARGET, Target};
 
             let target = TARGET.lock().unwrap().clone();
             match target {
-                Target::Engine => Ok(PathBuf::from(segment)),
-                Target::Ui => Ok(PathBuf::from("../../../").join(segment)),
-                Target::Tool { .. } => Ok(PathBuf::from(segment)),
+                Target::Engine => Ok(PathBuf::from(".")),
+                Target::Ui => Ok(PathBuf::from("../../../")),
+                Target::Tool { .. } => Ok(PathBuf::from(".")),
             }
         }
 
@@ -118,8 +118,13 @@ impl Config {
                 std::fs::create_dir(&parent)?;
             }
 
-            Ok(parent.join(segment))
+            Ok(parent)
         }
+    }
+
+    /// Get the config path from dir
+    pub fn config_path(segment: &str) -> Result<PathBuf> {
+        Ok(Self::config_base_dir()?.join(segment))
     }
 
     /// Validate the config and replace any missing values with defaults

--- a/src/util/src/fs.rs
+++ b/src/util/src/fs.rs
@@ -1,0 +1,107 @@
+use std::fs;
+use std::path::Path;
+
+use crate::error::{Context, Result};
+use crate::tracing::warn;
+
+/// Check if file exists then remove it
+pub fn check_and_remove_file(source_dir: &Path, file: &str) -> Result<()> {
+    let file = source_dir.join(file);
+    if fs::metadata(&file).map(|f| f.is_file()).unwrap_or(false) {
+        fs::remove_file(&file).context(format!("remove {:?}", &file))?;
+    } else {
+        warn!("file {:?} not found", file);
+    }
+    Ok(())
+}
+
+/// Check if dir exists then remove it
+pub fn check_and_remove_dir(source_dir: &Path, dir: &str) -> Result<()> {
+    let dir = source_dir.join(dir);
+    if fs::metadata(&dir).map(|f| f.is_dir()).unwrap_or(false) {
+        fs::remove_dir_all(&dir).context(format!("remove {dir:?}"))?;
+    } else {
+        warn!("dir {:?} not found", dir);
+    }
+    Ok(())
+}
+
+/// Check if source file exists then copy it
+pub fn check_and_copy_file(source_dir: &Path, target_dir: &Path, file: &str) -> Result<()> {
+    let from_file = source_dir.join(file);
+    let to_file = target_dir.join(file);
+    if fs::metadata(&from_file)
+        .map(|f| f.is_file())
+        .unwrap_or(false)
+    {
+        fs::copy(from_file, to_file).context(format!("copy {file}"))?;
+    } else {
+        warn!("file {file} not found");
+    }
+    Ok(())
+}
+
+/// Check if source dir exists then copy it
+pub fn check_and_copy_dir(source_dir: &Path, target_dir: &Path, file: &str) -> Result<()> {
+    let from_dir = source_dir.join(file);
+    let to_dir = target_dir.join(file);
+    if fs::metadata(&from_dir).map(|f| f.is_dir()).unwrap_or(false) {
+        // Create destination directory if it doesn't exist
+        if !to_dir.exists() {
+            fs::create_dir_all(&to_dir).context(format!("create dir {}", to_dir.display()))?;
+        }
+
+        // Copy all files from source directory to destination directory
+        for entry in fs::read_dir(&from_dir).context(format!("read dir {}", from_dir.display()))? {
+            let entry = entry.context("read dir entry")?;
+            let entry_path = entry.path();
+            let file_name = entry_path.file_name().unwrap();
+            let dest_path = to_dir.join(file_name);
+
+            if entry_path.is_file() {
+                fs::copy(&entry_path, &dest_path).context(format!(
+                    "copy file {} to {}",
+                    entry_path.display(),
+                    dest_path.display()
+                ))?;
+            } else if entry_path.is_dir() {
+                // Recursively copy subdirectories
+                check_and_copy_dir(&from_dir, &to_dir, file_name.to_str().unwrap())?;
+            }
+        }
+    } else {
+        warn!("dir {} not found", file);
+    }
+    Ok(())
+}
+
+/// Remove db files
+pub fn remove_db_files(source_dir: &Path) -> Result<()> {
+    // remove previous files (especially the non-main.db files)
+    check_and_remove_file(source_dir, "main.db")?;
+    check_and_remove_file(source_dir, "main.db-journal")?;
+    check_and_remove_file(source_dir, "main.db-shm")?;
+    check_and_remove_file(source_dir, "main.db-wal")?;
+    Ok(())
+}
+
+/// Remove icon files
+pub fn remove_icon_files(source_dir: &Path) -> Result<()> {
+    check_and_remove_dir(source_dir, "icons")?;
+    Ok(())
+}
+
+/// Copy db files
+pub fn copy_db_files(source_dir: &Path, target_dir: &Path) -> Result<()> {
+    check_and_copy_file(source_dir, target_dir, "main.db")?;
+    check_and_copy_file(source_dir, target_dir, "main.db-journal")?;
+    check_and_copy_file(source_dir, target_dir, "main.db-shm")?;
+    check_and_copy_file(source_dir, target_dir, "main.db-wal")?;
+    Ok(())
+}
+
+/// Copy icon files
+pub fn copy_icon_files(source_dir: &Path, target_dir: &Path) -> Result<()> {
+    check_and_copy_dir(source_dir, target_dir, "icons")?;
+    Ok(())
+}

--- a/src/util/src/lib.rs
+++ b/src/util/src/lib.rs
@@ -8,6 +8,8 @@ pub mod config;
 pub mod ds;
 /// Error base
 pub mod error;
+/// File system helpers
+pub mod fs;
 /// Async base
 pub mod future;
 /// Number types


### PR DESCRIPTION
### TL;DR

Added database management tools for merging apps and copying databases between environments.

### What changed?

- Added a new `merge_apps` tool that allows merging multiple app entries in the database into a single app
- Added a `copy_db` tool to copy databases between different environments
- Refactored database-related file operations into reusable utility functions in `util::fs`
- Modified `DatabasePool::new()` to accept a path parameter instead of requiring a Config
- Added support for interactive app selection using the `inquire` crate

### How to test?

1. To merge apps:
   ```
   cargo run --bin merge_apps
   ```
   This will open an interactive prompt to select apps to merge.

   You can also use command-line arguments:
   ```
   cargo run --bin merge_apps -- --apps 1,2,3 --target 1
   ```

2. To copy a database:
   ```
   cargo run --bin copy_db -- --source install --target .
   ```
   This copies from the installed app to the current directory.