### PR TITLE
fix: HorizontalOverflowList perf

### DIFF
--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -218,6 +218,9 @@ function AlertListItem({ alert }: { alert: Alert }) {
                 <HorizontalOverflowList
                   className="gap-1 h-6"
                   items={tagApps}
+                  // no need to ever render more than 25 apps,
+                  // the screen size will likely never be large enough
+                  maxItemCount={25}
                   renderItem={(app) => <MiniAppItem key={app.id} app={app} />}
                   renderOverflowItem={(app) => (
                     <MiniAppItem key={app.id} app={app} />

--- a/src/ui/app/routes/tags/index.tsx
+++ b/src/ui/app/routes/tags/index.tsx
@@ -285,6 +285,9 @@ function TagListItem({
           <HorizontalOverflowList
             className="gap-1 h-6 -mb-2"
             items={apps}
+            // no need to ever render more than 25 apps,
+            // the screen size will likely never be large enough
+            maxItemCount={25}
             renderItem={(app) => <MiniAppItem key={app.id} app={app} />}
             renderOverflowItem={(app) => <MiniAppItem key={app.id} app={app} />}
             renderOverflowSign={(items) => (


### PR DESCRIPTION
Closes COBALT-42

This PR adds a new `maxItemCount` optional parameter to the `HorizontalOverflowList` component to limit the number of items rendered. The component now slices the items array to respect this maximum count.

The implementation:
- Adds the parameter to the component props interface
- Applies the limit when rendering items
- Applies the limit to overflow items calculation

The feature is used in the alerts and tags routes, where a limit of 25 apps is set to prevent rendering an excessive number of app items, as the screen size would never be large enough to display more than that.