### PR TITLE
Better Git Worktree Setup

### DIFF
--- a/.cursor/rules/worktree-agent-dev.mdc
+++ b/.cursor/rules/worktree-agent-dev.mdc
@@ -1,0 +1,22 @@
+---
+alwaysApply: true
+---
+## Worktree / Agent Dev Workflow (Windows)
+
+**CRITICAL**: When working in a Cursor worktree or agent context on this project, you MUST follow these steps:
+
+### Required Steps:
+
+1. **ALWAYS use `bun dev:agent`** - NEVER use `bun dev` directly. The `dev:agent` script assigns random ports to avoid conflicts when multiple worktrees run in parallel.
+
+2. **Do NOT launch a browser manually** - The Tauri app will launch its own window automatically. Do not open a browser to the dev server URL.
+
+3. **Wait for MCP port** - After running `bun dev:agent`, wait for the output line `MCP Port: <port>`. The Tauri MCP bridge uses a random port (not the default). Extract this port number from the output.
+
+4. **Use Tauri MCP, not browser MCP** - Once the MCP port is available, use the Tauri MCP server (not browser-based MCP tools) to interact with the application.
+
+### Summary:
+- ✅ Run: `bun dev:agent`
+- ✅ Wait for: `MCP Port: <port>` in output
+- ❌ Do NOT run: `bun dev`
+- ❌ Do NOT manually open browser to dev server URL

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,6 @@
+{
+  "setup-worktree-windows": [
+    "bun i",
+    "cargo build"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ cargo build
 
 # Run the UI
 bun dev
+# Run the UI (for Agents / Git Worktrees)
+bun dev:agent
 # Run the Engine
 cargo run --bin engine
 

--- a/dev/dev-agent.ps1
+++ b/dev/dev-agent.ps1
@@ -1,0 +1,10 @@
+$env:TAURI_DEV_MCP_PORT = (Get-Random -Minimum 5000 -Maximum 65535)
+$env:TAURI_DEV_PORT = (Get-Random -Minimum 5000 -Maximum 65535)
+$env:TAURI_CLI_PORT = (Get-Random -Minimum 5000 -Maximum 65535)
+
+Write-Output "MCP Port: $env:TAURI_DEV_MCP_PORT"
+Write-Output "Frontend Port: $env:TAURI_DEV_PORT"
+Write-Output "CLI Port: $env:TAURI_CLI_PORT"
+
+
+bun dev --config "{`\`"build`\`": { `\`"devUrl`\`": `\`"http://localhost:$env:TAURI_DEV_PORT`\`"}}"

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -41,6 +41,8 @@ cargo build
 
 # Run the UI
 bun dev
+# Run the UI (for Agents / Git Worktrees)
+bun dev:agent
 # Run the Engine
 cargo run --bin engine
 

--- a/docs/DEV_GUIDE_UI.md
+++ b/docs/DEV_GUIDE_UI.md
@@ -73,7 +73,7 @@ src/ui/
 ### Local Development
 
 1. Run `bun i`
-1. Start the development server: `bun dev`
+1. Start the development server: `bun dev` or `bun dev:agent` (for Agents / Git Worktrees)
 
 The development server includes:
 - Hot-reloading for React components
@@ -88,7 +88,7 @@ In dev mode, we can setup the Tauri MCP server (https://github.com/hypothesi/mcp
 npx -y install-mcp @hypothesi/tauri-mcp-server --client cursor
 ```
 
-Running `bun dev` will start the MCP server and make it available to Cursor. See their docs to see what's possible via MCP.
+Running `bun dev` or `bun dev:agent` (for Agents / Git Worktrees) will start the MCP server and make it available to Cursor. See their docs to see what's possible via MCP.
 
 ### Recommended VS Code Extensions
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": ["src/ui"],
   "scripts": {
     "dev": "bun --cwd src/ui tauri:dev",
+    "dev:agent": "powershell ./dev/dev-agent.ps1",
     "build": "bun --cwd src/ui tauri:build",
     "typecheck": "bun --cwd src/ui typecheck",
     "format": "bun --cwd src/ui format",

--- a/src/ui/src-tauri/src/lib.rs
+++ b/src/ui/src-tauri/src/lib.rs
@@ -16,7 +16,19 @@ pub fn run() {
     util::set_target(Target::Ui);
 
     #[cfg(debug_assertions)]
-    let builder = tauri::Builder::default().plugin(tauri_plugin_mcp_bridge::init());
+    let builder = tauri::Builder::default().plugin(tauri_plugin_mcp_bridge::init_with_config({
+        use util::error::Context;
+
+        let port = std::env::var("TAURI_DEV_MCP_PORT");
+        if let Ok(port) = port {
+            tauri_plugin_mcp_bridge::Config {
+                base_port: port.parse().context("invalid MCP port").unwrap(),
+                ..Default::default()
+            }
+        } else {
+            tauri_plugin_mcp_bridge::Config::default()
+        }
+    }));
     #[cfg(not(debug_assertions))]
     let builder =
         tauri::Builder::default().plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -38,6 +38,13 @@ export default defineConfig({
     },
   },
   plugins: [reactRouter(), tsconfigPaths(), devToolsJson()],
+  optimizeDeps: {
+    // Routes in app and the corresponding type definitions are not
+    // automatically included in the dependency graph, so we need to
+    // explicitly include them here for vite prebunding optimization
+    // during development
+    entries: ["app/**/*.ts{x,}", ".react-router/**/*.ts{x,}"],
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./app"),

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -6,6 +6,7 @@ import devToolsJson from "vite-plugin-devtools-json";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 const host = process.env.TAURI_DEV_HOST;
+const port = process.env.TAURI_DEV_PORT ?? "5173";
 
 export default defineConfig({
   // prevent vite from obscuring rust errors
@@ -15,7 +16,7 @@ export default defineConfig({
     strictPort: true,
     // if the host Tauri is expecting is set, use it
     host: host ?? false,
-    port: 5173,
+    port: parseInt(port),
   },
   // Env variables starting with the item of `envPrefix` will be exposed in tauri's source code through `import.meta.env`.
   envPrefix: ["VITE_", "TAURI_ENV_*"],


### PR DESCRIPTION
This PR adds proper support for Windows development environments when using Git worktrees or Cursor agents. Key improvements include:

- Added `bun dev:agent` command that assigns random ports to avoid conflicts when multiple worktrees run in parallel
- Created PowerShell script (`dev-agent.ps1`) to handle port assignment for Tauri, MCP, and CLI services
- Modified Tauri configuration to accept custom MCP port from environment variables
- Added Cursor worktree configuration and development rules
- Updated documentation in README and DEV_GUIDE files to include worktree-specific instructions
- Improved Vite configuration to handle dynamic port assignment
- Added explicit dependency entries in Vite config for better prebundling optimization

These changes ensure developers can work with multiple worktrees simultaneously without port conflicts, particularly important for Windows environments.