### PR TITLE
Unignore Alerts and Reminders

### DIFF
--- a/src/data/src/db/repo_crud.rs
+++ b/src/data/src/db/repo_crud.rs
@@ -914,11 +914,12 @@ impl Repository {
         Ok(())
     }
 
-    /// Create Alert event ignore
-    pub async fn create_alert_event_ignore(
+    /// Create Alert event
+    pub async fn create_alert_event(
         &mut self,
         alert_id: Ref<Alert>,
         timestamp: Timestamp,
+        reason: Reason,
     ) -> Result<()> {
         Self::insert_alert_event(
             &mut self.db.conn,
@@ -926,7 +927,7 @@ impl Repository {
                 id: Ref::new(0),
                 alert_id,
                 timestamp,
-                reason: Reason::Ignored,
+                reason,
             },
         )
         .await?;

--- a/src/data/src/entities.rs
+++ b/src/data/src/entities.rs
@@ -318,6 +318,8 @@ pub enum Reason {
     Hit,
     /// The [Alert]/[Reminder] was ignored
     Ignored,
+    /// The [Alert]/[Reminder] was unignored
+    Unignored,
 }
 
 /// An instance of [Alert] triggering.

--- a/src/data/src/queries/triggered_alerts.sql
+++ b/src/data/src/queries/triggered_alerts.sql
@@ -54,5 +54,5 @@ SELECT al.*, ae.timestamp, (CASE WHEN al.app_id IS NOT NULL THEN (
     LEFT JOIN latest_alert_event ae
         ON al.id = ae.alert_id
     WHERE d.dur >= al.usage_limit AND al.active <> 0 AND
-        (ae.reason IS NULL OR ae.reason = 0)
+        (ae.reason IS NULL OR ae.reason <> 1) -- either no event or not ignored
     GROUP BY al.id

--- a/src/ui/app/lib/entities.ts
+++ b/src/ui/app/lib/entities.ts
@@ -197,7 +197,7 @@ export interface SystemEvent {
   event: SystemEventEnum;
 }
 
-export type Reason = "hit" | "ignored";
+export type Reason = "hit" | "ignored" | "unignored";
 
 export interface AlertEvent {
   id: Ref<AlertEvent>;

--- a/src/ui/app/lib/repo.ts
+++ b/src/ui/app/lib/repo.ts
@@ -4,6 +4,7 @@ import type {
   App,
   Duration as DataDuration,
   InteractionPeriod,
+  Reason,
   Ref,
   Reminder,
   ReminderEvent,
@@ -210,11 +211,16 @@ export async function removeAlert(alertId: Ref<Alert>): Promise<void> {
   return await invoke("remove_alert", { alertId });
 }
 
-export async function createAlertEventIgnore(
+export async function createAlertEvent(
   alertId: Ref<Alert>,
   timestamp: Timestamp,
+  reason: Reason,
 ): Promise<void> {
-  return await invoke("create_alert_event_ignore", { alertId, timestamp });
+  return await invoke("create_alert_event", {
+    alertId,
+    timestamp,
+    reason,
+  });
 }
 
 export async function getAppSessionUsages({

--- a/src/ui/app/lib/state.ts
+++ b/src/ui/app/lib/state.ts
@@ -4,7 +4,7 @@ import type { Alert, App, Ref, Tag } from "@/lib/entities";
 import { info } from "@/lib/log";
 import {
   createAlert,
-  createAlertEventIgnore,
+  createAlertEvent,
   createTag,
   getAlerts,
   getApps,
@@ -143,7 +143,7 @@ interface AppState {
   createAlert: (tag: CreateAlert) => Promise<Ref<Alert>>;
   updateAlert: (prev: Alert, next: UpdatedAlert) => Promise<Ref<Alert>>;
   removeAlert: (tagId: Ref<Alert>) => Promise<void>;
-  ignoreAlert: (alertId: Ref<Alert>) => Promise<void>;
+  toggleAlert: (alert: Alert) => Promise<void>;
 }
 
 export const useAppState = create<AppState>((set) => {
@@ -232,9 +232,13 @@ export const useAppState = create<AppState>((set) => {
         })(state),
       );
     },
-    ignoreAlert: async (alertId) => {
+    toggleAlert: async (alert) => {
       const now = DateTime.now();
-      await createAlertEventIgnore(alertId, dateTimeToTicks(now));
+      await createAlertEvent(
+        alert.id,
+        dateTimeToTicks(now),
+        alert.status.tag === "ignored" ? "unignored" : "ignored",
+      );
       await refreshParts(now, set, { refreshAlerts: true });
     },
   };

--- a/src/ui/src-tauri/src/lib.rs
+++ b/src/ui/src-tauri/src/lib.rs
@@ -55,7 +55,7 @@ pub fn run() {
             repo::create_alert,
             repo::update_alert,
             repo::remove_alert,
-            repo::create_alert_event_ignore,
+            repo::create_alert_event,
             repo::get_app_session_usages,
             repo::get_interaction_periods,
             repo::get_system_events,

--- a/src/ui/src-tauri/src/repo.rs
+++ b/src/ui/src-tauri/src/repo.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use data::db::infused;
 use data::entities::{
-    Alert, AlertEvent, App, InteractionPeriod, Period, Ref, SystemEvent, Tag, Timestamp,
+    Alert, AlertEvent, App, InteractionPeriod, Period, Reason, Ref, SystemEvent, Tag, Timestamp,
 };
 use tauri::State;
 use util::error::Context;
@@ -298,16 +298,17 @@ pub async fn remove_alert(state: State<'_, AppState>, alert_id: Ref<Alert>) -> A
 
 #[tauri::command]
 #[tracing::instrument(err, skip(state))]
-pub async fn create_alert_event_ignore(
+pub async fn create_alert_event(
     state: State<'_, AppState>,
     alert_id: Ref<Alert>,
     timestamp: Timestamp,
+    reason: Reason,
 ) -> AppResult<()> {
     let mut repo = {
         let state = state.read().await;
         state.assume_init().get_repo().await?
     };
-    Ok(repo.create_alert_event_ignore(alert_id, timestamp).await?)
+    Ok(repo.create_alert_event(alert_id, timestamp, reason).await?)
 }
 
 #[tauri::command]


### PR DESCRIPTION
Closes COBALT-12

This PR adds the ability to unignore alerts and reminders that were previously ignored. The implementation includes:

- Renamed `create_alert_event_ignore` to `create_alert_event` with a new `reason` parameter to support different event types
- Added a new `Unignored` reason type to the `Reason` enum
- Updated SQL queries to properly handle unignore events when determining triggered alerts and reminders
- Modified the UI to display an "Unignore" button when an alert is ignored
- Added timeline visualization for unignore events with blue color coding
- Added comprehensive test coverage for various ignore/unignore scenarios

The logic ensures that:
- Alerts that are unignored will trigger if their usage threshold is exceeded
- Reminders follow the same pattern, triggering when appropriate after being unignored
- The UI clearly shows the current state and allows toggling between ignored and unignored states

This change improves user experience by allowing temporary ignoring of alerts without having to recreate them later.