### PR TITLE
Better UWP Icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.34",
+ "zerocopy",
 ]
 
 [[package]]
@@ -384,12 +384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,12 +709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,25 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,12 +899,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1379,21 +1342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide 0.8.3",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,16 +1738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,17 +1920,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -2398,24 +2325,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "exr",
- "gif",
- "jpeg-decoder",
- "num-traits",
- "png 0.17.16",
- "qoi",
- "tiff",
-]
-
-[[package]]
-name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
@@ -2575,15 +2484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,12 +2546,6 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
 ]
-
-[[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libappindicator"
@@ -3931,7 +3825,6 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "platform"
 version = "0.5.0"
 dependencies = [
- "image 0.24.9",
  "infer 0.15.0",
  "mime2ext",
  "rand 0.9.1",
@@ -4090,15 +3983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -4286,26 +4170,6 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -5627,7 +5491,7 @@ dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",
  "futures-util",
- "image 0.25.9",
+ "image",
  "jni",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -5889,17 +5753,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -6791,12 +6644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
 name = "whoami"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7619,16 +7466,7 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
- "zerocopy-derive 0.7.34",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive 0.8.27",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -7636,17 +7474,6 @@ name = "zerocopy-derive"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7719,15 +7546,6 @@ name = "zune-core"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -384,6 +384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +873,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +930,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1342,6 +1379,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide 0.8.3",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1982,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -2325,6 +2398,24 @@ dependencies = [
 
 [[package]]
 name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-traits",
+ "png 0.17.16",
+ "qoi",
+ "tiff",
+]
+
+[[package]]
+name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
@@ -2484,6 +2575,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2646,12 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
 ]
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libappindicator"
@@ -3825,6 +3931,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "platform"
 version = "0.5.0"
 dependencies = [
+ "image 0.24.9",
  "infer 0.15.0",
  "mime2ext",
  "rand 0.9.1",
@@ -3983,6 +4090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -4170,6 +4286,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -5491,7 +5627,7 @@ dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",
  "futures-util",
- "image",
+ "image 0.25.9",
  "jni",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -5753,6 +5889,17 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -6644,6 +6791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "whoami"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7466,7 +7619,16 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.34",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive 0.8.27",
 ]
 
 [[package]]
@@ -7474,6 +7636,17 @@ name = "zerocopy-derive"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7546,6 +7719,15 @@ name = "zune-core"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -19,7 +19,6 @@ util = { path = "../util" }
 mime2ext = "0.1.52"
 infer = "0.15.0"
 semver = "1.0.26"
-image = "0.24"
 
 [dependencies.windows-core]
 version = "0.59"

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -19,6 +19,7 @@ util = { path = "../util" }
 mime2ext = "0.1.52"
 infer = "0.15.0"
 semver = "1.0.26"
+image = "0.24"
 
 [dependencies.windows-core]
 version = "0.59"
@@ -30,6 +31,7 @@ features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Security",
     "Win32_UI_Shell_PropertiesSystem",
+    "Win32_UI_Shell",
     "Win32_Storage_EnhancedStorage",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Threading",
@@ -40,12 +42,15 @@ features = [
     "Win32_System_WinRT",
     "Win32_System_Time",
     "Win32_Graphics_Gdi",
+    "Win32_Graphics_Imaging",
     "Win32_System_RemoteDesktop",
     "Win32_System_Power",
     "Win32_System_SystemServices",
     "Win32_System_WindowsProgramming",
     "Win32_UI_Accessibility",
     "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_ProcessStatus",
     "Win32_System_Variant",

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use rand::seq::IndexedMutRandom;
 use util::error::{Context, Result};
-use util::tracing::ResultTraceExt;
+use util::tracing::{ResultTraceExt, warn};
 use windows::ApplicationModel::{AppDisplayInfo, AppInfo as UWPAppInfo};
 use windows::Foundation::Size;
 use windows::Storage::FileProperties::ThumbnailMode;
@@ -242,6 +242,10 @@ impl AppInfo {
         // Try shell method first for better icon quality
         if let Ok(icon) = Self::uwp_icon_from_shell(aumid) {
             return Ok(icon);
+        } else {
+            warn!(
+                "failed to get uwp icon from shell for {aumid:?}, falling back to GetLogo method"
+            );
         }
 
         // Fall back to GetLogo method if shell method fails
@@ -411,8 +415,8 @@ impl AppInfo {
 
         Ok(Icon {
             data: png_data,
-            ext: None,
-            mime: None, // Set mime to None as requested
+            ext: Some("png".to_string()),
+            mime: Some("image/png".to_string()),
         })
     }
 }

--- a/src/platform/src/objects/app_info.rs
+++ b/src/platform/src/objects/app_info.rs
@@ -9,10 +9,27 @@ use windows::Foundation::Size;
 use windows::Storage::FileProperties::ThumbnailMode;
 use windows::Storage::StorageFile;
 use windows::Storage::Streams::DataReader;
+use windows::Win32::Foundation::{HGLOBAL, SIZE};
+use windows::Win32::Graphics::Gdi::{DeleteObject, HGDIOBJ, HPALETTE};
+use windows::Win32::Graphics::Imaging::{
+    self, CLSID_WICImagingFactory, GUID_ContainerFormatPng, IWICBitmap, IWICBitmapEncoder,
+    IWICBitmapFrameEncode, IWICImagingFactory, WICBitmapAlphaChannelOption,
+};
 use windows::Win32::Storage::Packaging::Appx::{
     PackageNameAndPublisherIdFromFamilyName, ParseApplicationUserModelId,
 };
-use windows::core::{AgileReference, HSTRING, PCWSTR, PWSTR};
+use windows::Win32::System::Com::StructuredStorage::{
+    CreateStreamOnHGlobal, GetHGlobalFromStream, IPropertyBag2,
+};
+use windows::Win32::System::Com::{
+    CLSCTX_INPROC_SERVER, CoCreateInstance, STREAM_SEEK_END, STREAM_SEEK_SET,
+};
+use windows::Win32::System::Memory::{GlobalLock, GlobalUnlock};
+use windows::Win32::UI::Shell::{
+    IShellItem, IShellItemImageFactory, SHCreateItemFromParsingName, SIIGBF_BIGGERSIZEOK,
+    SIIGBF_ICONONLY,
+};
+use windows::core::{AgileReference, HSTRING, Interface, PCWSTR, PWSTR};
 
 use crate::adapt_size2;
 use crate::buf::WideBuffer;
@@ -91,7 +108,7 @@ impl Icon {
 /// Image size for Win32 apps
 pub const WIN32_IMAGE_SIZE: u32 = 64;
 /// Image size for UWP apps
-pub const UWP_IMAGE_SIZE: f32 = 256.0;
+pub const UWP_IMAGE_SIZE: i32 = 64;
 
 impl AppInfo {
     /// Create a default [AppInfo] from a Win32 path
@@ -176,7 +193,7 @@ impl AppInfo {
         let app_info = UWPAppInfo::GetFromAppUserModelId(&aumid.into())?;
         let display_info = app_info.DisplayInfo()?;
         let package = app_info.Package()?;
-        let icon = Self::uwp_icon(&display_info)
+        let icon = Self::uwp_icon(aumid, &display_info)
             .await
             .map(Some)
             .with_context(|| format!("get uwp icon for {aumid:?}"))
@@ -221,12 +238,18 @@ impl AppInfo {
         })
     }
 
-    async fn uwp_icon(display_info: &AppDisplayInfo) -> Result<Icon> {
+    async fn uwp_icon(aumid: &str, display_info: &AppDisplayInfo) -> Result<Icon> {
+        // Try shell method first for better icon quality
+        if let Ok(icon) = Self::uwp_icon_from_shell(aumid) {
+            return Ok(icon);
+        }
+
+        // Fall back to GetLogo method if shell method fails
         let (content_type, size, reader) = {
             let icon = display_info
                 .GetLogo(Size {
-                    Width: UWP_IMAGE_SIZE,
-                    Height: UWP_IMAGE_SIZE,
+                    Width: UWP_IMAGE_SIZE as f32,
+                    Height: UWP_IMAGE_SIZE as f32,
                 })?
                 .OpenReadAsync()?
                 .await?;
@@ -242,6 +265,154 @@ impl AppInfo {
             data,
             ext: None,
             mime: Some(content_type.to_string()),
+        })
+    }
+
+    fn uwp_icon_from_shell(aumid: &str) -> Result<Icon> {
+        // Construct the parsing name: shell:AppsFolder\<AUMID>
+        let parsing_name = format!("shell:AppsFolder\\{}", aumid);
+        let parsing_name_hstring = HSTRING::from(&parsing_name);
+        let parsing_name_pcwstr = PCWSTR::from_raw(parsing_name_hstring.as_ptr());
+
+        // Create shell item from parsing name
+        let shell_item: IShellItem = unsafe {
+            SHCreateItemFromParsingName(parsing_name_pcwstr, None)
+                .context("SHCreateItemFromParsingName failed")?
+        };
+
+        // Query for IShellItemImageFactory
+        let image_factory: IShellItemImageFactory = shell_item
+            .cast()
+            .context("Failed to cast to IShellItemImageFactory")?;
+
+        // Get the image as HBITMAP
+        let hbitmap = unsafe {
+            image_factory
+                .GetImage(
+                    SIZE {
+                        cx: UWP_IMAGE_SIZE,
+                        cy: UWP_IMAGE_SIZE,
+                    },
+                    SIIGBF_BIGGERSIZEOK | SIIGBF_ICONONLY,
+                )
+                .context("GetImage failed")?
+        };
+
+        // Use WIC to convert HBITMAP to PNG
+        let wic_factory: IWICImagingFactory = unsafe {
+            CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
+                .context("Failed to create WIC factory")?
+        };
+
+        // Create WIC bitmap from HBITMAP (use default palette and alpha channel)
+        let wic_bitmap: IWICBitmap = unsafe {
+            wic_factory
+                .CreateBitmapFromHBITMAP(
+                    hbitmap,
+                    HPALETTE::default(),
+                    WICBitmapAlphaChannelOption::default(),
+                )
+                .context("Failed to create WIC bitmap")?
+        };
+
+        // Clean up HBITMAP (WIC has its own copy)
+        unsafe {
+            let _ = DeleteObject(HGDIOBJ(hbitmap.0));
+        }
+
+        // Create in-memory stream using CreateStreamOnHGlobal
+        let stream = unsafe {
+            CreateStreamOnHGlobal(HGLOBAL::default(), true)
+                .context("Failed to create stream on HGlobal")?
+        };
+
+        // Create PNG encoder
+        let encoder: IWICBitmapEncoder = unsafe {
+            wic_factory
+                .CreateEncoder(&GUID_ContainerFormatPng, std::ptr::null())
+                .context("Failed to create PNG encoder")?
+        };
+
+        // Initialize encoder with stream
+        unsafe {
+            encoder
+                .Initialize(&stream, Imaging::WICBitmapEncoderNoCache)
+                .context("Failed to initialize encoder")?;
+        }
+
+        // Create frame encoder
+        let mut frame_encoder: Option<IWICBitmapFrameEncode> = None;
+        unsafe {
+            encoder
+                .CreateNewFrame(&mut frame_encoder, std::ptr::null_mut())
+                .context("Failed to create frame encoder")?;
+        }
+        let frame_encoder =
+            frame_encoder.ok_or_else(|| util::error::eyre!("Frame encoder is None"))?;
+
+        // Initialize frame (pass None for encoder options)
+        unsafe {
+            frame_encoder
+                .Initialize(None::<&IPropertyBag2>)
+                .context("Failed to initialize frame")?;
+        }
+
+        // Set source bitmap
+        unsafe {
+            frame_encoder
+                .WriteSource(&wic_bitmap, std::ptr::null())
+                .context("Failed to write source")?;
+        }
+
+        // Commit frame
+        unsafe {
+            frame_encoder.Commit().context("Failed to commit frame")?;
+        }
+
+        // Commit encoder
+        unsafe {
+            encoder.Commit().context("Failed to commit encoder")?;
+        }
+
+        // Get the size of the encoded data from the stream
+        let mut new_position = 0u64;
+        unsafe {
+            stream
+                .Seek(0, STREAM_SEEK_END, Some(&mut new_position))
+                .context("Failed to seek to end")?;
+        }
+        let stream_size = new_position;
+
+        // Seek back to beginning to read the data
+        unsafe {
+            stream
+                .Seek(0, STREAM_SEEK_SET, None)
+                .context("Failed to seek to beginning")?;
+        }
+
+        // Get the HGlobal from the stream and read the data
+        let stream_hglobal =
+            unsafe { GetHGlobalFromStream(&stream).context("Failed to get HGlobal from stream")? };
+
+        let ptr = unsafe { GlobalLock(stream_hglobal) };
+        if ptr.is_null() {
+            return Err(util::error::eyre!("Failed to lock global memory"));
+        }
+
+        let png_data = unsafe {
+            let slice = std::slice::from_raw_parts(ptr as *const u8, stream_size as usize);
+            slice.to_vec()
+        };
+
+        unsafe {
+            let _ = GlobalUnlock(stream_hglobal);
+            // Note: hglobal is freed automatically when stream is dropped
+        }
+
+        Ok(Icon {
+            data: png_data,
+            ext: None,
+            mime: None, // Set mime to None as requested
         })
     }
 }


### PR DESCRIPTION
Closes COBALT-36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves UWP icon retrieval and encoding for better quality and consistency.
> 
> - Add shell-based path to fetch UWP icons via `IShellItemImageFactory` and convert `HBITMAP` to PNG using WIC; fall back to `DisplayInfo.GetLogo` when needed
> - Change `UWP_IMAGE_SIZE` to `64` (i32) and update usage; `uwp_icon` now takes `aumid` for shell lookup and logs warnings on fallback
> - Introduce `HBitmapManaged` to ensure GDI `HBITMAP` cleanup
> - Expand Windows crate features in `Cargo.toml` (Shell, Imaging, COM StructuredStorage, Memory, etc.)
> - Add test for default UWP fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c14aba3b341d74873e293f2a8fc2d3f152397853. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->