### PR TITLE
Fixup COM issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,19 +125,28 @@ jobs:
   integration:
     runs-on: windows-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust Toolchain
         uses: dtolnay/rust-toolchain@1.88.0
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Set up Python
         run: uv python install
       - name: Ruff Format
+        if: matrix.group == 1
         run: uv run ruff format --check
       - name: Ruff Check
+        if: matrix.group == 1
         run: uv run ruff check --output-format=github
-      - name: Run tests
-        run: uv run --exact --package integration-py  pytest -o log_cli_level=INFO -v
+      - name: Run tests (group ${{ matrix.group }}/4)
+        run: uv run --exact --package integration-py pytest -o log_cli_level=INFO -v --splits 4 --group ${{ matrix.group }}

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -86,6 +86,9 @@ fn setup() -> Result<(Config, Runtime)> {
     let rt = Builder::new_multi_thread()
         .enable_time()
         .enable_io()
+        .on_thread_start(|| {
+            platform::setup_thread_com().expect("com init on tokio worker");
+        })
         .build()?;
 
     Ok((config, rt))

--- a/tests/integration-py/driver.py
+++ b/tests/integration-py/driver.py
@@ -14,7 +14,7 @@ from wasabi import color
 
 logger = logging.getLogger(__name__)
 
-TOLERANCE_MS = 200
+TOLERANCE_MS = 400
 
 
 class DriverData:

--- a/tests/integration-py/pyproject.toml
+++ b/tests/integration-py/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pyautogui>=0.9.54",
     "pytest>=8.4.1",
+    "pytest-split>=0.9.0",
     "pywin32>=311",
     "selenium>=4.34.2",
     "wasabi>=1.1.3",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Windows COM initialization and UIA event handler lifecycle, where mistakes can cause subtle deadlocks/crashes or missed events; CI/test changes are low risk but may hide flakes via increased tolerances and sharding.
> 
> **Overview**
> Fixes Windows COM/UIA shutdown and threading issues by initializing COM as **STA** on the main platform thread, adding `setup_thread_com()` for **MTA** init on Tokio worker threads, and making `PropertyChange` teardown skip COM calls when `AgileReference::resolve()` fails during process shutdown.
> 
> Speeds up CI integration runs by splitting Python integration tests into a 4-way matrix via `pytest-split`, running Ruff only once, and sharing the Rust cache key across those jobs; also relaxes timestamp comparison tolerance in integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c37e67f372885cef61beeba0fedbdd01a249e17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->