### PR TITLE
Fixup Refresh Validations

### DIFF
--- a/src/ui/app/components/usage-card.tsx
+++ b/src/ui/app/components/usage-card.tsx
@@ -132,7 +132,7 @@ export function UsageCardTitle({
         <Tooltip>
           <TooltipTrigger className="max-w-full text-base flex items-center gap-1.5 text-card-foreground/50 truncate">
             {title}
-            {(isLoading || isValidating) && (
+            {((isLoading ?? false) || (isValidating ?? false)) && (
               <Loader2 className="size-4 animate-spin" />
             )}
           </TooltipTrigger>

--- a/src/ui/app/components/usage-card.tsx
+++ b/src/ui/app/components/usage-card.tsx
@@ -56,10 +56,12 @@ export function UsageCard({
 export function PrevButton({
   canGoPrev,
   isLoading,
+  isValidating,
   goPrev,
 }: {
   canGoPrev: boolean;
   isLoading: boolean;
+  isValidating: boolean;
   goPrev: () => void;
 }) {
   return (
@@ -67,7 +69,7 @@ export function PrevButton({
       variant="ghost"
       size="icon"
       onClick={goPrev}
-      disabled={!canGoPrev || isLoading}
+      disabled={!canGoPrev || isLoading || isValidating}
     >
       <ChevronLeft />
     </Button>
@@ -77,10 +79,12 @@ export function PrevButton({
 export function NextButton({
   canGoNext,
   isLoading,
+  isValidating,
   goNext,
 }: {
   canGoNext: boolean;
   isLoading: boolean;
+  isValidating: boolean;
   goNext: () => void;
 }) {
   return (
@@ -88,7 +92,7 @@ export function NextButton({
       variant="ghost"
       size="icon"
       onClick={goNext}
-      disabled={!canGoNext || isLoading}
+      disabled={!canGoNext || isLoading || isValidating}
     >
       <ChevronRight />
     </Button>

--- a/src/ui/app/components/usage-card.tsx
+++ b/src/ui/app/components/usage-card.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/viz/viz-card";
 import { useToday } from "@/hooks/use-time";
 import { toHumanInterval, type Interval } from "@/lib/time";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { useMemo } from "react";
 
 export interface UsageCardProps {
@@ -25,10 +25,15 @@ export interface UsageCardProps {
   totalUsage: number;
   children: React.ReactNode;
   actions: React.ReactNode;
+
+  isLoading?: boolean;
+  isValidating?: boolean;
 }
 
 export function UsageCard({
   interval,
+  isLoading,
+  isValidating,
   usage,
   totalUsage,
   children,
@@ -42,6 +47,8 @@ export function UsageCard({
             usage={usage}
             totalUsage={totalUsage}
             interval={interval}
+            isLoading={isLoading}
+            isValidating={isValidating}
           />
         </VizCardTitle>
 
@@ -103,10 +110,14 @@ export function UsageCardTitle({
   usage,
   totalUsage,
   interval,
+  isLoading,
+  isValidating,
 }: {
   usage?: number;
   totalUsage: number;
   interval: Interval;
+  isLoading?: boolean;
+  isValidating?: boolean;
 }) {
   const today = useToday();
   const title = useMemo(
@@ -119,8 +130,11 @@ export function UsageCardTitle({
       {/* TODO: create a interval range component? */}
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger className="max-w-full text-base text-card-foreground/50 truncate">
+          <TooltipTrigger className="max-w-full text-base flex items-center gap-1.5 text-card-foreground/50 truncate">
             {title}
+            {(isLoading || isValidating) && (
+              <Loader2 className="size-4 animate-spin" />
+            )}
           </TooltipTrigger>
           <TooltipContent>
             <div>{title}</div>

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -152,7 +152,8 @@ interface GanttProps {
 export function Gantt({
   usages: usagesPerAppSession,
   usagesLoading,
-  usagesValidating,
+  // we don't actually use this - the indicator is in the Session cards instead
+  // usagesValidating,
   streaks,
   streaksLoading,
   streaksValidating,
@@ -816,18 +817,14 @@ export function Gantt({
           {key.type === "interactionBar" ? (
             <InteractionInfoBar
               loading={
-                !!(
-                  interactionPeriodsLoading ||
-                  systemEventsLoading ||
-                  streaksLoading
-                )
+                (interactionPeriodsLoading ?? false) ||
+                (systemEventsLoading ?? false) ||
+                (streaksLoading ?? false)
               }
               validating={
-                !!(
-                  interactionPeriodsValidating ||
-                  systemEventsValidating ||
-                  streaksValidating
-                )
+                (interactionPeriodsValidating ?? false) ||
+                (systemEventsValidating ?? false) ||
+                (streaksValidating ?? false)
               }
               interactionInfoBarHeight={interactionInfoBarHeight}
               key={key.type + key.id}

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -123,15 +123,19 @@ type SeriesKey = (SessionSeriesKey | AppSeriesKey | InteractionBarSeriesKey) & {
 interface GanttProps {
   usages: AppSessionUsages;
   usagesLoading?: boolean;
+  usagesValidating?: boolean;
 
   streaks?: Streak[];
   streaksLoading?: boolean;
+  streaksValidating?: boolean;
 
   interactionPeriods?: InteractionPeriod[];
   interactionPeriodsLoading?: boolean;
+  interactionPeriodsValidating?: boolean;
 
   systemEvents?: SystemEvent[];
   systemEventsLoading?: boolean;
+  systemEventsValidating?: boolean;
 
   summary?: React.ReactNode;
   defaultExpanded?: Record<Ref<App>, boolean>;
@@ -148,12 +152,16 @@ interface GanttProps {
 export function Gantt({
   usages: usagesPerAppSession,
   usagesLoading,
+  usagesValidating,
   streaks,
   streaksLoading,
+  streaksValidating,
   interactionPeriods,
   interactionPeriodsLoading,
+  interactionPeriodsValidating,
   systemEvents,
   systemEventsLoading,
+  systemEventsValidating,
   summary,
   defaultExpanded,
   interval,
@@ -809,9 +817,16 @@ export function Gantt({
             <InteractionInfoBar
               loading={
                 !!(
-                  interactionPeriodsLoading ??
-                  systemEventsLoading ??
+                  interactionPeriodsLoading ||
+                  systemEventsLoading ||
                   streaksLoading
+                )
+              }
+              validating={
+                !!(
+                  interactionPeriodsValidating ||
+                  systemEventsValidating ||
+                  streaksValidating
                 )
               }
               interactionInfoBarHeight={interactionInfoBarHeight}
@@ -848,6 +863,9 @@ export function Gantt({
       interactionPeriodsLoading,
       systemEventsLoading,
       streaksLoading,
+      interactionPeriodsValidating,
+      systemEventsValidating,
+      streaksValidating,
       toggleApp,
       expanded,
       appMap,
@@ -1014,10 +1032,12 @@ export function Gantt({
 
 function InteractionInfoBar({
   loading,
+  validating,
   interactionInfoBarHeight,
   className,
 }: {
   loading: boolean;
+  validating: boolean;
   interactionInfoBarHeight: number;
   className?: ClassValue;
 }) {
@@ -1029,7 +1049,9 @@ function InteractionInfoBar({
       >
         <LaptopIcon className="w-6 h-6 ml-6" />
         <Text className="font-semibold ml-4">Interactions</Text>
-        {loading && <Loader2Icon className="animate-spin ml-4" />}
+        {(loading || validating) && (
+          <Loader2Icon className="animate-spin ml-4" />
+        )}
       </div>
       <div className="h-px bg-border absolute bottom-[-0.5px] left-0 right-0" />
     </div>
@@ -1186,17 +1208,21 @@ function InteractionTooltip({
 export function DurationSummaries({
   usages,
   usagesLoading,
+  usagesValidating,
 
   streaks,
   streaksLoading,
+  streaksValidating,
 
   className,
 }: {
   usages: AppSessionUsages;
   usagesLoading?: boolean;
+  usagesValidating?: boolean;
 
   streaks?: Streak[];
   streaksLoading?: boolean;
+  streaksValidating?: boolean;
 
   className?: ClassValue;
 }) {
@@ -1221,7 +1247,11 @@ export function DurationSummaries({
     >
       {streaks &&
         (streaksLoading ? (
-          <Loader2Icon className="animate-spin" />
+          <>
+            <Loader2Icon className="animate-spin" />
+            <div>/</div>
+            <Loader2Icon className="animate-spin" />
+          </>
         ) : (
           <>
             <DurationText
@@ -1229,12 +1259,14 @@ export function DurationSummaries({
               className="text-green-500/80"
               description="Focus Streaks"
             />
+            {streaksValidating && <Loader2Icon className="animate-spin" />}
             <div>/</div>
             <DurationText
               ticks={distractiveStreakUsage}
               className="text-red-400/80"
               description="Distractive Streaks"
             />
+            {streaksValidating && <Loader2Icon className="animate-spin" />}
           </>
         ))}
       {streaks && <div>/</div>}
@@ -1247,6 +1279,7 @@ export function DurationSummaries({
             className="text-foreground/80"
             description="Total Usage"
           />
+          {usagesValidating && <Loader2Icon className="animate-spin" />}
         </>
       )}
     </div>

--- a/src/ui/app/routes/alerts/[id].tsx
+++ b/src/ui/app/routes/alerts/[id].tsx
@@ -376,20 +376,28 @@ function AlertTimelineCard({ alert }: { alert: Alert }) {
   const { interval, canGoNext, goNext, canGoPrev, goPrev, setInterval } =
     useIntervalControlsWithDefault("week");
 
-  const { ret: alertEvents, isLoading: eventsLoading } = useAlertEvents({
+  const {
+    ret: alertEvents,
+    isLoading: eventsLoading,
+    isValidating: eventsValidating,
+  } = useAlertEvents({
     start: interval.start,
     end: interval.end,
     alertId: alert.id,
   });
 
-  const { ret: reminderEvents, isLoading: reminderLoading } =
-    useAlertReminderEvents({
-      start: interval.start,
-      end: interval.end,
-      alertId: alert.id,
-    });
+  const {
+    ret: reminderEvents,
+    isLoading: reminderLoading,
+    isValidating: reminderValidating,
+  } = useAlertReminderEvents({
+    start: interval.start,
+    end: interval.end,
+    alertId: alert.id,
+  });
 
   const isLoading = eventsLoading || reminderLoading;
+  const isValidating = eventsValidating || reminderValidating;
 
   // Combine and sort events chronologically
   const timelineEvents = useMemo(() => {
@@ -408,7 +416,7 @@ function AlertTimelineCard({ alert }: { alert: Alert }) {
       <VizCardHeader className="pb-4">
         <VizCardTitle className="pl-4 pt-4 flex items-center gap-2">
           <span className="font-semibold">Events</span>
-          {isLoading && (
+          {(isLoading || isValidating) && (
             <div className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
           )}
         </VizCardTitle>
@@ -416,6 +424,7 @@ function AlertTimelineCard({ alert }: { alert: Alert }) {
           <PrevButton
             canGoPrev={canGoPrev}
             isLoading={isLoading}
+            isValidating={isValidating}
             goPrev={goPrev}
           />
           <DateRangePicker
@@ -426,6 +435,7 @@ function AlertTimelineCard({ alert }: { alert: Alert }) {
           <NextButton
             canGoNext={canGoNext}
             isLoading={isLoading}
+            isValidating={isValidating}
             goNext={goNext}
           />
         </VizCardAction>

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -301,7 +301,11 @@ function AppUsageBarChartCard({
   const { interval, canGoNext, goNext, canGoPrev, goPrev } =
     useIntervalControlsWithDefault(timePeriod);
 
-  const { isLoading, ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+  const {
+    isLoading,
+    isValidating,
+    ret: appDurationsPerPeriod,
+  } = useAppDurationsPerPeriod({
     ...interval,
     period,
   });
@@ -342,11 +346,13 @@ function AppUsageBarChartCard({
           <PrevButton
             canGoPrev={canGoPrev}
             isLoading={isLoading}
+            isValidating={isValidating}
             goPrev={goPrev}
           />
           <NextButton
             canGoNext={canGoNext}
             isLoading={isLoading}
+            isValidating={isValidating}
             goNext={goNext}
           />
         </>
@@ -359,7 +365,11 @@ function AppUsageHeatmapCard({ app }: { app: App }) {
   const { interval, canGoNext, goNext, canGoPrev, goPrev } =
     useIntervalControlsWithDefault("year");
 
-  const { isLoading, ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+  const {
+    isLoading,
+    isValidating,
+    ret: appDurationsPerPeriod,
+  } = useAppDurationsPerPeriod({
     ...interval,
     period: "day",
   });
@@ -394,11 +404,13 @@ function AppUsageHeatmapCard({ app }: { app: App }) {
           <PrevButton
             canGoPrev={canGoPrev}
             isLoading={isLoading}
+            isValidating={isValidating}
             goPrev={goPrev}
           />
           <NextButton
             canGoNext={canGoNext}
             isLoading={isLoading}
+            isValidating={isValidating}
             goNext={goNext}
           />
         </>
@@ -423,13 +435,17 @@ function AppSessionsCard({ app }: { app: App }) {
   const { interval, canGoNext, goNext, canGoPrev, goPrev, setInterval } =
     useIntervalControlsWithDefault("day");
 
-  const { ret: usages, isLoading: usagesLoading } =
-    useAppSessionUsages(interval);
+  const {
+    ret: usages,
+    isLoading: usagesLoading,
+    isValidating: usagesValidating,
+  } = useAppSessionUsages(interval);
   const onlyAppSessionUsages = useMemo(() => {
     return usages[app.id] ? { [app.id]: usages[app.id] } : {};
   }, [usages, app.id]);
 
   const isLoading = usagesLoading;
+  const isValidating = usagesValidating;
 
   return (
     <VizCard>
@@ -439,12 +455,15 @@ function AppSessionsCard({ app }: { app: App }) {
             <div className="flex flex-col gap-2 my-2 mx-4">
               <div className="text-lg font-bold flex items-center gap-2">
                 Sessions
-                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+                {(isLoading || isValidating) && (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                )}
               </div>
               <div className="flex items-center -ml-2">
                 <PrevButton
                   canGoPrev={canGoPrev}
                   isLoading={isLoading}
+                  isValidating={isValidating}
                   goPrev={goPrev}
                 />
                 <DateRangePicker
@@ -455,6 +474,7 @@ function AppSessionsCard({ app }: { app: App }) {
                 <NextButton
                   canGoNext={canGoNext}
                   isLoading={isLoading}
+                  isValidating={isValidating}
                   goNext={goNext}
                 />
               </div>
@@ -462,6 +482,7 @@ function AppSessionsCard({ app }: { app: App }) {
           }
           usages={onlyAppSessionUsages}
           usagesLoading={usagesLoading}
+          usagesValidating={usagesValidating}
           defaultExpanded={{ [app.id]: true }}
           interval={interval}
         />

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -341,6 +341,8 @@ function AppUsageBarChartCard({
       usage={totalAppUsage}
       totalUsage={totalUsage}
       children={children}
+      isLoading={isLoading}
+      isValidating={isValidating}
       actions={
         <>
           <PrevButton
@@ -399,6 +401,8 @@ function AppUsageHeatmapCard({ app }: { app: App }) {
       usage={usage}
       totalUsage={totalUsage}
       interval={interval}
+      isLoading={isLoading}
+      isValidating={isValidating}
       actions={
         <>
           <PrevButton

--- a/src/ui/app/routes/history.tsx
+++ b/src/ui/app/routes/history.tsx
@@ -147,7 +147,11 @@ function AppUsagePerPeriodHistory() {
   const [period, setPeriod] = useState<Period>("day");
   const { interval } = useHistoryContext();
 
-  const { isLoading, ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+  const {
+    isLoading,
+    isValidating,
+    ret: appDurationsPerPeriod,
+  } = useAppDurationsPerPeriod({
     ...interval,
     period,
   });
@@ -182,7 +186,9 @@ function AppUsagePerPeriodHistory() {
           <Label className="font-medium text-muted-foreground">Usage</Label>
           <DurationText ticks={totalUsage} className="text-lg font-semibold" />
         </div>
-        {isLoading && <Loader2 className="animate-spin w-4 h-4" />}
+        {(isLoading || isValidating) && (
+          <Loader2 className="animate-spin w-4 h-4" />
+        )}
         <div className="flex-1 md:min-w-0" />
         <FormItem>
           <Label className="font-medium text-muted-foreground place-self-end">
@@ -226,20 +232,38 @@ function AppUsagePerPeriodHistory() {
 function SessionHistory() {
   const { interval } = useHistoryContext();
 
-  const { ret: usages, isLoading: usagesLoading } =
-    useAppSessionUsages(interval);
-  const { ret: interactions, isLoading: interactionPeriodsLoading } =
-    useInteractionPeriods(interval);
-  const { ret: systemEvents, isLoading: systemEventsLoading } =
-    useSystemEvents(interval);
-  const { ret: streaks, isLoading: streaksLoading } =
-    useDefaultStreaks(interval);
+  const {
+    ret: usages,
+    isLoading: usagesLoading,
+    isValidating: usagesValidating,
+  } = useAppSessionUsages(interval);
+  const {
+    ret: interactions,
+    isLoading: interactionPeriodsLoading,
+    isValidating: interactionPeriodsValidating,
+  } = useInteractionPeriods(interval);
+  const {
+    ret: systemEvents,
+    isLoading: systemEventsLoading,
+    isValidating: systemEventsValidating,
+  } = useSystemEvents(interval);
+  const {
+    ret: streaks,
+    isLoading: streaksLoading,
+    isValidating: streaksValidating,
+  } = useDefaultStreaks(interval);
 
   const isLoading =
     usagesLoading ||
     interactionPeriodsLoading ||
     systemEventsLoading ||
     streaksLoading;
+
+  const isValidating =
+    usagesValidating ||
+    interactionPeriodsValidating ||
+    systemEventsValidating ||
+    streaksValidating;
 
   return (
     <div className="flex flex-col flex-1 gap-6">
@@ -251,8 +275,10 @@ function SessionHistory() {
           <DurationSummaries
             usages={usages}
             usagesLoading={usagesLoading}
+            usagesValidating={usagesValidating}
             streaks={streaks}
             streaksLoading={streaksLoading}
+            streaksValidating={streaksValidating}
           />
         </FormItem>
       </div>
@@ -263,18 +289,24 @@ function SessionHistory() {
             <div className="flex flex-col gap-2 my-2 mx-4">
               <div className="text-lg font-bold flex items-center gap-2">
                 Sessions
-                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+                {(isLoading || isValidating) && (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                )}
               </div>
             </div>
           }
           usages={usages}
           usagesLoading={usagesLoading}
+          usagesValidating={usagesValidating}
           streaks={streaks}
           streaksLoading={streaksLoading}
+          streaksValidating={streaksValidating}
           interactionPeriods={interactions}
           interactionPeriodsLoading={interactionPeriodsLoading}
+          interactionPeriodsValidating={interactionPeriodsValidating}
           systemEvents={systemEvents}
           systemEventsLoading={systemEventsLoading}
+          systemEventsValidating={systemEventsValidating}
           interval={interval}
         />
       </div>

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -323,7 +323,7 @@ function UsageStatItem({
             className={cn("h-6 w-6 mt-1 animate-spin self-end", color)}
           />
         ) : (
-          <div className="flex items-center gap-1  justify-end">
+          <div className="flex items-center gap-1 justify-end">
             {isValidating && (
               <Loader2 className="h-6 w-6 mt-1 animate-spin self-end" />
             )}

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -182,6 +182,8 @@ function AppUsageBarChartCard({
       interval={interval}
       totalUsage={totalUsage}
       children={children}
+      isLoading={isLoading}
+      isValidating={isValidating}
       actions={
         <>
           <PrevButton

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -51,15 +51,16 @@ import { useMemo } from "react";
 
 export default function Home() {
   const interval = usePeriodInterval("day");
-  const { ret: streaks, isLoading: streaksLoading } =
-    useDefaultStreaks(interval);
+  const {
+    ret: streaks,
+    isLoading: streaksLoading,
+    isValidating: streaksValidating,
+  } = useDefaultStreaks(interval);
   const {
     ret: appDurationsPerPeriod,
     isLoading: appDurationsPerPeriodLoading,
-  } = useAppDurationsPerPeriod({
-    ...interval,
-    period: "hour",
-  });
+    isValidating: appDurationsPerPeriodValidating,
+  } = useAppDurationsPerPeriod({ ...interval, period: "hour" });
 
   const [focusStreakUsage, distractiveStreakUsage] =
     useStreakDurations(streaks);
@@ -84,6 +85,7 @@ export default function Home() {
             <AlertEventItem />
             <UsageStatItem
               isLoading={streaksLoading}
+              isValidating={streaksValidating}
               label="Focus Streaks"
               usage={focusStreakUsage}
               color="text-green-600 dark:text-green-400"
@@ -91,6 +93,7 @@ export default function Home() {
             />
             <UsageStatItem
               isLoading={streaksLoading}
+              isValidating={streaksValidating}
               label="Distractive Streaks"
               usage={distractiveStreakUsage}
               color="text-red-600 dark:text-red-400"
@@ -98,6 +101,7 @@ export default function Home() {
             />
             <UsageStatItem
               isLoading={appDurationsPerPeriodLoading}
+              isValidating={appDurationsPerPeriodValidating}
               label="Total Usage"
               usage={totalUsage}
               color="text-foreground"
@@ -144,7 +148,11 @@ function AppUsageBarChartCard({
   const { interval, canGoNext, goNext, canGoPrev, goPrev } =
     useIntervalControlsWithDefault(timePeriod);
 
-  const { isLoading, ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+  const {
+    isLoading,
+    isValidating,
+    ret: appDurationsPerPeriod,
+  } = useAppDurationsPerPeriod({
     ...interval,
     period,
   });
@@ -179,11 +187,13 @@ function AppUsageBarChartCard({
           <PrevButton
             canGoPrev={canGoPrev}
             isLoading={isLoading}
+            isValidating={isValidating}
             goPrev={goPrev}
           />
           <NextButton
             canGoNext={canGoNext}
             isLoading={isLoading}
+            isValidating={isValidating}
             goNext={goNext}
           />
         </>
@@ -196,20 +206,38 @@ function SessionsCard() {
   const { interval, canGoNext, goNext, canGoPrev, goPrev, setInterval } =
     useIntervalControlsWithDefault("day");
 
-  const { ret: usages, isLoading: usagesLoading } =
-    useAppSessionUsages(interval);
-  const { ret: interactions, isLoading: interactionPeriodsLoading } =
-    useInteractionPeriods(interval);
-  const { ret: systemEvents, isLoading: systemEventsLoading } =
-    useSystemEvents(interval);
-  const { ret: streaks, isLoading: streaksLoading } =
-    useDefaultStreaks(interval);
+  const {
+    ret: usages,
+    isLoading: usagesLoading,
+    isValidating: usagesValidating,
+  } = useAppSessionUsages(interval);
+  const {
+    ret: interactions,
+    isLoading: interactionPeriodsLoading,
+    isValidating: interactionPeriodsValidating,
+  } = useInteractionPeriods(interval);
+  const {
+    ret: systemEvents,
+    isLoading: systemEventsLoading,
+    isValidating: systemEventsValidating,
+  } = useSystemEvents(interval);
+  const {
+    ret: streaks,
+    isLoading: streaksLoading,
+    isValidating: streaksValidating,
+  } = useDefaultStreaks(interval);
 
   const isLoading =
     usagesLoading ||
     interactionPeriodsLoading ||
     systemEventsLoading ||
     streaksLoading;
+
+  const isValidating =
+    usagesValidating ||
+    interactionPeriodsValidating ||
+    systemEventsValidating ||
+    streaksValidating;
 
   return (
     <VizCard>
@@ -219,12 +247,15 @@ function SessionsCard() {
             <div className="flex flex-col gap-2 my-2 mx-4">
               <div className="text-lg font-bold flex items-center gap-2">
                 Sessions
-                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+                {(isLoading || isValidating) && (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                )}
               </div>
               <div className="flex items-center -ml-2">
                 <PrevButton
                   canGoPrev={canGoPrev}
                   isLoading={isLoading}
+                  isValidating={isValidating}
                   goPrev={goPrev}
                 />
                 <DateRangePicker
@@ -235,6 +266,7 @@ function SessionsCard() {
                 <NextButton
                   canGoNext={canGoNext}
                   isLoading={isLoading}
+                  isValidating={isValidating}
                   goNext={goNext}
                 />
               </div>
@@ -242,12 +274,16 @@ function SessionsCard() {
           }
           usages={usages}
           usagesLoading={usagesLoading}
+          usagesValidating={usagesValidating}
           streaks={streaks}
           streaksLoading={streaksLoading}
+          streaksValidating={streaksValidating}
           interactionPeriods={interactions}
           interactionPeriodsLoading={interactionPeriodsLoading}
+          interactionPeriodsValidating={interactionPeriodsValidating}
           systemEvents={systemEvents}
           systemEventsLoading={systemEventsLoading}
+          systemEventsValidating={systemEventsValidating}
           interval={interval}
         />
       </VizCardContent>
@@ -258,12 +294,14 @@ function SessionsCard() {
 // Component for displaying usage statistics
 function UsageStatItem({
   isLoading,
+  isValidating,
   label,
   usage,
   color,
   cardColor,
 }: {
   isLoading: boolean;
+  isValidating: boolean;
   label: string;
   usage: number;
   color?: string;
@@ -283,10 +321,15 @@ function UsageStatItem({
             className={cn("h-6 w-6 mt-1 animate-spin self-end", color)}
           />
         ) : (
-          <DurationText
-            className={cn("text-xl font-bold self-end", color)}
-            ticks={usage}
-          />
+          <div className="flex items-center gap-1  justify-end">
+            {isValidating && (
+              <Loader2 className="h-6 w-6 mt-1 animate-spin self-end" />
+            )}
+            <DurationText
+              className={cn("text-xl font-bold self-end", color)}
+              ticks={usage}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -249,7 +249,11 @@ function TagUsageBarChartCard({
   const { interval, canGoNext, goNext, canGoPrev, goPrev } =
     useIntervalControlsWithDefault(timePeriod);
 
-  const { isLoading, ret: appDurationsPerPeriod } = useAppDurationsPerPeriod({
+  const {
+    isLoading,
+    isValidating,
+    ret: appDurationsPerPeriod,
+  } = useAppDurationsPerPeriod({
     ...interval,
     period,
   });
@@ -291,11 +295,13 @@ function TagUsageBarChartCard({
           <PrevButton
             canGoPrev={canGoPrev}
             isLoading={isLoading}
+            isValidating={isValidating}
             goPrev={goPrev}
           />
           <NextButton
             canGoNext={canGoNext}
             isLoading={isLoading}
+            isValidating={isValidating}
             goNext={goNext}
           />
         </>
@@ -308,7 +314,11 @@ function TagUsageHeatmapCard({ tag }: { tag: Tag }) {
   const { interval, canGoNext, goNext, canGoPrev, goPrev } =
     useIntervalControlsWithDefault("year");
 
-  const { isLoading: isLoading, ret: usages } = useTagDurationsPerPeriod({
+  const {
+    isLoading,
+    isValidating,
+    ret: usages,
+  } = useTagDurationsPerPeriod({
     ...interval,
     period: "day",
   });
@@ -339,11 +349,13 @@ function TagUsageHeatmapCard({ tag }: { tag: Tag }) {
           <PrevButton
             canGoPrev={canGoPrev}
             isLoading={isLoading}
+            isValidating={isValidating}
             goPrev={goPrev}
           />
           <NextButton
             canGoNext={canGoNext}
             isLoading={isLoading}
+            isValidating={isValidating}
             goNext={goNext}
           />
         </>
@@ -368,8 +380,11 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
   const { interval, canGoNext, goNext, canGoPrev, goPrev, setInterval } =
     useIntervalControlsWithDefault("day");
 
-  const { ret: usages, isLoading: usagesLoading } =
-    useAppSessionUsages(interval);
+  const {
+    ret: usages,
+    isLoading: usagesLoading,
+    isValidating: usagesValidating,
+  } = useAppSessionUsages(interval);
   const tagAppSessionUsages = useMemo(() => {
     return _(tag.apps)
       .filter((appId) => usages[appId] !== undefined)
@@ -379,6 +394,7 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
   }, [usages, tag]);
 
   const isLoading = usagesLoading;
+  const isValidating = usagesValidating;
 
   return (
     <VizCard>
@@ -388,12 +404,15 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
             <div className="flex flex-col gap-2 my-2 mx-4">
               <div className="text-lg font-bold flex items-center gap-2">
                 Sessions
-                {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+                {(isLoading || isValidating) && (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                )}
               </div>
               <div className="flex items-center -ml-2">
                 <PrevButton
                   canGoPrev={canGoPrev}
                   isLoading={isLoading}
+                  isValidating={isValidating}
                   goPrev={goPrev}
                 />
                 <DateRangePicker
@@ -404,6 +423,7 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
                 <NextButton
                   canGoNext={canGoNext}
                   isLoading={isLoading}
+                  isValidating={isValidating}
                   goNext={goNext}
                 />
               </div>
@@ -411,6 +431,7 @@ function TagSessionsCard({ tag }: { tag: Tag }) {
           }
           usages={tagAppSessionUsages}
           usagesLoading={usagesLoading}
+          usagesValidating={usagesValidating}
           interval={interval}
         />
       </VizCardContent>

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -290,6 +290,8 @@ function TagUsageBarChartCard({
       usage={totalTagUsage}
       totalUsage={totalUsage}
       children={children}
+      isLoading={isLoading}
+      isValidating={isValidating}
       actions={
         <>
           <PrevButton
@@ -344,6 +346,8 @@ function TagUsageHeatmapCard({ tag }: { tag: Tag }) {
       usage={usage}
       totalUsage={totalUsage}
       interval={interval}
+      isLoading={isLoading}
+      isValidating={isValidating}
       actions={
         <>
           <PrevButton


### PR DESCRIPTION
Closes COBALT-21, COBALT-22, COBALT-23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit refresh/validation UI and stabilizes chart rendering.
> 
> - Usage UX: `UsageCard`, `PrevButton`/`NextButton`, and titles accept `isValidating`; spinners shown during validation and nav buttons disabled while loading/validating
> - Gantt: supports `...Validating` props for usages/streaks/interactions/system events; shows validating spinner in `InteractionInfoBar` and `DurationSummaries`
> - Pages (home, history, apps/[id], tags/[id], alerts/[id]): plumb `isValidating` from data hooks and render indicators; combine with loading states consistently
> - UsageChart: refactor to `useMemo` option, initialize ECharts once, update with `{ notMerge: true }`, add resize observer on `finished`, and separate zr/chart mousemove handlers to improve hover behavior and reactivity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13e48fb24318feaa85e4a9dc1f9fa2607c47bffb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->