### PR TITLE
Add hover cards for apps, tags, and alerts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-progress": "^1.1.7",
@@ -296,6 +297,8 @@
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
 
+    "@radix-ui/react-hover-card": ["@radix-ui/react-hover-card@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg=="],
+
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
     "@radix-ui/react-label": ["@radix-ui/react-label@2.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ=="],
@@ -304,7 +307,7 @@
 
     "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.7", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw=="],
 
-    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
 
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
 
@@ -1436,7 +1439,19 @@
 
     "@npmcli/promise-spawn/which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
 
-    "@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
+    "@radix-ui/react-hover-card/@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-hover-card/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-hover-card/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
+
+    "@radix-ui/react-select/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
 
     "@react-router/dev/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
@@ -1518,7 +1533,13 @@
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.6.12", "", { "dependencies": { "@floating-ui/core": "^1.6.0", "@floating-ui/utils": "^0.2.8" } }, "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w=="],
+    "@radix-ui/react-menu/@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
+
+    "@radix-ui/react-select/@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
@@ -1546,8 +1567,28 @@
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.6.8", "", { "dependencies": { "@floating-ui/utils": "^0.2.8" } }, "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA=="],
+    "@radix-ui/react-menu/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.6.12", "", { "dependencies": { "@floating-ui/core": "^1.6.0", "@floating-ui/utils": "^0.2.8" } }, "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w=="],
 
-    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.8", "", {}, "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="],
+    "@radix-ui/react-popover/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.6.12", "", { "dependencies": { "@floating-ui/core": "^1.6.0", "@floating-ui/utils": "^0.2.8" } }, "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w=="],
+
+    "@radix-ui/react-select/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.6.12", "", { "dependencies": { "@floating-ui/core": "^1.6.0", "@floating-ui/utils": "^0.2.8" } }, "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.6.12", "", { "dependencies": { "@floating-ui/core": "^1.6.0", "@floating-ui/utils": "^0.2.8" } }, "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.6.8", "", { "dependencies": { "@floating-ui/utils": "^0.2.8" } }, "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.8", "", {}, "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.6.8", "", { "dependencies": { "@floating-ui/utils": "^0.2.8" } }, "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.8", "", {}, "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="],
+
+    "@radix-ui/react-select/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.6.8", "", { "dependencies": { "@floating-ui/utils": "^0.2.8" } }, "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.8", "", {}, "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.6.8", "", { "dependencies": { "@floating-ui/utils": "^0.2.8" } }, "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.8", "", {}, "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="],
   }
 }

--- a/src/ui/app/components/alert/alert-hover-card.tsx
+++ b/src/ui/app/components/alert/alert-hover-card.tsx
@@ -1,0 +1,164 @@
+import { StatusBadge } from "@/components/alert/status-badge";
+import { TriggerActionIndicator } from "@/components/alert/trigger-action";
+import AppIcon from "@/components/app/app-icon";
+import { DurationText } from "@/components/time/duration-text";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/text";
+import { useApp, useTag } from "@/hooks/use-refresh";
+import type { Alert } from "@/lib/entities";
+import { timeFrameToLabel } from "@/lib/entities";
+import { ArrowRightIcon, ClockAlertIcon, TagIcon } from "lucide-react";
+import { useMemo, type ReactNode } from "react";
+import { NavLink } from "react-router";
+
+export function AlertHoverCard({
+  alert,
+  children,
+}: {
+  alert: Alert;
+  children: ReactNode;
+}) {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="w-80">
+        <AlertHoverCardContent alert={alert} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function AlertHoverCardContent({ alert }: { alert: Alert }) {
+  const app = useApp(alert.target.tag === "app" ? alert.target.id : null);
+  const tag = useTag(alert.target.tag === "tag" ? alert.target.id : null);
+  const targetEntity = app ?? tag;
+
+  const currentUsage = useMemo(() => {
+    const usages = alert.target.tag === "app" ? app?.usages : tag?.usages;
+    if (!usages) return 0;
+    switch (alert.timeFrame) {
+      case "daily":
+        return usages.today;
+      case "weekly":
+        return usages.week;
+      case "monthly":
+        return usages.month;
+    }
+  }, [alert, app, tag]);
+
+  const progress = Math.min(
+    (currentUsage / (alert.usageLimit || 1)) * 100,
+    100,
+  );
+
+  const targetLink = app ? `/apps/${app.id}` : tag ? `/tags/${tag.id}` : "#";
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        {app ? (
+          <AppIcon app={app} className="w-10 h-10 shrink-0" />
+        ) : tag ? (
+          <TagIcon
+            className="w-10 h-10 shrink-0"
+            style={{ color: tag.color }}
+          />
+        ) : null}
+        <div className="flex flex-col min-w-0 gap-1">
+          <NavLink
+            to={targetLink}
+            className="hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Text className="font-semibold">
+              {targetEntity?.name ?? "Unknown"}
+            </Text>
+          </NavLink>
+          <div className="flex items-center gap-2">
+            <StatusBadge status={alert.status} className="text-xs h-5" />
+            <TriggerActionIndicator
+              action={alert.triggerAction}
+              className="text-xs"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-sm">
+          <div className="flex items-center gap-1.5">
+            <DurationText ticks={currentUsage} className="font-medium" />
+            <span className="text-muted-foreground">
+              ({Math.round(progress)}%)
+            </span>
+          </div>
+          <div className="flex items-center gap-1 text-muted-foreground text-xs">
+            <DurationText ticks={alert.usageLimit} />
+            <span>/</span>
+            <span>{timeFrameToLabel(alert.timeFrame)}</span>
+          </div>
+        </div>
+        <Progress value={progress} className="h-1.5 rounded-sm" />
+      </div>
+
+      {alert.reminders.length > 0 && (
+        <>
+          <Separator />
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <ClockAlertIcon className="size-3.5" />
+            <span>
+              {alert.reminders.length} Reminder
+              {alert.reminders.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </>
+      )}
+
+      {targetEntity && (
+        <>
+          <Separator />
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div>
+              <div className="text-xs text-muted-foreground">Today</div>
+              <DurationText
+                ticks={targetEntity.usages.today}
+                className="text-sm font-medium"
+              />
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Week</div>
+              <DurationText
+                ticks={targetEntity.usages.week}
+                className="text-sm font-medium"
+              />
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Month</div>
+              <DurationText
+                ticks={targetEntity.usages.month}
+                className="text-sm font-medium"
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      <Separator />
+
+      <NavLink
+        to={`/alerts/${alert.id}`}
+        className="text-sm text-primary hover:underline inline-flex items-center gap-1 self-start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        View Details
+        <ArrowRightIcon className="size-3" />
+      </NavLink>
+    </div>
+  );
+}

--- a/src/ui/app/components/alert/alert-hover-card.tsx
+++ b/src/ui/app/components/alert/alert-hover-card.tsx
@@ -1,6 +1,7 @@
 import { StatusBadge } from "@/components/alert/status-badge";
 import { TriggerActionIndicator } from "@/components/alert/trigger-action";
 import AppIcon from "@/components/app/app-icon";
+import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
 import {
   HoverCard,
@@ -13,7 +14,7 @@ import { Text } from "@/components/ui/text";
 import { useApp, useTag } from "@/hooks/use-refresh";
 import type { Alert } from "@/lib/entities";
 import { timeFrameToLabel } from "@/lib/entities";
-import { ArrowRightIcon, ClockAlertIcon, TagIcon } from "lucide-react";
+import { ArrowRightIcon, ClockAlertIcon } from "lucide-react";
 import { useMemo, type ReactNode } from "react";
 import { NavLink } from "react-router";
 
@@ -65,10 +66,7 @@ function AlertHoverCardContent({ alert }: { alert: Alert }) {
         {app ? (
           <AppIcon app={app} className="w-10 h-10 shrink-0" />
         ) : tag ? (
-          <TagIcon
-            className="w-10 h-10 shrink-0"
-            style={{ color: tag.color }}
-          />
+          <TagIcon tag={tag} className="w-10 h-10 shrink-0" />
         ) : null}
         <div className="flex flex-col min-w-0 gap-1">
           <NavLink

--- a/src/ui/app/components/alert/choose-target.tsx
+++ b/src/ui/app/components/alert/choose-target.tsx
@@ -11,6 +11,7 @@ import { SearchBar } from "@/components/search-bar";
 import { CreateTagDialog } from "@/components/tag/create-tag-dialog";
 import { ScoreCircle } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -25,7 +26,7 @@ import type { tagSchema } from "@/lib/schema";
 import { useAppState } from "@/lib/state";
 import { cn } from "@/lib/utils";
 import { useConcatVirtualItems, useVirtualSection } from "@/lib/virtualization";
-import { ChevronDown, ChevronRight, Plus, TagIcon } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -111,10 +112,7 @@ export function ChooseTarget({
           >
             <TagHoverCard tag={tag}>
               <div className="inline-flex items-center gap-2 min-w-0">
-                <TagIcon
-                  className="w-4 h-4 shrink-0"
-                  style={{ color: tag.color }}
-                />
+                <TagIcon tag={tag} className="w-4 h-4 shrink-0" />
                 <Text>{tag.name}</Text>
                 <ScoreCircle score={tag.score} />
               </div>
@@ -297,10 +295,7 @@ function ChooseTargetTrigger({
       ) : value?.tag === "tag" && tag ? (
         <TagHoverCard tag={tag}>
           <span className="inline-flex items-center gap-2">
-            <TagIcon
-              className="w-5 h-5 shrink-0"
-              style={{ color: tag.color }}
-            />
+            <TagIcon tag={tag} className="w-5 h-5 shrink-0" />
             <Text>{tag.name}</Text>
             <ScoreCircle score={tag.score} />
           </span>

--- a/src/ui/app/components/alert/choose-target.tsx
+++ b/src/ui/app/components/alert/choose-target.tsx
@@ -1,3 +1,4 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { MiniTagItem } from "@/components/app/choose-multi-apps";
 import {
@@ -9,6 +10,7 @@ import {
 import { SearchBar } from "@/components/search-bar";
 import { CreateTagDialog } from "@/components/tag/create-tag-dialog";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -107,12 +109,16 @@ export function ChooseTarget({
             )}
             onClick={() => onValueChanged({ tag: "tag", id: tag.id })}
           >
-            <TagIcon
-              className="w-4 h-4 shrink-0"
-              style={{ color: tag.color }}
-            />
-            <Text>{tag.name}</Text>
-            <ScoreCircle score={tag.score} />
+            <TagHoverCard tag={tag}>
+              <div className="inline-flex items-center gap-2 min-w-0">
+                <TagIcon
+                  className="w-4 h-4 shrink-0"
+                  style={{ color: tag.color }}
+                />
+                <Text>{tag.name}</Text>
+                <ScoreCircle score={tag.score} />
+              </div>
+            </TagHoverCard>
           </button>
         </div>
       ),
@@ -196,8 +202,12 @@ export function ChooseTarget({
             )}
             onClick={() => onValueChanged({ tag: "app", id: app.id })}
           >
-            <AppIcon app={app} className="w-4 h-4 shrink-0" />
-            <Text>{app.name}</Text>
+            <AppHoverCard app={app}>
+              <div className="inline-flex items-center gap-2 min-w-0">
+                <AppIcon app={app} className="w-4 h-4 shrink-0" />
+                <Text>{app.name}</Text>
+              </div>
+            </AppHoverCard>
             <MiniTagItem tagId={app.tagId} />
           </button>
         </div>
@@ -278,16 +288,23 @@ function ChooseTargetTrigger({
       className={cn("flex gap-2 items-center", className)}
     >
       {value?.tag === "app" && app ? (
-        <>
-          <AppIcon app={app} className="w-5 h-5 shrink-0" />
-          <Text>{app.name}</Text>
-        </>
+        <AppHoverCard app={app}>
+          <span className="inline-flex items-center gap-2">
+            <AppIcon app={app} className="w-5 h-5 shrink-0" />
+            <Text>{app.name}</Text>
+          </span>
+        </AppHoverCard>
       ) : value?.tag === "tag" && tag ? (
-        <>
-          <TagIcon className="w-5 h-5 shrink-0" style={{ color: tag.color }} />
-          <Text>{tag.name}</Text>
-          <ScoreCircle score={tag.score} />
-        </>
+        <TagHoverCard tag={tag}>
+          <span className="inline-flex items-center gap-2">
+            <TagIcon
+              className="w-5 h-5 shrink-0"
+              style={{ color: tag.color }}
+            />
+            <Text>{tag.name}</Text>
+            <ScoreCircle score={tag.score} />
+          </span>
+        </TagHoverCard>
       ) : (
         (placeholder ?? (
           <Text className="text-muted-foreground">Choose Target</Text>

--- a/src/ui/app/components/app/app-hover-card.tsx
+++ b/src/ui/app/components/app/app-hover-card.tsx
@@ -1,0 +1,137 @@
+import AppIcon from "@/components/app/app-icon";
+import { ScoreCircle } from "@/components/tag/score";
+import { DurationText } from "@/components/time/duration-text";
+import { Badge } from "@/components/ui/badge";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/text";
+import { useTag } from "@/hooks/use-refresh";
+import type { App } from "@/lib/entities";
+import { ArrowRightIcon, TagIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { NavLink } from "react-router";
+
+export function AppHoverCard({
+  app,
+  children,
+}: {
+  app: App;
+  children: ReactNode;
+}) {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="w-80">
+        <AppHoverCardContent app={app} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function AppHoverCardContent({ app }: { app: App }) {
+  const tag = useTag(app.tagId);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <AppIcon app={app} className="w-10 h-10 shrink-0" />
+        <div className="flex flex-col min-w-0 gap-1">
+          <Text className="font-semibold">{app.name}</Text>
+          {app.identity.tag !== "website" && app.company && (
+            <Text className="text-sm text-muted-foreground">{app.company}</Text>
+          )}
+        </div>
+      </div>
+
+      {tag && (
+        <NavLink
+          to={`/tags/${tag.id}`}
+          className="inline-flex self-start"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Badge
+            variant="outline"
+            style={{
+              borderColor: tag.color,
+              color: tag.color,
+              backgroundColor: "rgba(255, 255, 255, 0.2)",
+            }}
+            className="whitespace-nowrap hover:opacity-80 transition-opacity"
+          >
+            <TagIcon className="size-3 mr-1" />
+            <Text className="max-w-32">{tag.name}</Text>
+            <ScoreCircle score={tag.score} className="ml-1.5" />
+          </Badge>
+        </NavLink>
+      )}
+
+      {app.description && (
+        <Text className="text-sm text-muted-foreground line-clamp-2">
+          {app.description}
+        </Text>
+      )}
+
+      <div className="text-xs inline-flex items-center border border-border rounded-md overflow-hidden bg-muted/30 self-start max-w-full">
+        <div className="bg-muted px-2 py-1 border-r border-border font-medium shrink-0">
+          {app.identity.tag === "uwp"
+            ? "UWP"
+            : app.identity.tag === "win32"
+              ? "Win32"
+              : app.identity.tag === "website"
+                ? "Web"
+                : "Squirrel"}
+        </div>
+        <Text className="font-mono px-2 py-1 text-muted-foreground">
+          {app.identity.tag === "uwp"
+            ? app.identity.aumid
+            : app.identity.tag === "win32"
+              ? app.identity.path
+              : app.identity.tag === "website"
+                ? app.identity.baseUrl
+                : app.identity.identifier}
+        </Text>
+      </div>
+
+      <Separator />
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <div>
+          <div className="text-xs text-muted-foreground">Today</div>
+          <DurationText
+            ticks={app.usages.today}
+            className="text-sm font-medium"
+          />
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Week</div>
+          <DurationText
+            ticks={app.usages.week}
+            className="text-sm font-medium"
+          />
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Month</div>
+          <DurationText
+            ticks={app.usages.month}
+            className="text-sm font-medium"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <NavLink
+        to={`/apps/${app.id}`}
+        className="text-sm text-primary hover:underline inline-flex items-center gap-1 self-start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        View Details
+        <ArrowRightIcon className="size-3" />
+      </NavLink>
+    </div>
+  );
+}

--- a/src/ui/app/components/app/app-hover-card.tsx
+++ b/src/ui/app/components/app/app-hover-card.tsx
@@ -1,5 +1,6 @@
 import AppIcon from "@/components/app/app-icon";
 import { ScoreCircle } from "@/components/tag/score";
+import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -11,7 +12,7 @@ import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/text";
 import { useTag } from "@/hooks/use-refresh";
 import type { App } from "@/lib/entities";
-import { ArrowRightIcon, TagIcon } from "lucide-react";
+import { ArrowRightIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { NavLink } from "react-router";
 
@@ -62,7 +63,7 @@ function AppHoverCardContent({ app }: { app: App }) {
             }}
             className="whitespace-nowrap hover:opacity-80 transition-opacity"
           >
-            <TagIcon className="size-3 mr-1" />
+            <TagIcon tag={tag} className="size-3 mr-1" />
             <Text className="max-w-32">{tag.name}</Text>
             <ScoreCircle score={tag.score} className="ml-1.5" />
           </Badge>

--- a/src/ui/app/components/app/app-icon.tsx
+++ b/src/ui/app/components/app/app-icon.tsx
@@ -7,7 +7,7 @@ import {
   CircleHelp as CircleHelpStatic,
   Tag as TagStatic,
 } from "lucide-static";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ComponentPropsWithoutRef } from "react";
 
 export const DEFAULT_ICON_SVG_URL = "data:image/svg+xml," + CircleHelpStatic;
 export const TAG_ICON_URL = "data:image/svg+xml," + TagStatic;
@@ -38,10 +38,11 @@ export function tagIconUrl(color?: string) {
 export default function AppIcon({
   app,
   className,
+  ...rest
 }: {
   app?: App;
   className?: ClassValue;
-}) {
+} & Omit<ComponentPropsWithoutRef<"div">, "children" | "className">) {
   const [hasError, setHasError] = useState(false);
   const [icon, setIcon] = useState<string | null>(() =>
     app?.hasIcon ? appIconUrl(app) : null,
@@ -62,7 +63,11 @@ export default function AppIcon({
   }, [app?.id, app?.hasIcon]);
 
   if (!icon || hasError) {
-    return <CircleHelp className={cn("text-foreground", className)} />;
+    return (
+      <div className={cn("text-foreground", className)} {...rest}>
+        <CircleHelp className="w-full h-full" />
+      </div>
+    );
   }
 
   return (
@@ -70,6 +75,7 @@ export default function AppIcon({
       className={cn(className)}
       src={icon}
       onError={() => setHasError(true)}
+      {...rest}
     />
   );
 }

--- a/src/ui/app/components/app/app-list-item.tsx
+++ b/src/ui/app/components/app/app-list-item.tsx
@@ -1,3 +1,4 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { Badge } from "@/components/ui/badge";
 import { Text } from "@/components/ui/text";
@@ -12,8 +13,12 @@ export function AppBadge({ app, remove }: { app: App; remove?: () => void }) {
         backgroundColor: "rgba(255, 255, 255, 0.1)",
       }}
     >
-      <AppIcon app={app} className="h-5 w-5 mr-2" />
-      <Text className="text-base">{app.name}</Text>
+      <AppHoverCard app={app}>
+        <AppIcon app={app} className="h-5 w-5 mr-2" />
+      </AppHoverCard>
+      <AppHoverCard app={app}>
+        <Text className="text-base">{app.name}</Text>
+      </AppHoverCard>
       {remove && (
         <button
           type="button"

--- a/src/ui/app/components/app/app-overflow-tooltip.tsx
+++ b/src/ui/app/components/app/app-overflow-tooltip.tsx
@@ -1,0 +1,68 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
+import AppIcon from "@/components/app/app-icon";
+import { Badge } from "@/components/ui/badge";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Text } from "@/components/ui/text";
+import type { App } from "@/lib/entities";
+import type { CSSProperties, ReactNode } from "react";
+import { FixedSizeList as List } from "react-window";
+
+// hardcoding these makes things a lot easier
+
+const ROW_HEIGHT = 32;
+const MAX_VISIBLE_ROWS = 8;
+
+export function AppOverflowTooltip({
+  apps,
+  children,
+}: {
+  apps: App[];
+  children?: ReactNode;
+}) {
+  const listHeight = Math.min(apps.length, MAX_VISIBLE_ROWS) * ROW_HEIGHT;
+  const hasScrollbar = apps.length > MAX_VISIBLE_ROWS;
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        {children ?? (
+          <Badge
+            variant="outline"
+            style={{ backgroundColor: "rgba(255, 255, 255, 0.2)" }}
+            className="whitespace-nowrap ml-1 text-card-foreground/60 rounded-md h-6 cursor-default"
+          >{`+${apps.length}`}</Badge>
+        )}
+      </HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="p-1.5 w-52">
+        <List
+          height={listHeight}
+          itemCount={apps.length}
+          itemSize={ROW_HEIGHT}
+          width="100%"
+          itemData={apps}
+        >
+          {({ index, style }: { index: number; style: CSSProperties }) => {
+            const app = apps[index];
+            return (
+              <div
+                style={style}
+                className={hasScrollbar ? "px-0.5 pr-1" : "px-0.5"}
+              >
+                <AppHoverCard app={app}>
+                  <div className="flex items-center gap-2 px-2 h-7 rounded-md bg-muted/40 hover:bg-muted transition-colors cursor-default">
+                    <AppIcon app={app} className="w-4 h-4 shrink-0" />
+                    <Text className="text-xs">{app.name}</Text>
+                  </div>
+                </AppHoverCard>
+              </div>
+            );
+          }}
+        </List>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/src/ui/app/components/app/choose-multi-apps.tsx
+++ b/src/ui/app/components/app/choose-multi-apps.tsx
@@ -1,8 +1,10 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { AppBadge } from "@/components/app/app-list-item";
 import { NoApps, NoAppsFound } from "@/components/empty-states";
 import { SearchBar } from "@/components/search-bar";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -33,18 +35,20 @@ export function MiniTagItem({ tagId }: { tagId: Ref<Tag> | null }) {
   const tag = useTag(tagId);
   return (
     tag && (
-      <Badge
-        variant="outline"
-        style={{
-          borderColor: tag.color,
-          color: tag.color,
-          backgroundColor: "rgba(255, 255, 255, 0.2)",
-        }}
-        className="whitespace-nowrap min-w-0 -my-0.5 px-2 py-0.5 rounded-full border"
-      >
-        <Text className="max-w-32">{tag.name}</Text>
-        <ScoreCircle score={tag.score} className="ml-2 -mr-1" />
-      </Badge>
+      <TagHoverCard tag={tag}>
+        <Badge
+          variant="outline"
+          style={{
+            borderColor: tag.color,
+            color: tag.color,
+            backgroundColor: "rgba(255, 255, 255, 0.2)",
+          }}
+          className="whitespace-nowrap min-w-0 -my-0.5 px-2 py-0.5 rounded-full border"
+        >
+          <Text className="max-w-32">{tag.name}</Text>
+          <ScoreCircle score={tag.score} className="ml-2 -mr-1" />
+        </Badge>
+      </TagHoverCard>
     )
   );
 }
@@ -119,12 +123,15 @@ export function ChooseMultiApps({
                 onCheckedChange={() => toggleOption(app.id)}
                 className="border-foreground/20"
               />
-              <AppIcon
-                app={app}
-                className="size-4 text-muted-foreground shrink-0"
-              />
-              <Text>{app.name}</Text>
-              {/* Don't show tag if for *this* tag, since a creating tag will not even be valid */}
+              <AppHoverCard app={app}>
+                <div className="inline-flex items-center gap-2 min-w-0">
+                  <AppIcon
+                    app={app}
+                    className="size-4 text-muted-foreground shrink-0"
+                  />
+                  <Text>{app.name}</Text>
+                </div>
+              </AppHoverCard>
               {!isSelected && <MiniTagItem tagId={app.tagId} />}
             </div>
           </div>

--- a/src/ui/app/components/app/choose-multi-apps.tsx
+++ b/src/ui/app/components/app/choose-multi-apps.tsx
@@ -148,7 +148,7 @@ export function ChooseMultiApps({
   }, [items]);
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={setOpen}>
       <div className="flex flex-wrap items-center gap-2">
         {valueApps.map((app, index) => {
           return (

--- a/src/ui/app/components/overflow-list.tsx
+++ b/src/ui/app/components/overflow-list.tsx
@@ -1,9 +1,3 @@
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useWidth } from "@/hooks/use-width";
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
@@ -22,15 +16,13 @@ export function HorizontalOverflowList<T>({
   className,
   items,
   renderItem,
-  renderOverflowItem,
-  renderOverflowSign,
+  renderOverflow,
   maxItemCount,
 }: {
   className: ClassValue;
   items: T[];
   renderItem: (item: T) => ReactNode;
-  renderOverflowItem: (item: T) => ReactNode;
-  renderOverflowSign: (overflowItems: T[]) => ReactNode;
+  renderOverflow: (overflowItems: T[]) => ReactNode;
   maxItemCount?: number;
 }) {
   const ref = useRef<HTMLDivElement>(null);
@@ -80,23 +72,7 @@ export function HorizontalOverflowList<T>({
         <div className="flex items-center" key={index}>
           {renderItem(item)}
 
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger
-                asChild
-                className={cn({
-                  hidden: index !== overflowIndex - 1,
-                })}
-              >
-                {renderOverflowSign(overflowItems)}
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="flex flex-col gap-2 py-2">
-                  {overflowItems.map(renderOverflowItem)}
-                </div>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          {index === overflowIndex - 1 && renderOverflow(overflowItems)}
         </div>
       ))}
     </div>

--- a/src/ui/app/components/tag/choose-tag.tsx
+++ b/src/ui/app/components/tag/choose-tag.tsx
@@ -1,6 +1,7 @@
 import { NoTags, NoTagsFound } from "@/components/empty-states";
 import { CreateTagDialog } from "@/components/tag/create-tag-dialog";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -80,12 +81,16 @@ export function ChooseTag({
                 onSelect={() => onValueChanged(tag.id)}
                 className={cn({ "bg-muted/60": value === tag.id })}
               >
-                <TagIcon
-                  className="w-4 h-4 shrink-0"
-                  style={{ color: tag.color }}
-                />
-                <Text>{tag.name}</Text>
-                <ScoreCircle score={tag.score} />
+                <TagHoverCard tag={tag}>
+                  <div className="inline-flex items-center gap-2 min-w-0">
+                    <TagIcon
+                      className="w-4 h-4 shrink-0"
+                      style={{ color: tag.color }}
+                    />
+                    <Text>{tag.name}</Text>
+                    <ScoreCircle score={tag.score} />
+                  </div>
+                </TagHoverCard>
               </CommandItem>
             ))}
 

--- a/src/ui/app/components/tag/choose-tag.tsx
+++ b/src/ui/app/components/tag/choose-tag.tsx
@@ -2,6 +2,7 @@ import { NoTags, NoTagsFound } from "@/components/empty-states";
 import { CreateTagDialog } from "@/components/tag/create-tag-dialog";
 import { ScoreCircle } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -21,7 +22,7 @@ import type { Ref, Tag } from "@/lib/entities";
 import type { tagSchema } from "@/lib/schema";
 import { useAppState } from "@/lib/state";
 import { cn } from "@/lib/utils";
-import { Plus, TagIcon } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useCallback, useState, type ReactNode } from "react";
 import type { z } from "zod";
 
@@ -83,10 +84,7 @@ export function ChooseTag({
               >
                 <TagHoverCard tag={tag}>
                   <div className="inline-flex items-center gap-2 min-w-0">
-                    <TagIcon
-                      className="w-4 h-4 shrink-0"
-                      style={{ color: tag.color }}
-                    />
+                    <TagIcon tag={tag} className="w-4 h-4 shrink-0" />
                     <Text>{tag.name}</Text>
                     <ScoreCircle score={tag.score} />
                   </div>

--- a/src/ui/app/components/tag/tag-hover-card.tsx
+++ b/src/ui/app/components/tag/tag-hover-card.tsx
@@ -1,4 +1,5 @@
 import AppIcon from "@/components/app/app-icon";
+import { AppOverflowTooltip } from "@/components/app/app-overflow-tooltip";
 import { ScoreBadge } from "@/components/tag/score";
 import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
@@ -69,9 +70,7 @@ function TagHoverCardContent({ tag }: { tag: Tag }) {
               </NavLink>
             ))}
             {remainingCount > 0 && (
-              <span className="inline-flex items-center px-2 py-0.5 rounded-md border border-border text-xs text-muted-foreground">
-                +{remainingCount} more
-              </span>
+              <AppOverflowTooltip apps={hiddenApps}></AppOverflowTooltip>
             )}
           </div>
         </div>

--- a/src/ui/app/components/tag/tag-hover-card.tsx
+++ b/src/ui/app/components/tag/tag-hover-card.tsx
@@ -1,0 +1,117 @@
+import AppIcon from "@/components/app/app-icon";
+import { ScoreBadge } from "@/components/tag/score";
+import { DurationText } from "@/components/time/duration-text";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/text";
+import { useApps } from "@/hooks/use-refresh";
+import type { Tag } from "@/lib/entities";
+import { ArrowRightIcon, TagIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { NavLink } from "react-router";
+
+const MAX_VISIBLE_APPS = 10;
+
+export function TagHoverCard({
+  tag,
+  children,
+}: {
+  tag: Tag;
+  children: ReactNode;
+}) {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="w-80">
+        <TagHoverCardContent tag={tag} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function TagHoverCardContent({ tag }: { tag: Tag }) {
+  const apps = useApps(tag.apps);
+  const visibleApps = apps.slice(0, MAX_VISIBLE_APPS);
+  const hiddenApps = apps.slice(MAX_VISIBLE_APPS);
+  const remainingCount = hiddenApps.length;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <TagIcon className="w-10 h-10 shrink-0" style={{ color: tag.color }} />
+        <div className="flex flex-col min-w-0 gap-1">
+          <Text className="font-semibold">{tag.name}</Text>
+          <ScoreBadge score={tag.score} className="self-start text-xs" />
+        </div>
+      </div>
+
+      {apps.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <Text
+            className="text-xs text-muted-foreground font-medium"
+            children={`${apps.length.toString()} App${apps.length !== 1 ? "s" : ""}`}
+          />
+          <div className="flex flex-wrap gap-1">
+            {visibleApps.map((app) => (
+              <NavLink
+                key={app.id}
+                to={`/apps/${app.id}`}
+                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border border-border bg-muted/30 hover:bg-muted transition-colors text-xs"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <AppIcon app={app} className="w-3.5 h-3.5" />
+                <Text className="max-w-24">{app.name}</Text>
+              </NavLink>
+            ))}
+            {remainingCount > 0 && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded-md border border-border text-xs text-muted-foreground">
+                +{remainingCount} more
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      <Separator />
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <div>
+          <div className="text-xs text-muted-foreground">Today</div>
+          <DurationText
+            ticks={tag.usages.today}
+            className="text-sm font-medium"
+          />
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Week</div>
+          <DurationText
+            ticks={tag.usages.week}
+            className="text-sm font-medium"
+          />
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Month</div>
+          <DurationText
+            ticks={tag.usages.month}
+            className="text-sm font-medium"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <NavLink
+        to={`/tags/${tag.id}`}
+        className="text-sm text-primary hover:underline inline-flex items-center gap-1 self-start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        View Details
+        <ArrowRightIcon className="size-3" />
+      </NavLink>
+    </div>
+  );
+}

--- a/src/ui/app/components/tag/tag-hover-card.tsx
+++ b/src/ui/app/components/tag/tag-hover-card.tsx
@@ -1,5 +1,6 @@
 import AppIcon from "@/components/app/app-icon";
 import { ScoreBadge } from "@/components/tag/score";
+import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
 import {
   HoverCard,
@@ -10,7 +11,7 @@ import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/text";
 import { useApps } from "@/hooks/use-refresh";
 import type { Tag } from "@/lib/entities";
-import { ArrowRightIcon, TagIcon } from "lucide-react";
+import { ArrowRightIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { NavLink } from "react-router";
 
@@ -42,7 +43,7 @@ function TagHoverCardContent({ tag }: { tag: Tag }) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-3">
-        <TagIcon className="w-10 h-10 shrink-0" style={{ color: tag.color }} />
+        <TagIcon tag={tag} className="w-10 h-10 shrink-0" />
         <div className="flex flex-col min-w-0 gap-1">
           <Text className="font-semibold">{tag.name}</Text>
           <ScoreBadge score={tag.score} className="self-start text-xs" />

--- a/src/ui/app/components/tag/tag-icon.tsx
+++ b/src/ui/app/components/tag/tag-icon.tsx
@@ -1,0 +1,25 @@
+import type { Tag as TagEntity } from "@/lib/entities";
+import { cn } from "@/lib/utils";
+import type { ClassValue } from "clsx";
+import { Tag } from "lucide-react";
+import type { ComponentProps } from "react";
+
+export default function TagIcon({
+  tag,
+  className,
+  style,
+  ...rest
+}: {
+  tag?: TagEntity;
+  className?: ClassValue;
+} & Omit<ComponentProps<"div">, "children" | "className">) {
+  return (
+    <div
+      className={cn(className)}
+      style={tag ? { color: tag.color, ...style } : style}
+      {...rest}
+    >
+      <Tag className="w-full h-full" />
+    </div>
+  );
+}

--- a/src/ui/app/components/ui/hover-card.tsx
+++ b/src/ui/app/components/ui/hover-card.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/ui/app/components/ui/hover-card.tsx
+++ b/src/ui/app/components/ui/hover-card.tsx
@@ -11,16 +11,18 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
-      className
-    )}
-    {...props}
-  />
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
 ))
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
 

--- a/src/ui/app/components/ui/text.tsx
+++ b/src/ui/app/components/ui/text.tsx
@@ -1,15 +1,17 @@
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
+import type { ComponentPropsWithoutRef } from "react";
 
 export function Text({
   children,
   className,
+  ...rest
 }: {
   children: string;
   className?: ClassValue;
-}) {
+} & Omit<ComponentPropsWithoutRef<"div">, "children" | "className" | "title">) {
   return (
-    <div className={cn("truncate", className)} title={children}>
+    <div className={cn("truncate", className)} title={children} {...rest}>
       {children || <span className="opacity-50 font-mono">Empty</span>}
     </div>
   );

--- a/src/ui/app/components/ui/text.tsx
+++ b/src/ui/app/components/ui/text.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentProps } from "react";
 
 export function Text({
   children,
@@ -9,7 +9,7 @@ export function Text({
 }: {
   children: string;
   className?: ClassValue;
-} & Omit<ComponentPropsWithoutRef<"div">, "children" | "className" | "title">) {
+} & Omit<ComponentProps<"div">, "children" | "className" | "title">) {
   return (
     <div className={cn("truncate", className)} title={children} {...rest}>
       {children || <span className="opacity-50 font-mono">Empty</span>}

--- a/src/ui/app/components/viz/gantt2.tsx
+++ b/src/ui/app/components/viz/gantt2.tsx
@@ -1,3 +1,4 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import {
   DISTRACTIVE_STREAK_BACKGROUND,
@@ -1080,8 +1081,12 @@ function AppInfoBar({
         ) : (
           <ChevronRight size={20} className="flex-shrink-0" />
         )}
-        <AppIcon app={app} className="ml-2 w-6 h-6 shrink-0" />
-        <Text className="font-semibold ml-4">{app.name}</Text>
+        <AppHoverCard app={app}>
+          <div className="inline-flex items-center min-w-0">
+            <AppIcon app={app} className="ml-2 w-6 h-6 shrink-0" />
+            <Text className="font-semibold ml-4">{app.name}</Text>
+          </div>
+        </AppHoverCard>
       </div>
       <div className="h-px bg-border absolute bottom-[-0.5px] left-0 right-0" />
     </div>

--- a/src/ui/app/components/viz/usage-tooltip.tsx
+++ b/src/ui/app/components/viz/usage-tooltip.tsx
@@ -1,5 +1,7 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import {
   fullKeyToString,
   type FullKey,
@@ -124,31 +126,35 @@ export function UsageTooltipContent({
 
 function AppRow({ app, isHighlighted }: { app: App; isHighlighted: boolean }) {
   return (
-    <div className="flex items-center gap-2 min-w-0">
-      <AppIcon app={app} className="w-4 h-4 shrink-0" />
-      <Text
-        className={cn("min-w-0", {
-          "text-muted-foreground": !isHighlighted,
-        })}
-      >
-        {app.name}
-      </Text>
-    </div>
+    <AppHoverCard app={app}>
+      <div className="flex items-center gap-2 min-w-0">
+        <AppIcon app={app} className="w-4 h-4 shrink-0" />
+        <Text
+          className={cn("min-w-0", {
+            "text-muted-foreground": !isHighlighted,
+          })}
+        >
+          {app.name}
+        </Text>
+      </div>
+    </AppHoverCard>
   );
 }
 
 function TagRow({ tag, isHighlighted }: { tag: Tag; isHighlighted: boolean }) {
   return (
-    <div className="flex items-center gap-2 min-w-0">
-      <TagIcon className="w-4 h-4 shrink-0" style={{ color: tag.color }} />
-      <Text
-        className={cn("min-w-0", {
-          "text-muted-foreground": !isHighlighted,
-        })}
-      >
-        {tag.name}
-      </Text>
-    </div>
+    <TagHoverCard tag={tag}>
+      <div className="flex items-center gap-2 min-w-0">
+        <TagIcon className="w-4 h-4 shrink-0" style={{ color: tag.color }} />
+        <Text
+          className={cn("min-w-0", {
+            "text-muted-foreground": !isHighlighted,
+          })}
+        >
+          {tag.name}
+        </Text>
+      </div>
+    </TagHoverCard>
   );
 }
 
@@ -197,18 +203,20 @@ function AppDisplay({
   at?: DateTime;
 }) {
   return (
-    <div className={cn("flex items-center gap-2 ml-2", className)}>
-      <AppIcon app={app} className="w-6 h-6 shrink-0 mr-1" />
-      <div className="flex flex-col mr-4">
-        <Text className="text-base max-w-52">{app.name}</Text>
-        {at && (
-          <DateTimeText
-            className="text-xs text-muted-foreground"
-            datetime={at}
-          />
-        )}
+    <AppHoverCard app={app}>
+      <div className={cn("flex items-center gap-2 ml-2", className)}>
+        <AppIcon app={app} className="w-6 h-6 shrink-0 mr-1" />
+        <div className="flex flex-col mr-4">
+          <Text className="text-base max-w-52">{app.name}</Text>
+          {at && (
+            <DateTimeText
+              className="text-xs text-muted-foreground"
+              datetime={at}
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </AppHoverCard>
   );
 }
 
@@ -222,20 +230,25 @@ function TagDisplay({
   at?: DateTime;
 }) {
   return (
-    <div className={cn("flex items-center gap-2 ml-2", className)}>
-      <TagIcon className="w-6 h-6 shrink-0 mr-1" style={{ color: tag.color }} />
-      <div className="flex flex-col mr-4">
-        <div className="flex items-center gap-2">
-          <Text className="text-base max-w-52">{tag.name}</Text>
-          <ScoreCircle score={tag.score} />
+    <TagHoverCard tag={tag}>
+      <div className={cn("flex items-center gap-2 ml-2", className)}>
+        <TagIcon
+          className="w-6 h-6 shrink-0 mr-1"
+          style={{ color: tag.color }}
+        />
+        <div className="flex flex-col mr-4">
+          <div className="flex items-center gap-2">
+            <Text className="text-base max-w-52">{tag.name}</Text>
+            <ScoreCircle score={tag.score} />
+          </div>
+          {at && (
+            <DateTimeText
+              className="text-xs text-muted-foreground"
+              datetime={at}
+            />
+          )}
         </div>
-        {at && (
-          <DateTimeText
-            className="text-xs text-muted-foreground"
-            datetime={at}
-          />
-        )}
       </div>
-    </div>
+    </TagHoverCard>
   );
 }

--- a/src/ui/app/components/viz/usage-tooltip.tsx
+++ b/src/ui/app/components/viz/usage-tooltip.tsx
@@ -2,6 +2,7 @@ import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { ScoreCircle } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import {
   fullKeyToString,
   type FullKey,
@@ -14,7 +15,6 @@ import type { App, Ref, Tag } from "@/lib/entities";
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
 import _ from "lodash";
-import { TagIcon } from "lucide-react";
 import type { DateTime } from "luxon";
 import React, { useMemo } from "react";
 
@@ -145,7 +145,7 @@ function TagRow({ tag, isHighlighted }: { tag: Tag; isHighlighted: boolean }) {
   return (
     <TagHoverCard tag={tag}>
       <div className="flex items-center gap-2 min-w-0">
-        <TagIcon className="w-4 h-4 shrink-0" style={{ color: tag.color }} />
+        <TagIcon tag={tag} className="w-4 h-4 shrink-0" />
         <Text
           className={cn("min-w-0", {
             "text-muted-foreground": !isHighlighted,
@@ -232,10 +232,7 @@ function TagDisplay({
   return (
     <TagHoverCard tag={tag}>
       <div className={cn("flex items-center gap-2 ml-2", className)}>
-        <TagIcon
-          className="w-6 h-6 shrink-0 mr-1"
-          style={{ color: tag.color }}
-        />
+        <TagIcon tag={tag} className="w-6 h-6 shrink-0 mr-1" />
         <div className="flex flex-col mr-4">
           <div className="flex items-center gap-2">
             <Text className="text-base max-w-52">{tag.name}</Text>

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -3,6 +3,7 @@ import AppIcon from "@/components/app/app-icon";
 import { SearchBar } from "@/components/search-bar";
 import { ScoreCircle } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -20,12 +21,7 @@ import { cn } from "@/lib/utils";
 import type { CheckedState } from "@radix-ui/react-checkbox";
 import type { ClassValue } from "clsx";
 import _ from "lodash";
-import {
-  ChevronDown,
-  ChevronRight,
-  EllipsisVertical,
-  TagIcon,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, EllipsisVertical } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -240,10 +236,7 @@ export function VerticalLegend({
             />
             <TagHoverCard tag={tag}>
               <div className="inline-flex items-center gap-2 min-w-0">
-                <TagIcon
-                  className="h-4 w-4 shrink-0"
-                  style={{ color: tag.color }}
-                />
+                <TagIcon tag={tag} className="h-4 w-4 shrink-0" />
                 <Text className="text-sm">{tag.name}</Text>
                 <ScoreCircle score={tag.score} />
               </div>

--- a/src/ui/app/components/viz/vertical-legend.tsx
+++ b/src/ui/app/components/viz/vertical-legend.tsx
@@ -1,6 +1,8 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { SearchBar } from "@/components/search-bar";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -236,12 +238,16 @@ export function VerticalLegend({
               className="w-1 h-4 shrink-0 rounded-sm"
               style={{ backgroundColor: tag.color }}
             />
-            <TagIcon
-              className="h-4 w-4 shrink-0"
-              style={{ color: tag.color }}
-            />
-            <Text className="text-sm">{tag.name}</Text>
-            <ScoreCircle score={tag.score} />
+            <TagHoverCard tag={tag}>
+              <div className="inline-flex items-center gap-2 min-w-0">
+                <TagIcon
+                  className="h-4 w-4 shrink-0"
+                  style={{ color: tag.color }}
+                />
+                <Text className="text-sm">{tag.name}</Text>
+                <ScoreCircle score={tag.score} />
+              </div>
+            </TagHoverCard>
           </div>
         );
       } else {
@@ -260,8 +266,14 @@ export function VerticalLegend({
               className="w-1 h-4 shrink-0 rounded-sm"
               style={{ backgroundColor: app.color }}
             />
-            <AppIcon app={app} className="h-4 w-4 shrink-0" />
-            <Text className="text-sm text-muted-foreground">{app.name}</Text>
+            <AppHoverCard app={app}>
+              <div className="inline-flex items-center gap-2 min-w-0">
+                <AppIcon app={app} className="h-4 w-4 shrink-0" />
+                <Text className="text-sm text-muted-foreground">
+                  {app.name}
+                </Text>
+              </div>
+            </AppHoverCard>
           </div>
         );
       }

--- a/src/ui/app/routes/alerts/[id].tsx
+++ b/src/ui/app/routes/alerts/[id].tsx
@@ -1,6 +1,8 @@
 import { StatusBadge } from "@/components/alert/status-badge";
 import { TriggerActionIndicator } from "@/components/alert/trigger-action";
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { DurationText } from "@/components/time/duration-text";
 import { DateTimeText } from "@/components/time/time-text";
@@ -96,14 +98,26 @@ function AlertPage({ alert }: { alert: Alert }) {
             <BreadcrumbSeparator className="hidden md:block" />
             <BreadcrumbItem className="overflow-hidden">
               <BreadcrumbPage className="inline-flex items-center overflow-hidden">
-                {app && <AppIcon app={app} className="w-5 h-5 mr-2 shrink-0" />}
-                {tag && (
-                  <TagIcon
-                    className="w-5 h-5 mr-2 shrink-0"
-                    style={{ color: tag.color }}
-                  />
+                {app ? (
+                  <AppHoverCard app={app}>
+                    <span className="inline-flex items-center">
+                      <AppIcon app={app} className="w-5 h-5 mr-2 shrink-0" />
+                      <Text className="truncate">{targetName}</Text>
+                    </span>
+                  </AppHoverCard>
+                ) : tag ? (
+                  <TagHoverCard tag={tag}>
+                    <span className="inline-flex items-center">
+                      <TagIcon
+                        className="w-5 h-5 mr-2 shrink-0"
+                        style={{ color: tag.color }}
+                      />
+                      <Text className="truncate">{targetName}</Text>
+                    </span>
+                  </TagHoverCard>
+                ) : (
+                  <Text className="truncate">{targetName}</Text>
                 )}
-                <Text className="truncate">{targetName}</Text>
               </BreadcrumbPage>
             </BreadcrumbItem>
           </BreadcrumbList>
@@ -177,28 +191,51 @@ function AlertInfoCard({
       <div className="flex flex-col gap-4">
         {/* Header with name and icon */}
         <div className="flex items-center gap-4">
-          <NavLink to={targetLink}>
-            {app ? (
-              <AppIcon
-                app={app}
-                className="w-12 h-12 shrink-0 hover:opacity-80 transition-opacity"
-              />
-            ) : tag ? (
-              <TagIcon
-                className="w-12 h-12 shrink-0 hover:opacity-80 transition-opacity"
-                style={{ color: tag.color }}
-              />
-            ) : null}
-          </NavLink>
+          {app ? (
+            <AppHoverCard app={app}>
+              <NavLink to={targetLink}>
+                <AppIcon
+                  app={app}
+                  className="w-12 h-12 shrink-0 hover:opacity-80 transition-opacity"
+                />
+              </NavLink>
+            </AppHoverCard>
+          ) : tag ? (
+            <TagHoverCard tag={tag}>
+              <NavLink to={targetLink}>
+                <TagIcon
+                  className="w-12 h-12 shrink-0 hover:opacity-80 transition-opacity"
+                  style={{ color: tag.color }}
+                />
+              </NavLink>
+            </TagHoverCard>
+          ) : null}
           <div className="min-w-0 shrink flex flex-col gap-1">
-            <NavLink
-              to={targetLink}
-              className="hover:opacity-80 transition-opacity"
-            >
-              <Text className="text-2xl font-semibold">
-                {targetEntity?.name ?? "Unknown"}
-              </Text>
-            </NavLink>
+            {app ? (
+              <AppHoverCard app={app}>
+                <NavLink
+                  to={targetLink}
+                  className="hover:opacity-80 transition-opacity"
+                >
+                  <Text className="text-2xl font-semibold">
+                    {targetEntity?.name ?? "Unknown"}
+                  </Text>
+                </NavLink>
+              </AppHoverCard>
+            ) : tag ? (
+              <TagHoverCard tag={tag}>
+                <NavLink
+                  to={targetLink}
+                  className="hover:opacity-80 transition-opacity"
+                >
+                  <Text className="text-2xl font-semibold">
+                    {targetEntity?.name ?? "Unknown"}
+                  </Text>
+                </NavLink>
+              </TagHoverCard>
+            ) : (
+              <Text className="text-2xl font-semibold">Unknown</Text>
+            )}
             <StatusBadge status={alert.status} />
           </div>
           <div className="flex-1" />

--- a/src/ui/app/routes/alerts/[id].tsx
+++ b/src/ui/app/routes/alerts/[id].tsx
@@ -3,6 +3,7 @@ import { TriggerActionIndicator } from "@/components/alert/trigger-action";
 import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { DurationText } from "@/components/time/duration-text";
 import { DateTimeText } from "@/components/time/time-text";
@@ -54,7 +55,6 @@ import {
   ClockIcon,
   Edit2Icon,
   PlayIcon,
-  TagIcon,
   TrashIcon,
 } from "lucide-react";
 import { useCallback, useMemo } from "react";
@@ -108,10 +108,7 @@ function AlertPage({ alert }: { alert: Alert }) {
                 ) : tag ? (
                   <TagHoverCard tag={tag}>
                     <span className="inline-flex items-center">
-                      <TagIcon
-                        className="w-5 h-5 mr-2 shrink-0"
-                        style={{ color: tag.color }}
-                      />
+                      <TagIcon tag={tag} className="w-5 h-5 mr-2 shrink-0" />
                       <Text className="truncate">{targetName}</Text>
                     </span>
                   </TagHoverCard>
@@ -204,8 +201,8 @@ function AlertInfoCard({
             <TagHoverCard tag={tag}>
               <NavLink to={targetLink}>
                 <TagIcon
+                  tag={tag}
                   className="w-12 h-12 shrink-0 hover:opacity-80 transition-opacity"
-                  style={{ color: tag.color }}
                 />
               </NavLink>
             </TagHoverCard>

--- a/src/ui/app/routes/alerts/edit.tsx
+++ b/src/ui/app/routes/alerts/edit.tsx
@@ -2,7 +2,9 @@ import {
   AlertFormContainer,
   type FormValues,
 } from "@/components/alert/alert-form";
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -118,16 +120,26 @@ function EditAlertPage({ alert }: { alert: AlertEntity }) {
                   to={`/alerts/${alert.id}`}
                   className="inline-flex items-center overflow-hidden"
                 >
-                  {app && (
-                    <AppIcon app={app} className="w-5 h-5 mr-2 shrink-0" />
+                  {app ? (
+                    <AppHoverCard app={app}>
+                      <span className="inline-flex items-center">
+                        <AppIcon app={app} className="w-5 h-5 mr-2 shrink-0" />
+                        <Text>{targetName}</Text>
+                      </span>
+                    </AppHoverCard>
+                  ) : tag ? (
+                    <TagHoverCard tag={tag}>
+                      <span className="inline-flex items-center">
+                        <TagIcon
+                          className="w-5 h-5 mr-2 shrink-0"
+                          style={{ color: tag.color }}
+                        />
+                        <Text>{targetName}</Text>
+                      </span>
+                    </TagHoverCard>
+                  ) : (
+                    <Text>{targetName}</Text>
                   )}
-                  {tag && (
-                    <TagIcon
-                      className="w-5 h-5 mr-2 shrink-0"
-                      style={{ color: tag.color }}
-                    />
-                  )}
-                  <Text>{targetName}</Text>
                 </NavLink>
               </BreadcrumbLink>
             </BreadcrumbItem>

--- a/src/ui/app/routes/alerts/edit.tsx
+++ b/src/ui/app/routes/alerts/edit.tsx
@@ -5,6 +5,7 @@ import {
 import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -24,7 +25,6 @@ import type { Alert as AlertEntity, Ref } from "@/lib/entities";
 import type { UpdatedAlert } from "@/lib/repo";
 import { alertSchema } from "@/lib/schema";
 import { useAppState } from "@/lib/state";
-import { TagIcon } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { NavLink, useNavigate } from "react-router";
 import type { Route } from "../alerts/+types/edit";
@@ -130,10 +130,7 @@ function EditAlertPage({ alert }: { alert: AlertEntity }) {
                   ) : tag ? (
                     <TagHoverCard tag={tag}>
                       <span className="inline-flex items-center">
-                        <TagIcon
-                          className="w-5 h-5 mr-2 shrink-0"
-                          style={{ color: tag.color }}
-                        />
+                        <TagIcon tag={tag} className="w-5 h-5 mr-2 shrink-0" />
                         <Text>{targetName}</Text>
                       </span>
                     </TagHoverCard>

--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -7,6 +7,7 @@ import { HorizontalOverflowList } from "@/components/overflow-list";
 import { SearchBar } from "@/components/search-bar";
 import { ScoreBadge } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -33,7 +34,7 @@ import { cn } from "@/lib/utils";
 import { MiniTagItem } from "@/routes/apps";
 import { MiniAppItem } from "@/routes/tags";
 import type { ClassValue } from "clsx";
-import { Plus, TagIcon } from "lucide-react";
+import { Plus } from "lucide-react";
 import {
   memo,
   useCallback,
@@ -211,10 +212,7 @@ function AlertListItem({ alert }: { alert: Alert }) {
         ) : alert.target.tag === "tag" && tag ? (
           <>
             <TagHoverCard tag={tag}>
-              <TagIcon
-                className="mx-2 h-10 w-10 shrink-0"
-                style={{ color: tag.color }}
-              />
+              <TagIcon tag={tag} className="mx-2 h-10 w-10 shrink-0" />
             </TagHoverCard>
             <div className="flex flex-col min-w-0 gap-1">
               <div className="flex items-center gap-2">

--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -1,10 +1,12 @@
 import { StatusBadge } from "@/components/alert/status-badge";
 import { TriggerActionIndicator } from "@/components/alert/trigger-action";
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { NoAlerts, NoAlertsFound } from "@/components/empty-states";
 import { HorizontalOverflowList } from "@/components/overflow-list";
 import { SearchBar } from "@/components/search-bar";
 import { ScoreBadge } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { DurationText } from "@/components/time/duration-text";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -180,13 +182,17 @@ function AlertListItem({ alert }: { alert: Alert }) {
       <div className="h-20 flex items-center gap-2 p-4 @container">
         {alert.target.tag === "app" && app ? (
           <>
-            <AppIcon app={app} className="mx-2 h-10 w-10 shrink-0" />
+            <AppHoverCard app={app}>
+              <AppIcon app={app} className="mx-2 h-10 w-10 shrink-0" />
+            </AppHoverCard>
 
             <div className="flex flex-col min-w-0">
               <div className="inline-flex items-center gap-2">
-                <Text className="text-lg font-semibold max-w-72">
-                  {app.name}
-                </Text>
+                <AppHoverCard app={app}>
+                  <Text className="text-lg font-semibold max-w-72">
+                    {app.name}
+                  </Text>
+                </AppHoverCard>
                 {appTag && <MiniTagItem tag={appTag} />}
               </div>
               <span className="inline-flex gap-1 items-center text-xs text-card-foreground/50">
@@ -204,15 +210,19 @@ function AlertListItem({ alert }: { alert: Alert }) {
           </>
         ) : alert.target.tag === "tag" && tag ? (
           <>
-            <TagIcon
-              className="mx-2 h-10 w-10 shrink-0"
-              style={{ color: tag.color }}
-            />
+            <TagHoverCard tag={tag}>
+              <TagIcon
+                className="mx-2 h-10 w-10 shrink-0"
+                style={{ color: tag.color }}
+              />
+            </TagHoverCard>
             <div className="flex flex-col min-w-0 gap-1">
               <div className="flex items-center gap-2">
-                <Text className="text-lg font-semibold max-w-72">
-                  {tag.name}
-                </Text>
+                <TagHoverCard tag={tag}>
+                  <Text className="text-lg font-semibold max-w-72">
+                    {tag.name}
+                  </Text>
+                </TagHoverCard>
                 <ScoreBadge score={tag.score} />
               </div>
               {tagApps.length !== 0 && (

--- a/src/ui/app/routes/alerts/index.tsx
+++ b/src/ui/app/routes/alerts/index.tsx
@@ -2,6 +2,7 @@ import { StatusBadge } from "@/components/alert/status-badge";
 import { TriggerActionIndicator } from "@/components/alert/trigger-action";
 import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
+import { AppOverflowTooltip } from "@/components/app/app-overflow-tooltip";
 import { NoAlerts, NoAlertsFound } from "@/components/empty-states";
 import { HorizontalOverflowList } from "@/components/overflow-list";
 import { SearchBar } from "@/components/search-bar";
@@ -9,7 +10,6 @@ import { ScoreBadge } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
-import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -231,18 +231,7 @@ function AlertListItem({ alert }: { alert: Alert }) {
                   // the screen size will likely never be large enough
                   maxItemCount={25}
                   renderItem={(app) => <MiniAppItem key={app.id} app={app} />}
-                  renderOverflowItem={(app) => (
-                    <MiniAppItem key={app.id} app={app} />
-                  )}
-                  renderOverflowSign={(items) => (
-                    <Badge
-                      variant="outline"
-                      style={{
-                        backgroundColor: "rgba(255, 255, 255, 0.2)",
-                      }}
-                      className="whitespace-nowrap ml-1 text-card-foreground/60 rounded-md h-6"
-                    >{`+${items.length}`}</Badge>
-                  )}
+                  renderOverflow={(apps) => <AppOverflowTooltip apps={apps} />}
                 />
               )}
             </div>

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -3,6 +3,7 @@ import { ColorPicker } from "@/components/color-picker";
 import { EditableText } from "@/components/editable-text";
 import { ChooseTag } from "@/components/tag/choose-tag";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -237,33 +238,35 @@ function TagSelect({
   const tag = useTag(tagId);
 
   return tag ? (
-    <Badge
-      variant="outline"
-      style={{
-        borderColor: tag.color,
-        color: tag.color,
-        backgroundColor: "rgba(255, 255, 255, 0.2)",
-      }}
-      className={cn("whitespace-nowrap", className)}
-    >
-      <NavLink to={`/tags/${tagId}`} className="min-w-0 flex items-center">
-        <Text className="max-w-32 ml-1">{tag.name}</Text>
-        <ScoreCircle score={tag.score} className="ml-2" />
-      </NavLink>
-      <ChooseTag
-        value={tagId}
-        onValueChanged={setTagId}
-        render={() => (
-          <Button
-            size="icon"
-            variant="ghost"
-            className="p-1 ml-1 w-auto h-auto"
-          >
-            <ChevronsUpDown />
-          </Button>
-        )}
-      />
-    </Badge>
+    <TagHoverCard tag={tag}>
+      <Badge
+        variant="outline"
+        style={{
+          borderColor: tag.color,
+          color: tag.color,
+          backgroundColor: "rgba(255, 255, 255, 0.2)",
+        }}
+        className={cn("whitespace-nowrap", className)}
+      >
+        <NavLink to={`/tags/${tagId}`} className="min-w-0 flex items-center">
+          <Text className="max-w-32 ml-1">{tag.name}</Text>
+          <ScoreCircle score={tag.score} className="ml-2" />
+        </NavLink>
+        <ChooseTag
+          value={tagId}
+          onValueChanged={setTagId}
+          render={() => (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="p-1 ml-1 w-auto h-auto"
+            >
+              <ChevronsUpDown />
+            </Button>
+          )}
+        />
+      </Badge>
+    </TagHoverCard>
   ) : (
     <Badge
       variant="outline"

--- a/src/ui/app/routes/apps/[id].tsx
+++ b/src/ui/app/routes/apps/[id].tsx
@@ -238,35 +238,35 @@ function TagSelect({
   const tag = useTag(tagId);
 
   return tag ? (
-    <TagHoverCard tag={tag}>
-      <Badge
-        variant="outline"
-        style={{
-          borderColor: tag.color,
-          color: tag.color,
-          backgroundColor: "rgba(255, 255, 255, 0.2)",
-        }}
-        className={cn("whitespace-nowrap", className)}
-      >
+    <Badge
+      variant="outline"
+      style={{
+        borderColor: tag.color,
+        color: tag.color,
+        backgroundColor: "rgba(255, 255, 255, 0.2)",
+      }}
+      className={cn("whitespace-nowrap", className)}
+    >
+      <TagHoverCard tag={tag}>
         <NavLink to={`/tags/${tagId}`} className="min-w-0 flex items-center">
           <Text className="max-w-32 ml-1">{tag.name}</Text>
           <ScoreCircle score={tag.score} className="ml-2" />
         </NavLink>
-        <ChooseTag
-          value={tagId}
-          onValueChanged={setTagId}
-          render={() => (
-            <Button
-              size="icon"
-              variant="ghost"
-              className="p-1 ml-1 w-auto h-auto"
-            >
-              <ChevronsUpDown />
-            </Button>
-          )}
-        />
-      </Badge>
-    </TagHoverCard>
+      </TagHoverCard>
+      <ChooseTag
+        value={tagId}
+        onValueChanged={setTagId}
+        render={() => (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="p-1 ml-1 w-auto h-auto"
+          >
+            <ChevronsUpDown />
+          </Button>
+        )}
+      />
+    </Badge>
   ) : (
     <Badge
       variant="outline"

--- a/src/ui/app/routes/apps/index.tsx
+++ b/src/ui/app/routes/apps/index.tsx
@@ -2,6 +2,7 @@ import AppIcon from "@/components/app/app-icon";
 import { NoApps, NoAppsFound } from "@/components/empty-states";
 import { SearchBar } from "@/components/search-bar";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { DurationText } from "@/components/time/duration-text";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -55,18 +56,20 @@ export function MiniTagItem({
   className?: ClassValue;
 }) {
   return (
-    <Badge
-      variant="outline"
-      style={{
-        borderColor: tag.color,
-        color: tag.color,
-        backgroundColor: "rgba(255, 255, 255, 0.2)",
-      }}
-      className={cn("whitespace-nowrap min-w-0", className)}
-    >
-      <Text className="max-w-32">{tag.name}</Text>
-      <ScoreCircle score={tag.score} className="ml-2 -mr-1" />
-    </Badge>
+    <TagHoverCard tag={tag}>
+      <Badge
+        variant="outline"
+        style={{
+          borderColor: tag.color,
+          color: tag.color,
+          backgroundColor: "rgba(255, 255, 255, 0.2)",
+        }}
+        className={cn("whitespace-nowrap min-w-0", className)}
+      >
+        <Text className="max-w-32">{tag.name}</Text>
+        <ScoreCircle score={tag.score} className="ml-2 -mr-1" />
+      </Badge>
+    </TagHoverCard>
   );
 }
 

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -1,10 +1,8 @@
 import { AlertHoverCard } from "@/components/alert/alert-hover-card";
 import { StatusBadge } from "@/components/alert/status-badge";
 import { TriggerActionIndicator } from "@/components/alert/trigger-action";
-import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { ScoreCircle } from "@/components/tag/score";
-import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import TagIcon from "@/components/tag/tag-icon";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { DurationText } from "@/components/time/duration-text";
@@ -411,19 +409,15 @@ function MiniTargetItem({ alert }: { alert: Alert }) {
   const tag = useTag(alert.target.tag === "tag" ? alert.target.id : null);
 
   return alert.target.tag === "app" && app ? (
-    <AppHoverCard app={app}>
-      <div className="flex gap-1 items-center">
-        <AppIcon className="h-4 w-4 shrink-0" app={app} />
-        <div>{app.name}</div>
-      </div>
-    </AppHoverCard>
+    <div className="flex gap-1 items-center">
+      <AppIcon className="h-4 w-4 shrink-0" app={app} />
+      <div>{app.name}</div>
+    </div>
   ) : alert.target.tag === "tag" && tag ? (
-    <TagHoverCard tag={tag}>
-      <div className="flex gap-1 items-center">
-        <TagIcon tag={tag} className="h-4 w-4 shrink-0" />
-        <div>{tag.name}</div>
-        <ScoreCircle score={tag.score} />
-      </div>
-    </TagHoverCard>
+    <div className="flex gap-1 items-center">
+      <TagIcon tag={tag} className="h-4 w-4 shrink-0" />
+      <div>{tag.name}</div>
+      <ScoreCircle score={tag.score} />
+    </div>
   ) : null;
 }

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -5,6 +5,7 @@ import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { ScoreCircle } from "@/components/tag/score";
 import { TagHoverCard } from "@/components/tag/tag-hover-card";
+import TagIcon from "@/components/tag/tag-icon";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { DurationText } from "@/components/time/duration-text";
 import {
@@ -48,7 +49,7 @@ import {
 } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import _ from "lodash";
-import { Loader2, TagIcon } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
@@ -419,7 +420,7 @@ function MiniTargetItem({ alert }: { alert: Alert }) {
   ) : alert.target.tag === "tag" && tag ? (
     <TagHoverCard tag={tag}>
       <div className="flex gap-1 items-center">
-        <TagIcon className="h-4 w-4 shrink-0" style={{ color: tag.color }} />
+        <TagIcon tag={tag} className="h-4 w-4 shrink-0" />
         <div>{tag.name}</div>
         <ScoreCircle score={tag.score} />
       </div>

--- a/src/ui/app/routes/home.tsx
+++ b/src/ui/app/routes/home.tsx
@@ -1,7 +1,10 @@
+import { AlertHoverCard } from "@/components/alert/alert-hover-card";
 import { StatusBadge } from "@/components/alert/status-badge";
 import { TriggerActionIndicator } from "@/components/alert/trigger-action";
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { ScoreCircle } from "@/components/tag/score";
+import { TagHoverCard } from "@/components/tag/tag-hover-card";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import { DurationText } from "@/components/time/duration-text";
 import {
@@ -10,14 +13,13 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
 } from "@/components/ui/breadcrumb";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { NextButton, PrevButton, UsageCard } from "@/components/usage-card";
 import { Gantt } from "@/components/viz/gantt2";
 import { UsageChart } from "@/components/viz/usage-chart";
@@ -355,20 +357,20 @@ function AlertEventItem() {
         <div className="text-sm font-medium">Triggered Alerts</div>
 
         {triggeredAlerts.length > 0 ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger className="self-end">
+          <HoverCard>
+            <HoverCardTrigger asChild>
+              <button type="button" className="self-end">
                 <div className="text-xl font-bold">
                   {triggeredAlerts.length}
                 </div>
-              </TooltipTrigger>
-              <TooltipContent className="grid grid-cols-[1fr_auto_auto] gap-x-2 gap-y-1.5">
-                {triggeredAlerts.map((alert) => (
-                  <MiniAlertItem key={alert.id} alert={alert} />
-                ))}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+              </button>
+            </HoverCardTrigger>
+            <HoverCardContent className="w-auto max-w-md grid grid-cols-[1fr_auto_auto] gap-x-2 gap-y-1.5 p-3">
+              {triggeredAlerts.map((alert) => (
+                <MiniAlertItem key={alert.id} alert={alert} />
+              ))}
+            </HoverCardContent>
+          </HoverCard>
         ) : (
           <div className="text-xl font-bold">None</div>
         )}
@@ -379,25 +381,27 @@ function AlertEventItem() {
 
 function MiniAlertItem({ alert }: { alert: Alert }) {
   return (
-    <div className="shadow-lg p-1 rounded-md bg-card border border-border grid grid-cols-subgrid col-span-full gap-3 items-center">
-      <MiniTargetItem alert={alert} />
-      <div className="flex gap-1 items-center text-xs text-muted-foreground whitespace-nowrap">
-        <DurationText ticks={alert.usageLimit} />
-        <span>/</span>
-        <span>{timeFrameToLabel(alert.timeFrame)}</span>
+    <AlertHoverCard alert={alert}>
+      <div className="shadow-lg p-1 rounded-md bg-card border border-border grid grid-cols-subgrid col-span-full gap-3 items-center">
+        <MiniTargetItem alert={alert} />
+        <div className="flex gap-1 items-center text-xs text-muted-foreground whitespace-nowrap">
+          <DurationText ticks={alert.usageLimit} />
+          <span>/</span>
+          <span>{timeFrameToLabel(alert.timeFrame)}</span>
+        </div>
+        <div className="flex justify-end gap-1">
+          <TriggerActionIndicator
+            action={alert.triggerAction}
+            className="text-xs whitespace-nowrap"
+          />
+          <StatusBadge
+            status={alert.status}
+            className="shrink-0"
+            showLabel={false}
+          />
+        </div>
       </div>
-      <div className="flex justify-end gap-1">
-        <TriggerActionIndicator
-          action={alert.triggerAction}
-          className="text-xs whitespace-nowrap"
-        />
-        <StatusBadge
-          status={alert.status}
-          className="shrink-0"
-          showLabel={false}
-        />
-      </div>
-    </div>
+    </AlertHoverCard>
   );
 }
 
@@ -406,15 +410,19 @@ function MiniTargetItem({ alert }: { alert: Alert }) {
   const tag = useTag(alert.target.tag === "tag" ? alert.target.id : null);
 
   return alert.target.tag === "app" && app ? (
-    <div className="flex gap-1 items-center">
-      <AppIcon className="h-4 w-4 shrink-0" app={app} />
-      <div>{app.name}</div>
-    </div>
+    <AppHoverCard app={app}>
+      <div className="flex gap-1 items-center">
+        <AppIcon className="h-4 w-4 shrink-0" app={app} />
+        <div>{app.name}</div>
+      </div>
+    </AppHoverCard>
   ) : alert.target.tag === "tag" && tag ? (
-    <div className="flex gap-1 items-center">
-      <TagIcon className="h-4 w-4 shrink-0" style={{ color: tag.color }} />
-      <div>{tag.name}</div>
-      <ScoreCircle score={tag.score} />
-    </div>
+    <TagHoverCard tag={tag}>
+      <div className="flex gap-1 items-center">
+        <TagIcon className="h-4 w-4 shrink-0" style={{ color: tag.color }} />
+        <div>{tag.name}</div>
+        <ScoreCircle score={tag.score} />
+      </div>
+    </TagHoverCard>
   ) : null;
 }

--- a/src/ui/app/routes/tags/[id].tsx
+++ b/src/ui/app/routes/tags/[id].tsx
@@ -2,6 +2,7 @@ import { ChooseMultiApps } from "@/components/app/choose-multi-apps";
 import { ColorPicker } from "@/components/color-picker";
 import { EditableText } from "@/components/editable-text";
 import { ScoreBadge, ScoreEdit } from "@/components/tag/score";
+import TagIcon from "@/components/tag/tag-icon";
 import { DateRangePicker } from "@/components/time/date-range-picker";
 import {
   AlertDialog,
@@ -52,7 +53,7 @@ import {
   type Period,
 } from "@/lib/time";
 import _ from "lodash";
-import { Loader2, TagIcon, TrashIcon } from "lucide-react";
+import { Loader2, TrashIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import { useCallback, useMemo } from "react";
 import { NavLink, useNavigate } from "react-router";
@@ -117,10 +118,7 @@ function TagPage({ tag }: { tag: Tag }) {
             <BreadcrumbSeparator className="hidden md:block" />
             <BreadcrumbItem className="overflow-hidden">
               <BreadcrumbPage className="inline-flex items-center overflow-hidden">
-                <TagIcon
-                  className="w-5 h-5 mr-2 shrink-0"
-                  style={{ color: tag.color }}
-                />
+                <TagIcon tag={tag} className="w-5 h-5 mr-2 shrink-0" />
                 <Text>{tag.name}</Text>
               </BreadcrumbPage>
             </BreadcrumbItem>
@@ -135,10 +133,7 @@ function TagPage({ tag }: { tag: Tag }) {
             <div className="flex flex-col gap-6">
               {/* Header with name and icon */}
               <div className="flex items-center gap-4">
-                <TagIcon
-                  className="w-12 h-12 shrink-0"
-                  style={{ color: tag.color }}
-                />
+                <TagIcon tag={tag} className="w-12 h-12 shrink-0" />
                 <div className="min-w-0 shrink flex flex-col gap-2">
                   <div className="min-w-0 flex gap-4">
                     <EditableText

--- a/src/ui/app/routes/tags/index.tsx
+++ b/src/ui/app/routes/tags/index.tsx
@@ -1,3 +1,4 @@
+import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
 import { NoTags, NoTagsFound } from "@/components/empty-states";
 import { HorizontalOverflowList } from "@/components/overflow-list";
@@ -57,18 +58,20 @@ export function MiniAppItem({
   className?: ClassValue;
 }) {
   return (
-    <div
-      className={cn(
-        "whitespace-nowrap min-w-0 flex gap-2 py-1 px-2 rounded-md border border-border h-6 items-center bg-secondary",
-        className,
-      )}
-      style={{
-        backgroundColor: "rgba(255, 255, 255, 0.1)",
-      }}
-    >
-      <AppIcon app={app} className="w-4 h-4" />
-      <Text className="max-w-52 text-xs">{app?.name ?? ""}</Text>
-    </div>
+    <AppHoverCard app={app}>
+      <div
+        className={cn(
+          "whitespace-nowrap min-w-0 flex gap-2 py-1 px-2 rounded-md border border-border h-6 items-center bg-secondary",
+          className,
+        )}
+        style={{
+          backgroundColor: "rgba(255, 255, 255, 0.1)",
+        }}
+      >
+        <AppIcon app={app} className="w-4 h-4" />
+        <Text className="max-w-52 text-xs">{app?.name ?? ""}</Text>
+      </div>
+    </AppHoverCard>
   );
 }
 

--- a/src/ui/app/routes/tags/index.tsx
+++ b/src/ui/app/routes/tags/index.tsx
@@ -1,5 +1,6 @@
 import { AppHoverCard } from "@/components/app/app-hover-card";
 import AppIcon from "@/components/app/app-icon";
+import { AppOverflowTooltip } from "@/components/app/app-overflow-tooltip";
 import { NoTags, NoTagsFound } from "@/components/empty-states";
 import { HorizontalOverflowList } from "@/components/overflow-list";
 import { SearchBar } from "@/components/search-bar";
@@ -7,7 +8,6 @@ import { CreateTagDialog } from "@/components/tag/create-tag-dialog";
 import { ScoreBadge } from "@/components/tag/score";
 import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
-import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -290,16 +290,7 @@ function TagListItem({
             // the screen size will likely never be large enough
             maxItemCount={25}
             renderItem={(app) => <MiniAppItem key={app.id} app={app} />}
-            renderOverflowItem={(app) => <MiniAppItem key={app.id} app={app} />}
-            renderOverflowSign={(items) => (
-              <Badge
-                variant="outline"
-                style={{
-                  backgroundColor: "rgba(255, 255, 255, 0.2)",
-                }}
-                className="whitespace-nowrap ml-1 text-card-foreground/60 rounded-md h-6"
-              >{`+${items.length}`}</Badge>
-            )}
+            renderOverflow={(apps) => <AppOverflowTooltip apps={apps} />}
           />
         )}
       </div>

--- a/src/ui/app/routes/tags/index.tsx
+++ b/src/ui/app/routes/tags/index.tsx
@@ -5,6 +5,7 @@ import { HorizontalOverflowList } from "@/components/overflow-list";
 import { SearchBar } from "@/components/search-bar";
 import { CreateTagDialog } from "@/components/tag/create-tag-dialog";
 import { ScoreBadge } from "@/components/tag/score";
+import TagIcon from "@/components/tag/tag-icon";
 import { DurationText } from "@/components/time/duration-text";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -37,7 +38,7 @@ import { useAppState, type EntityMap } from "@/lib/state";
 import { cn } from "@/lib/utils";
 import type { ClassValue } from "clsx";
 import _ from "lodash";
-import { ArrowDownUp, Plus, SortAsc, SortDesc, TagIcon } from "lucide-react";
+import { ArrowDownUp, Plus, SortAsc, SortDesc } from "lucide-react";
 import { DateTime } from "luxon";
 import {
   memo,
@@ -274,10 +275,7 @@ function TagListItem({
         "bg-card text-card-foreground hover:bg-muted/75 border-border border",
       )}
     >
-      <TagIcon
-        className="mx-2 h-10 w-10 shrink-0"
-        style={{ color: tag.color }}
-      />
+      <TagIcon tag={tag} className="mx-2 h-10 w-10 shrink-0" />
 
       <div className="flex flex-col min-w-0 gap-1">
         <div className="flex items-center gap-2">

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.7",


### PR DESCRIPTION
This pull request adds hover cards throughout the application to provide rich contextual information when hovering over apps, tags, and alerts.

**Key additions:**
- Added `@radix-ui/react-hover-card` dependency and created a reusable `HoverCard` component
- Implemented `AppHoverCard` showing app details, company info, usage statistics, and navigation links
- Implemented `TagHoverCard` displaying tag information, associated apps, score badges, and usage data
- Implemented `AlertHoverCard` with alert status, progress indicators, reminders, and target usage stats

**Enhanced components:**
- Created `TagIcon` component for consistent tag icon rendering with color support
- Added `AppOverflowTooltip` for displaying overflow apps in a scrollable list
- Updated `Text` component to accept additional props for better flexibility
- Modified `AppIcon` to support additional HTML attributes

**Integration across the app:**
- Wrapped app and tag references in hover cards throughout alert forms, lists, breadcrumbs, and visualization components
- Replaced tooltip-based overflow indicators with hover card implementations
- Updated various UI components to use the new hover card system for better user experience

The hover cards provide immediate access to relevant information without requiring navigation, improving the overall usability of the application.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX additions (new hover cards and small component API adjustments) with low likelihood of affecting core logic; main risk is minor regressions in hover/click interactions and list rendering.
> 
> **Overview**
> Introduces a reusable Radix `HoverCard` wrapper and new `AppHoverCard`, `TagHoverCard`, and `AlertHoverCard` components to surface contextual details (usage stats, metadata, navigation links) when hovering over items throughout alerts, tags, apps, and visualization views.
> 
> Reworks app/tag chips and overflow displays to use hover cards: adds `AppOverflowTooltip` (scrollable list) and updates `HorizontalOverflowList` to accept a single `renderOverflow` hook instead of tooltip-specific renderers.
> 
> Adds a shared `TagIcon` component and extends `AppIcon`/`Text` to forward DOM props, enabling consistent icon rendering and easier composition inside hover-card triggers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd415cfe73196671df1d1d8611324b8573c61311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->