### PR TITLE
Support MSI Updates with Restart Manager

### DIFF
--- a/src/ui/src-tauri/installer/main.wxs
+++ b/src/ui/src-tauri/installer/main.wxs
@@ -28,13 +28,6 @@
                  InstallScope="perMachine"
                  SummaryCodepage="!(loc.TauriCodepage)"/>
 
-        <!-- Force terminate application during uninstall/upgrade.
-        None of our bins use Restart Manager, so we force kill them
-        after Restart Manager fails to gracefully kill them -->
-        <Property Id="MSIRMSHUTDOWN" Value="1" />
-        <Property Id="MSIRESTARTMANAGERCONTROL" Value="DisableShutdown" />
-        <!-- <Property Id="MSIFASTINSTALL" Value="1" /> -->
-
         <!-- https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode -->
         <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
         <Property Id="REINSTALLMODE" Value="amus" />


### PR DESCRIPTION
This PR enhances how the application handles Windows MSI updates by properly responding to Restart Manager requests:

1. Restructured the main event loop to run on the main thread instead of a separate thread
2. Added proper handling of Windows Restart Manager messages:
   - Responds to `WM_QUERYENDSESSION` with a positive response when receiving `ENDSESSION_CLOSEAPP`
   - Gracefully exits the application when receiving `WM_ENDSESSION` with `ENDSESSION_CLOSEAPP`
3. Removed custom MSI installer properties that were forcing application termination during updates, as the application now properly handles shutdown requests

These changes allow the application to gracefully shut down during Windows updates or MSI installations, improving the user experience and preventing potential data loss during updates.